### PR TITLE
Adds ApplicationProvider interface and file watching implementation.

### DIFF
--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -6,8 +6,11 @@ dependencies {
   compile spinnaker.dependency("lombok")
   compile spinnaker.dependency("springContext")
   compile spinnaker.dependency("guava")
+  compile spinnaker.dependency("bootActuator")
 
   compile "org.apache.commons:commons-lang3:3.4"
+  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.4"
 
   testCompile spinnaker.dependency("spockSpring")
+  testCompile "commons-io:commons-io:2.5"
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -38,7 +38,8 @@ public class Application implements Named {
   @Data
   public class View {
     String name = Application.this.name;
-    Set<Authorization> authorizations = ImmutableSet.of(Authorization.READ,
+    Set<Authorization> authorizations = ImmutableSet.of(Authorization.CREATE,
+                                                        Authorization.READ,
                                                         Authorization.WRITE);
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/AccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/AccountProvider.java
@@ -35,14 +35,6 @@ public class AccountProvider {
   @Setter
   private List<CloudProviderAccounts> cloudProviderAccounts;
 
-  public Set<Account> getAccounts() {
-    return cloudProviderAccounts
-        .stream()
-        .map(CloudProviderAccounts::getAccounts)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
-  }
-
   public Set<Account> getAccounts(@NonNull Collection<String> groups) {
     return cloudProviderAccounts
         .stream()

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationProvider.java
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.fiat.model;
+package com.netflix.spinnaker.fiat.providers;
 
-public enum Authorization {
-  CREATE,
-  READ,
-  WRITE
+import com.netflix.spinnaker.fiat.model.resources.Application;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface ApplicationProvider {
+
+  Set<Application> getApplications(Collection<String> groups);
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/FileBasedApplicationProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/FileBasedApplicationProvider.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class FileBasedApplicationProvider implements ApplicationProvider {
+
+  private static String DEFAULT_WATCHED_FILE_EXTENSION = ".config";
+
+  @Setter
+  private String watchedFileExtension = DEFAULT_WATCHED_FILE_EXTENSION;
+
+  private ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+  private Map<String /* app name */, Application> applications = new ConcurrentHashMap<>();
+
+  private Thread watchThread;
+
+  public FileBasedApplicationProvider(){}
+
+  @VisibleForTesting
+  FileBasedApplicationProvider(Map<String, Application> applications) {
+    this.applications = applications;
+  }
+
+  @Override
+  public Set<Application> getApplications(@NonNull Collection<String> groups) {
+    return applications
+        .values()
+        .stream()
+        .filter(application ->
+                    application.getRequiredGroupMembership().isEmpty() ||
+                        !Collections.disjoint(application.getRequiredGroupMembership(), groups))
+        .collect(Collectors.toSet());
+  }
+
+  public FileBasedApplicationProvider watch(String watchedDirectory) {
+    watchThread = new Thread(new ConfigDirectoryWatcher(watchedDirectory));
+    watchThread.start();
+    return this;
+  }
+
+  @PreDestroy
+  public void close() {
+    if (watchThread != null && watchThread.isAlive()) {
+      watchThread.interrupt();
+    }
+  }
+
+  @RequiredArgsConstructor
+  private class ConfigDirectoryWatcher implements Runnable {
+
+    private final String watchedDirectory;
+
+    @Override
+    public void run() {
+      Path watchedDirPath = Paths.get(watchedDirectory);
+      parseExistingConfigFiles(watchedDirPath);
+      watchForChanges(watchedDirPath);
+    }
+
+    private void parseExistingConfigFiles(Path watchedDirPath) {
+      try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(watchedDirPath)) {
+        for (Path config : dirStream) {
+          if (!isConfigFile(config.getFileName().toString())) {
+            continue;
+          }
+
+          parseApplicationConfig(config)
+              .ifPresent(app -> {
+                applications.put(app.getName(), app);
+                log.info("Adding configured application: " + app.getName());
+              });
+        }
+      } catch (IOException ioe) {
+        log.error("Error reading existing application configuration files", ioe);
+      }
+    }
+
+    private void watchForChanges(Path watchedDirPath) {
+      try (WatchService watchService = watchedDirPath.getFileSystem().newWatchService()) {
+        watchedDirPath.register(watchService,
+                                StandardWatchEventKinds.ENTRY_CREATE,
+                                StandardWatchEventKinds.ENTRY_MODIFY,
+                                StandardWatchEventKinds.ENTRY_DELETE);
+        log.info("Watching " + watchedDirectory + " for file changes");
+        while (true) {
+          try {
+            WatchKey watchKey = watchService.take();
+
+            for (WatchEvent event : watchKey.pollEvents()) {
+              String filepath = event.context().toString();
+              if (!isConfigFile(filepath)) {
+                continue;
+              }
+
+              switch (event.kind().toString()) {
+                case "ENTRY_CREATE":
+                case "ENTRY_MODIFY":
+                  log.info("File created or modified: " + event.context().toString());
+                  val fullConfigPath = watchedDirPath.resolve((Path) event.context());
+                  parseApplicationConfig(fullConfigPath)
+                      .filter(newApp -> newApp != applications.get(newApp.getName()))
+                      .ifPresent(newApp -> applications.put(newApp.getName(), newApp));
+                  break;
+                case "ENTRY_DELETE":
+                  log.info("File deleted: " + event.context().toString());
+                  String appName = StringUtils.removeEnd(filepath, watchedFileExtension);
+                  applications.remove(appName);
+                  break;
+              }
+            }
+
+            watchKey.reset();
+          } catch (InterruptedException interrupt) {
+            log.info("Application configuration directory watching interrupted.");
+            break;
+          }
+        }
+      } catch (IOException ioe) {
+        log.error("Exception during application watching", ioe);
+      } finally {
+        log.info("Finished watching " + watchedDirectory + " for file changes");
+      }
+    }
+
+    private boolean isConfigFile(String filepath) {
+      return !filepath.startsWith(".") && filepath.endsWith(watchedFileExtension);
+    }
+
+    private Optional<Application> parseApplicationConfig(Path config) {
+      try {
+        return Optional.of(objectMapper.readValue(config.toFile(), Application.class));
+      } catch (IOException ioe) {
+        log.warn("Can't create application from config file: " + config.toString(), ioe);
+      }
+      return Optional.empty();
+    }
+  }
+}

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/AccountProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/AccountProviderSpec.groovy
@@ -21,22 +21,6 @@ import spock.lang.Specification
 
 class AccountProviderSpec extends Specification {
 
-  def "should get all configured accounts"() {
-    setup:
-    AccountProvider accountProvider = new AccountProvider().setCloudProviderAccounts(
-        [
-            new CloudProviderAccounts("A").setAccounts([new Account().setName("account1")]),
-            new CloudProviderAccounts("B").setAccounts([new Account().setName("account2")])
-        ]);
-
-    when:
-    def result = accountProvider.getAccounts()
-
-    then:
-    result.size() == 2
-    result*.name.containsAll(["account1", "account2"])
-  }
-
   def "should get all accounts based on supplied roles"() {
     setup:
     AccountProvider accountProvider = new AccountProvider().setCloudProviderAccounts(

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/FileBasedApplicationProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/FileBasedApplicationProviderSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers
+
+import com.netflix.spinnaker.fiat.model.resources.Application
+import org.apache.commons.io.FileUtils
+import spock.lang.Specification
+import spock.lang.Subject
+
+class FileBasedApplicationProviderSpec extends Specification {
+
+  @Subject FileBasedApplicationProvider provider
+
+  def cleanup() {
+    if (provider) {
+      provider.close()
+    }
+  }
+
+  def "should get all accounts based on supplied roles"() {
+    setup:
+    provider = new FileBasedApplicationProvider([
+        "noReqGroups"  : new Application().setName("noReqGroups"),
+        "reqGroup1"    : new Application().setName("reqGroup1").setRequiredGroupMembership(["group1"]),
+        "reqGroup1and2": new Application().setName("reqGroup1and2").setRequiredGroupMembership(["group1", "group2"])
+    ]);
+
+    when:
+    def result = provider.getApplications(input)
+
+    then:
+    result*.name.containsAll(values)
+
+    when:
+    provider.getApplications(null)
+
+    then:
+    thrown IllegalArgumentException
+
+    where:
+    input                || values
+    []                   || ["noReqGroups"]
+    ["group1"]           || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
+    ["group2"]           || ["noReqGroups", "reqGroup1and2"]
+    ["group1", "group2"] || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
+    ["group3"]           || ["noReqGroups"]
+    ["group2", "group3"] || ["noReqGroups", "reqGroup1and2"]
+  }
+
+  def "should watch config file directory"() {
+    setup:
+    String config1Content = """
+name: abc
+requiredGroupMembership:
+- abcGroup
+"""
+    String config2Content = """
+name: def
+"""
+
+    File configFile1 = File.createTempFile("abc", ".config")
+    configFile1.deleteOnExit()
+    FileUtils.write(configFile1, config1Content, "UTF-8", false /* append */)
+
+    Map applicationMap = [:]
+    provider = new FileBasedApplicationProvider(applicationMap)
+
+    when:
+    provider.watch(configFile1.getParentFile().getAbsolutePath())
+    sleep(250)
+
+    then:
+    applicationMap["abc"] == new Application().setName("abc").setRequiredGroupMembership(["abcGroup"])
+
+    when:
+    File configFile2 = File.createTempFile("abc", ".config")
+    configFile2.deleteOnExit()
+    FileUtils.write(configFile2, config2Content, "UTF-8", false /* append */)
+    sleep(250)
+
+    then:
+    applicationMap["def"] == new Application().setName("def")
+  }
+}

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.providers.AccountProvider;
+import com.netflix.spinnaker.fiat.providers.ApplicationProvider;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -27,7 +28,9 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,6 +48,10 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
   @Setter
   private AccountProvider accountProvider;
 
+  @Autowired
+  @Setter
+  private ApplicationProvider applicationProvider;
+
 
   @Override
   public UserPermission resolve(@NonNull String userId) {
@@ -58,8 +65,9 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                       .map(String::toLowerCase)
                       .collect(Collectors.toSet());
     val accounts = accountProvider.getAccounts(combo);
+    val apps = applicationProvider.getApplications(combo);
 
-    return new UserPermission().setId(userId).setAccounts(accounts);
+    return new UserPermission().setId(userId).setAccounts(accounts).setApplications(apps);
   }
 
   @Override
@@ -70,7 +78,8 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                 .map(entry ->
                          new UserPermission()
                              .setId(entry.getKey())
-                             .setAccounts(accountProvider.getAccounts(new ArrayList<>(entry.getValue()))))
+                             .setAccounts(accountProvider.getAccounts(entry.getValue()))
+                             .setApplications(applicationProvider.getApplications(entry.getValue())))
                 .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
   }
 }

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -100,9 +100,13 @@ public class RedisPermissionsRepository implements PermissionsRepository {
             break;
         }
 
+        String userId = permission.getId();
+        String userResourceKey = userKey(userId, r);
+
+        jedis.del(userResourceKey); // Clears any values that may have been deleted.
         if (!resourceValues.isEmpty()) {
-          jedis.hmset(userKey(permission.getId(), r), resourceValues);
-          jedis.sadd(allUsersKey(), permission.getId());
+          jedis.hmset(userResourceKey, resourceValues);
+          jedis.sadd(allUsersKey(), userId);
         }
       }
     } catch (Exception e) {

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.permissions
 
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.providers.AccountProvider
+import com.netflix.spinnaker.fiat.providers.ApplicationProvider
 import com.netflix.spinnaker.fiat.providers.CloudProviderAccounts
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider
 import spock.lang.Shared
@@ -44,9 +45,13 @@ class DefaultPermissionsResolverSpec extends Specification {
     setup:
     def testUserId = "testUserId"
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
+    ApplicationProvider applicationProvider = Mock(ApplicationProvider) {
+      getApplications(*_) >> []
+    }
     @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
         .setUserRolesProvider(userRolesProvider)
         .setAccountProvider(accountProvider)
+        .setApplicationProvider(applicationProvider)
 
     when:
     resolver.resolve(null as String)
@@ -62,6 +67,7 @@ class DefaultPermissionsResolverSpec extends Specification {
     result?.getId() == testUserId
     result?.getAccounts()?.size() == 1
     result?.getAccounts()*.name.containsAll(["noReqGroups"])
+    result?.getApplications() == [] as Set
 
     when:
     result = resolver.resolve(testUserId)
@@ -93,9 +99,13 @@ class DefaultPermissionsResolverSpec extends Specification {
     def user1 = "user1"
     def user2 = "user2"
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
+    ApplicationProvider applicationProvider = Mock(ApplicationProvider) {
+      getApplications(*_) >> []
+    }
     @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
         .setUserRolesProvider(userRolesProvider)
         .setAccountProvider(accountProvider)
+        .setApplicationProvider(applicationProvider)
 
     when:
     resolver.resolve(null as Collection)
@@ -114,7 +124,9 @@ class DefaultPermissionsResolverSpec extends Specification {
     result.size() == 2
     result["user1"]?.id == "user1"
     result["user1"]?.getAccounts()*.name.containsAll(["noReqGroups", "reqGroup1", "reqGroup1and2"])
+    result["user1"]?.getApplications() == [] as Set
     result["user2"]?.id == "user2"
     result["user2"]?.getAccounts()*.name.containsAll(["noReqGroups", "reqGroup1and2"])
+    result["user2"]?.getApplications() == [] as Set
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -87,6 +87,27 @@ class RedisPermissionsRepositorySpec extends Specification {
         ['app1': '{"name":"app1","requiredGroupMembership":[]}']
   }
 
+  def "should remove permission that has been revoked"() {
+    setup:
+    jedis.sadd("unittest:users", "testUser2");
+    jedis.hset("unittests:permissions:testUser2:accounts",
+               "account2",
+               '{"name":"account2","requiredGroupMembership":[]}')
+    jedis.hset("unittests:permissions:testUser2:applications",
+               "app2",
+               '{"name":"app2","requiredGroupMembership":[]}')
+
+    when:
+    repo.put(new UserPermission()
+                 .setId("testUser1")
+                 .setAccounts([] as Set)
+                 .setApplications([] as Set))
+
+    then:
+    jedis.hgetAll("unittests:permissions:testUser1:accounts") == [:]
+    jedis.hgetAll("unittests:permissions:testUser1:applications") == [:]
+  }
+
   def "should get the permission out of redis"() {
     setup:
     jedis.sadd("unittest:users", "testUser2");

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/AccountConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/AccountConfig.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AccountConfiguration {
+public class AccountConfig {
 
   @Bean
   @ConfigurationProperties("aws")

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ApplicationConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ApplicationConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.providers.FileBasedApplicationProvider;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApplicationConfig {
+
+  @Value("${applications.fileBased.directory}")
+  @Setter
+  private String watchedDirectory;
+
+  @Bean
+  @ConditionalOnProperty("applications.fileBased.directory")
+  FileBasedApplicationProvider fileBasedApplicationProvider() {
+    return new FileBasedApplicationProvider().watch(watchedDirectory);
+  }
+}


### PR DESCRIPTION
Based off of #10 , so please only review the **last** commit.

The intent is to get these app configs moved into an S3/GCS bucket, but starting with a file-based approach helps prove out the concepts.

A user's `fiat-local.yml` file would contain something like:
```
applications:
  fileBased:
    directory: /home/ttomsu/.spinnaker/appConfigs
```
where admins of the system would drop in files like `my-app.config` that look similar to how account configs are structured:
```
name: my-app
requiredGroupMembership:
- my-app-users
```

Eventually we'll get to the point where these files will be generated when an app is created in the UI and uploaded into the configured storage bucket, where it can be versioned and watched for changes by all Fiat instances. 

@cfieber @ajordens @duftler @jtk54 PTAL