### PR TITLE
Adds health indicator that won't signal the server is healthy until a…

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import lombok.Data;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BaseProvider {
+
+  @Value("${unhealthy.threshold:5}")
+  @Setter
+  private int unhealthyThreshold;
+
+  private AtomicInteger failureCountSinceLastSuccess = new AtomicInteger(-1);
+
+  void failure() {
+    // Increment the failure count only if there has been at least 1 success() call. Otherwise,
+    // leave the default, which is considered unhealthy.
+    if (!failureCountSinceLastSuccess.compareAndSet(-1, -1)) {
+      failureCountSinceLastSuccess.incrementAndGet();
+    }
+  }
+
+  void success() {
+    failureCountSinceLastSuccess.set(0);
+  }
+
+  public boolean isProviderHealthy() {
+    int count = failureCountSinceLastSuccess.get();
+    return 0 <= count && count < unhealthyThreshold;
+  }
+
+  public HealthView getHealthView() {
+    return new HealthView();
+  }
+
+  @Data
+  class HealthView {
+    boolean providerHealthy = BaseProvider.this.isProviderHealthy();
+    int failureCountSinceLastSuccess = BaseProvider.this.failureCountSinceLastSuccess.get();
+  }
+}

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -20,18 +20,18 @@ import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
-public class DefaultAccountProvider implements AccountProvider {
+public class DefaultAccountProvider extends BaseProvider implements AccountProvider {
 
   @Autowired
   @Setter
@@ -39,14 +39,17 @@ public class DefaultAccountProvider implements AccountProvider {
 
   public Set<Account> getAccounts(@NonNull Collection<String> groups) {
     try {
-      return clouddriverService
+      val returnVal = clouddriverService
           .getAccounts()
           .stream()
           .filter(account ->
                       account.getRequiredGroupMembership().isEmpty() ||
                           !Collections.disjoint(account.getRequiredGroupMembership(), groups))
           .collect(Collectors.toSet());
+      success();
+      return returnVal;
     } catch (RetrofitError re) {
+      failure();
       throw new ProviderException(re);
     }
   }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.providers;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import lombok.NonNull;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
@@ -29,7 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
-public class DefaultApplicationProvider implements ApplicationProvider {
+public class DefaultApplicationProvider extends BaseProvider implements ApplicationProvider {
 
   @Autowired
   private Front50Service front50Service;
@@ -37,14 +38,17 @@ public class DefaultApplicationProvider implements ApplicationProvider {
   @Override
   public Set<Application> getApplications(@NonNull Collection<String> groups) {
     try {
-      return front50Service
+      val returnVal = front50Service
           .getAllApplicationPermissions()
           .stream()
           .filter(application ->
                       application.getRequiredGroupMembership().isEmpty() ||
                           !Collections.disjoint(application.getRequiredGroupMembership(), groups))
           .collect(Collectors.toSet());
+      success();
+      return returnVal;
     } catch (RetrofitError re) {
+      failure();
       throw new ProviderException(re);
     }
   }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountProvider.java
@@ -22,5 +22,8 @@ import java.util.Collection;
 import java.util.Set;
 
 public interface ServiceAccountProvider {
+
+  Set<ServiceAccount> getAccounts() throws ProviderException;
+
   Set<ServiceAccount> getAccounts(Collection<String> groups) throws ProviderException;
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class BaseProviderSpec extends Specification {
+
+  def "should start and remain unhealthy until first success"() {
+    setup:
+    @Subject provider = new BaseProvider(unhealthyThreshold: 2)
+
+    expect:
+    !provider.isProviderHealthy()
+    provider.failure()
+    !provider.isProviderHealthy()
+
+    provider.success()
+    provider.isProviderHealthy()
+
+    provider.failure()
+    provider.isProviderHealthy()
+    provider.failure()
+    !provider.isProviderHealthy()
+
+    provider.success()
+    provider.isProviderHealthy()
+  }
+}

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -17,9 +17,6 @@
 package com.netflix.spinnaker.fiat.providers
 
 import com.netflix.spinnaker.fiat.model.ServiceAccount
-import com.netflix.spinnaker.fiat.model.UserPermission
-import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
-import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import spock.lang.Shared
 import spock.lang.Specification
@@ -62,28 +59,5 @@ class DefaultServiceAccountProviderSpec extends Specification {
     ["abc"]               || [abcAcct]
     ["abc", "xyz"]        || [abcAcct, xyzAcct]
     ["abc", "xyz", "def"] || [abcAcct, xyzAcct]
-  }
-
-  def "should update service accounts"() {
-    setup:
-    def abcPermission = new UserPermission().setId("abc")
-    def xyzPermission = new UserPermission().setId("xyz@domain.com")
-    PermissionsRepository repo = Mock(PermissionsRepository)
-    PermissionsResolver resolver = Mock(PermissionsResolver) {
-      resolve("abc") >> Optional.of(abcPermission)
-      resolve("xyz@domain.com") >> Optional.of(xyzPermission)
-    }
-    provider = new DefaultServiceAccountProvider(
-        front50Service: front50Service,
-        permissionsResolver: resolver,
-        permissionsRepo: repo,
-    )
-
-    when:
-    provider.updateServiceAccounts()
-
-    then:
-    1 * repo.put(abcPermission)
-    1 * repo.put(xyzPermission)
   }
 }

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -97,6 +97,8 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
 
   @Override
   public Map<String, UserPermission> resolve(@NonNull Collection<String> userIds) {
+    // TODO(ttomsu): Make bulk version of getUserPermission. Current impl will crush the resource
+    // provider when there are a lot of users.
     val roles = userRolesProvider.multiLoadRoles(userIds);
     return roles.entrySet()
                 .stream()

--- a/fiat-web/config/fiat.yml
+++ b/fiat-web/config/fiat.yml
@@ -8,8 +8,15 @@ okHttpClient:
   retries:
     maxElapsedBackoffMs: 5000
 
+endpoints:
+  health:
+    sensitive: false
+
 auth:
   anonymous:
     enabled: false
   getAll:
     enabled: false
+  userSync:
+    intervalMs: 600000
+    retryInterval: 10000

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderHealthIndicator.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderHealthIndicator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.providers.BaseProvider;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ResourceProviderHealthIndicator extends AbstractHealthIndicator {
+
+  @Autowired
+  @Setter
+  List<BaseProvider> providers;
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) throws Exception {
+    boolean isDown = false;
+    for (BaseProvider provider : providers) {
+      builder.withDetail(provider.getClass().getSimpleName(), provider.getHealthView());
+      isDown = isDown || !provider.isProviderHealthy();
+    }
+
+    if (isDown) {
+      builder.down();
+    } else {
+      builder.up();
+    }
+  }
+}


### PR DESCRIPTION
… successful service account sync.

If Fiat turns up before Front50, it will not become healthy (as indicated by `/health`) and keep retrying every 10s until a successful call to Front50 is made, at which point, the @Scheduler will resync every 10 minutes. If any periodic service account sync fails, it will continue to retry every 10s until a successful call. These retries are _independent_ of the Retrofit HTTP-level calls.  

If any period sync for user permissions fails 5 times (because either clouddriver or front50 are not responding), the Fiat service will go unhealthy. 

@jtk54 @duftler @cfieber @ajordens PTAL.

(FYI - I'll be out for the next week. Feel free to merge before then.)