### PR TITLE
Adds service account concept and static config setup, impl.

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.fiat.model.resources;
+package com.netflix.spinnaker.fiat.model;
 
-import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.fiat.model.resources.Named;
+import lombok.Data;
 
-public enum Resource {
-  ACCOUNT,
-  APPLICATION,
-  SERVICE_ACCOUNT; // Fiat service account.
+@Data
+public class ServiceAccount implements Named {
+  private String name;
 
-  // TODO(ttomsu): This is Redis-specific, so it probably shouldn't go here.
-  public static Resource parse(@NonNull String key) {
-    String resources = StringUtils.substringAfterLast(key, ":");
-    String resource = StringUtils.removeEnd(resources, "s");
-    return Resource.valueOf(resource.toUpperCase());
+  @JsonIgnore
+  public View getView() {
+    return new View();
   }
 
-  public String keySuffix() {
-    return this.toString().toLowerCase() + "s";
+  @Data
+  public class View {
+    String name = ServiceAccount.this.name;
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -32,6 +32,7 @@ public class UserPermission {
   private String id;
   private Set<Account> accounts = new HashSet<>();
   private Set<Application> applications = new HashSet<>();
+  private Set<ServiceAccount> serviceAccounts = new HashSet<>();
 
   @JsonIgnore
   public boolean isEmpty() {
@@ -46,7 +47,11 @@ public class UserPermission {
   @Data
   public class View {
     String name = UserPermission.this.id;
-    Map<String, Object> resources = ImmutableMap.of(
+    Set<ServiceAccount.View> serviceAccounts = UserPermission.this.serviceAccounts
+        .stream()
+        .map(ServiceAccount::getView)
+        .collect(Collectors.toSet());
+    Map<String, Object> cloudResources = ImmutableMap.of(
         "accounts",
         UserPermission.this.accounts
             .stream()

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.permissions;
 
+import com.netflix.spinnaker.fiat.model.ServiceAccount;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 
 import java.util.Collection;

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.ServiceAccount;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ServiceAccountProvider {
+
+  @Setter
+  private Map<String, ServiceAccount> serviceAccountsByName;
+
+  public Optional<ServiceAccount> getAccount(@NonNull String name) {
+    return Optional.ofNullable(serviceAccountsByName.get(name));
+  }
+
+  /**
+   * Return the set of service accounts to which a user with the specified collection of groups
+   * has access.
+   */
+  public Set<ServiceAccount> getAccounts(@NonNull Collection<String> groups) {
+    if (serviceAccountsByName == null) {
+      return Collections.emptySet();
+    }
+
+    return groups
+        .stream()
+        .filter(group -> serviceAccountsByName.containsKey(group))
+        .map(group -> serviceAccountsByName.get(group))
+        .collect(Collectors.toSet());
+  }
+}

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/ServiceAccountProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/ServiceAccountProviderSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers
+
+import com.netflix.spinnaker.fiat.model.ServiceAccount
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ServiceAccountProviderSpec extends Specification {
+
+  @Shared
+  @Subject
+  ServiceAccountProvider provider = new ServiceAccountProvider(
+      serviceAccountsByName: [
+          "abc": new ServiceAccount(name: "abc"),
+          "xyz": new ServiceAccount(name: "xyz")
+      ]
+  )
+
+  def "should return single account"() {
+    expect:
+    provider.getAccount("abc").get().name == "abc"
+    !provider.getAccount("def").isPresent()
+  }
+
+  def "should return all accounts the specified groups has access to"() {
+    when:
+    def result = provider.getAccounts(input)
+
+    then:
+    result*.name.containsAll(values)
+
+    when:
+    provider.getAccounts(null)
+
+    then:
+    thrown IllegalArgumentException
+
+    where:
+    input                 || values
+    []                    || []
+    ["abc"]               || ["abc"]
+    ["abc", "xyz"]        || ["abc", "xyz"]
+    ["abc", "xyz", "def"] || ["abc", "xyz"]
+  }
+}

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.permissions;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.providers.AccountProvider;
 import com.netflix.spinnaker.fiat.providers.ApplicationProvider;
+import com.netflix.spinnaker.fiat.providers.ServiceAccountProvider;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -52,6 +53,10 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
   @Setter
   private ApplicationProvider applicationProvider;
 
+  @Autowired
+  @Setter
+  private ServiceAccountProvider serviceAccountProvider;
+
 
   @Override
   public UserPermission resolve(@NonNull String userId) {
@@ -66,8 +71,13 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                       .collect(Collectors.toSet());
     val accounts = accountProvider.getAccounts(combo);
     val apps = applicationProvider.getApplications(combo);
+    val serviceAccts = serviceAccountProvider.getAccounts(combo);
 
-    return new UserPermission().setId(userId).setAccounts(accounts).setApplications(apps);
+    return new UserPermission()
+        .setId(userId)
+        .setAccounts(accounts)
+        .setApplications(apps)
+        .setServiceAccounts(serviceAccts);
   }
 
   @Override
@@ -79,7 +89,8 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                          new UserPermission()
                              .setId(entry.getKey())
                              .setAccounts(accountProvider.getAccounts(entry.getValue()))
-                             .setApplications(applicationProvider.getApplications(entry.getValue())))
+                             .setApplications(applicationProvider.getApplications(entry.getValue()))
+                             .setServiceAccounts(serviceAccountProvider.getAccounts(entry.getValue())))
                 .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ServiceAccountsConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ServiceAccountsConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.google.common.collect.Sets;
+import com.netflix.spinnaker.fiat.model.ServiceAccount;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
+import com.netflix.spinnaker.fiat.providers.ServiceAccountProvider;
+import lombok.Data;
+import lombok.val;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class ServiceAccountsConfig {
+
+  @Bean
+  public ServiceAccountList serviceAccountList() {
+    return new ServiceAccountList();
+  }
+
+  @Bean
+  public ServiceAccountProvider serviceAccountProvider(ServiceAccountList serviceAccountList,
+                                                       PermissionsRepository repo) {
+    val serviceAcctsByName = serviceAccountList
+        .getServiceAccounts()
+        .stream()
+        .map(serviceAccount -> {
+          // Can't resolve full account/application permissions here because it would cause
+          // a dependency cycle. Instead, account/applications are resolved on the first
+          // periodic sync.
+          repo.put(new UserPermission()
+                       .setId(serviceAccount.getName())
+                       .setServiceAccounts(Sets.newHashSet(serviceAccount)));
+          return serviceAccount;
+        })
+        .collect(Collectors.toMap(ServiceAccount::getName, Function.identity()));
+
+    return new ServiceAccountProvider().setServiceAccountsByName(serviceAcctsByName);
+  }
+
+  // It's silly that we have to define a container class for List objects, but that's apparently
+  // how Spring @ConfigurationProperties works.
+  //
+  // TODO(ttomsu): It's likely that users will need/want to create service accounts within the
+  // application. Therefore, it's quite possible this will all go away in favor of the file watcher/
+  // bucket watcher implementation.
+  @ConfigurationProperties("auth")
+  @Data
+  public static class ServiceAccountList {
+    private List<ServiceAccount> serviceAccounts;
+  }
+}


### PR DESCRIPTION
This is based off of #11, please only review the **last** commit.

Introduces the Fiat service account - a mechanism to allow automated/triggered pipelines to access protected resources. 

Because it is itself a group, only users who belong to the service account group will be able to see that it exists and to use it. This is reflected in the returned UserPermission object:

```
ttomsu@blinky:~/.spinnaker/appConfigs$ curl http://localhost:7003/authorize/ttomsu@spinnaker-test.net | pjs
{
    "cloudResources": {
        "accounts": [
            {
                "authorizations": [
                    "READ",
                    "WRITE"
                ],
                "name": "my-protected-account"
            },
            {
                "authorizations": [
                    "READ",
                    "WRITE"
                ],
                "name": "my-aws-account"
            }
        ],
        "applications": [
            {
                "authorizations": [
                    "CREATE",
                    "READ",
                    "WRITE"
                ],
                "name": "abc"
            }
        ]
    },
    "name": "ttomsu@spinnaker-test.net",
    "serviceAccounts": [
        {
            "name": "sekret-service-acct"
        }
    ]
}
```

This means that service account can be thought of/queried as a normal, real user:
```
ttomsu@blinky:~/.spinnaker/appConfigs$ curl http://localhost:7003/authorize/sekret-service-acct@spinnaker-test.net | pjs

{
    "cloudResources": {
        "accounts": [
            {
                "authorizations": [
                    "READ",
                    "WRITE"
                ],
                "name": "my-protected-account"
            },
            {
                "authorizations": [
                    "READ",
                    "WRITE"
                ],
                "name": "my-aws-account"
            }
        ],
        "applications": [
            {
                "authorizations": [
                    "CREATE",
                    "READ",
                    "WRITE"
                ],
                "name": "abc"
            }
        ]
    },
    "name": "sekret-service-acct@spinnaker-test.net",
    "serviceAccounts": []
}
```

When a user (with access to the service account) adds a trigger to a pipeline, and configures that trigger to run the pipeline as a service account, that pipeline will execute as if a real user logged in and clicked "Run" - including all authorization checks as if it were the real user.

This impl uses the Spring config to manage service accounts, but it's likely that real users will want to add/remove them through the application itself. We will probably end up with a similar scenario with how application configs are managed. 

@cfieber @ajordens @jtk54 @duftler PTAL.

