### PR TITLE
Implements /roles endpoint for managing permission entries for a user.

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/InMemoryPermissionsRepository.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/InMemoryPermissionsRepository.java
@@ -41,4 +41,9 @@ public class InMemoryPermissionsRepository implements PermissionsRepository {
   public Map<String, UserPermission> getAllById() {
     return ImmutableMap.copyOf(permissions);
   }
+
+  @Override
+  public UserPermission remove(String id) {
+    return this.permissions.remove(id);
+  }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
@@ -27,4 +27,6 @@ public interface PermissionsRepository {
   UserPermission get(String id);
 
   Map<String, UserPermission> getAllById();
+
+  UserPermission remove(String id);
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -16,12 +16,14 @@
 
 package com.netflix.spinnaker.fiat.controllers;
 
-import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
-import lombok.NonNull;
+import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 import java.util.Set;
@@ -50,10 +52,5 @@ public class AuthorizeController {
         .filter(account -> accountName.equalsIgnoreCase(account.getName()))
         .findFirst()
         .orElseThrow(NotFoundException::new);
-  }
-
-  @RequestMapping(value = "/{userId:.+}", method = RequestMethod.PUT)
-  public void putUserPermission(@PathVariable String userId, @RequestBody @NonNull UserPermission permission) {
-    permissionsRepository.put(userId, permission);
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.controllers;
+
+import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
+import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
+import com.netflix.spinnaker.fiat.roles.UserRolesSyncer;
+import lombok.NonNull;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/roles")
+public class RolesController {
+
+  @Autowired
+  @Setter
+  PermissionsResolver permissionsResolver;
+
+  @Autowired
+  @Setter
+  PermissionsRepository permissionsRepository;
+
+  @Autowired
+  @Setter
+  UserRolesSyncer syncer;
+
+  @RequestMapping(value = "/{userId:.+}", method = RequestMethod.POST)
+  public void putUserPermission(@PathVariable String userId) {
+    permissionsRepository.put(userId, permissionsResolver.resolve(userId));
+  }
+
+  @RequestMapping(value = "/{userId:.+}", method = RequestMethod.PUT)
+  public void putUserPermission(@PathVariable String userId,
+                                @RequestBody @NonNull List<String> externalRoles) {
+    // TODO(ttomsu): Add role merging capability to permissionsRepo.
+  }
+
+  @RequestMapping(value = "/{userId:.+}", method = RequestMethod.DELETE)
+  public void deleteUserPermission(@PathVariable String userId) {
+    permissionsRepository.remove(userId);
+  }
+
+  @RequestMapping(value = "/sync", method = RequestMethod.POST)
+  public void sync() {
+    syncer.sync();
+  }
+}


### PR DESCRIPTION
This PR enables me to upsert and delete an entry now through the /roles endpoint, and read the user (and derived account permissions) through the /authorize endpoint:

```
$ curl -X POST http://localhost:7003/roles/ttomsu@spinnaker-test.net
$ curl  http://localhost:7003/authorize/ttomsu@spinnaker-test.net | pjs
{
    "accounts": [
        {
            "name": "my-aws-account",
            "requiredGroupMembership": []
        },
        {
            "name": "my-protected-account",
            "requiredGroupMembership": [
                "sekret-users"
            ]
        }
    ],
    "applications": null,
    "id": "ttomsu@spinnaker-test.net"
}
$ curl -X DELETE http://localhost:7003/roles/ttomsu@spinnaker-test.net
$ curl  http://localhost:7003/authorize/ttomsu@spinnaker-test.net | pjs
{
    "error": "Not Found",
    "message": "No message available",
    "status": 404,
    "timestamp": 1467232717256
}
```

@jtk54 @duftler PTAL

@cfieber @ajordens FYI
