### PR TITLE
Return Views instead of Object models from the /authorize endpoint

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -16,15 +16,41 @@
 
 package com.netflix.spinnaker.fiat.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import lombok.Data;
 
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 public class UserPermission {
   private String id;
-  private Set<Account> accounts;
-  private Set<Application> applications;
+  private Set<Account> accounts = new HashSet<>();
+  private Set<Application> applications = new HashSet<>();
+
+  @JsonIgnore
+  public View getView() {
+    return new View();
+  }
+
+  @Data
+  public class View {
+    String name = UserPermission.this.id;
+    Map<String, Object> resources = ImmutableMap.of(
+        "accounts",
+        UserPermission.this.accounts
+            .stream()
+            .map(Account::getView)
+            .collect(Collectors.toSet()),
+        "applications",
+        UserPermission.this.applications
+            .stream()
+            .map(Application::getView)
+            .collect(Collectors.toSet()));
+  }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -35,6 +35,7 @@ public class Account {
     return new View();
   }
 
+  @Data
   public class View {
     String name = Account.this.name;
     Set<Authorization> authorizations = ImmutableSet.of(Authorization.READ,

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
 
@@ -25,4 +27,16 @@ import java.util.Set;
 public class Application {
   private final String name;
   private final Set<Authorization> authorizations;
+
+  @JsonIgnore
+  public View getView() {
+    return new View();
+  }
+
+  @Data
+  public class View {
+    String name = Application.this.name;
+    Set<Authorization> authorizations = ImmutableSet.of(Authorization.READ,
+                                                        Authorization.WRITE);
+  }
 }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -40,7 +40,7 @@ class AuthorizeControllerSpec extends Specification {
       def result = controller.getUserPermission("foo")
 
     then:
-      result == foo
+      result == foo.view
   }
 
   def "should get user's accounts from repo"() {
@@ -61,7 +61,7 @@ class AuthorizeControllerSpec extends Specification {
       def result = controller.getUserAccounts("foo")
 
     then:
-      result == [bar] as Set
+      result == [bar.view] as Set
   }
 
   def "should get user's accounts by name from repo"() {
@@ -82,6 +82,6 @@ class AuthorizeControllerSpec extends Specification {
       def result = controller.getUserAccount("foo", "bar")
 
     then:
-      result == bar
+      result == bar.view
   }
 }


### PR DESCRIPTION
This pattern separates the view of the data from it's actual (and serialized) representation. I found this to be a very useful pattern in Clouddriver when we serialized objects (and relationships) different than how we represented them back to Orca/Gate/Deck.

@duftler suggested adding the intermediate level "resources" to more clearly differentiate between metadata (userId) and data (anything under "resources")

@jtk54 @duftler @cfieber @ajordens PTAL
