### PR TITLE
Introduction of fiat-api module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ Roadmap/Implementation Punch list:
 * ☐ Compile "to secure" list of endpoints. (In progress)
 * ☐ **Component integration** - wire it all together throughout the other microservices.
   * ☑ Gate
-  * ☐ Front50 (in progress)
-    * ☐ GET /default/applications
-    * ☐ PUT /default/applications
-    * ☐ POST /default/applications/batchUpdate
-    * ☐ DELETE /default/applications/name/{application}
-    * ☐ GET /default/applications/name/{application}
-    * ☐ POST /default/applications/name/{application}
-    * ☐ GET /default/applications/search
-    * ☐ GET /default/applications/{application}/history
+  * ☑ Front50 (in progress)
+    * Troublesome:
+      * DELETE /pipelines/deleteById
+      * DELETE /strategies/deleteById
+      * NotificationsController
   * ☐ Orca
   * ☐ Clouddriver
   * ☐ Echo

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   spinnaker {
-    dependenciesVersion = "0.37.0"
+    dependenciesVersion = "0.48.0"
   }
   test {
     testLogging {

--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+  compile project(":fiat-core")
+
+  spinnaker.group("retrofitDefault")
+
+  compile spinnaker.dependency("korkSecurity")
+  compile spinnaker.dependency("bootActuator")
+  compile spinnaker.dependency("bootWeb")
+
+  compile spinnaker.dependency("springSecurityConfig")
+  compile spinnaker.dependency("springSecurityCore")
+  compile spinnaker.dependency("springSecurityWeb")
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.config.RetrofitConfig;
+import com.netflix.spinnaker.fiat.shared.FiatAuthenticationFilter;
+import com.netflix.spinnaker.fiat.shared.FiatService;
+import lombok.Setter;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import retrofit.Endpoints;
+import retrofit.RestAdapter;
+import retrofit.client.OkClient;
+import retrofit.converter.JacksonConverter;
+
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@Configuration
+@Import(RetrofitConfig.class)
+@ComponentScan("com.netflix.spinnaker.fiat.shared")
+public class FiatAuthenticationConfig {
+
+  @Autowired
+  @Setter
+  private RestAdapter.LogLevel retrofitLogLevel;
+
+  @Autowired
+  @Setter
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  @Setter
+  private OkClient okClient;
+
+  @Value("${services.fiat.baseUrl}")
+  @Setter
+  private String fiatEndpoint;
+
+  @Bean
+  public FiatService fiatService() {
+    return new RestAdapter.Builder()
+        .setEndpoint(Endpoints.newFixedEndpoint(fiatEndpoint))
+        .setClient(okClient)
+        .setConverter(new JacksonConverter(objectMapper))
+        .setLogLevel(retrofitLogLevel)
+        .build()
+        .create(FiatService.class);
+  }
+
+  @Bean
+  FilterRegistrationBean fiatFilterRegistrationBean(FiatAuthenticationFilter filter) {
+    val frb = new FilterRegistrationBean(filter);
+    frb.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
+    frb.addUrlPatterns("/*");
+    return frb;
+  }
+
+  @ConditionalOnExpression("!${services.fiat.enabled:false}")
+  @Bean
+  AnonymousConfig anonymousConfig() {
+    return new AnonymousConfig();
+  }
+
+  private class AnonymousConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http.authorizeRequests().anyRequest().permitAll();
+    }
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import java.io.IOException;
+import java.util.ArrayList;
+
+@Slf4j
+@Component
+public class FiatAuthenticationFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    Authentication auth = AuthenticatedRequest
+        .getSpinnakerUser()
+        .map(username -> (Authentication) new PreAuthenticatedAuthenticationToken(username,
+                                                                                  null,
+                                                                                  new ArrayList<>()))
+        .orElseGet(() -> new AnonymousAuthenticationToken(
+            "ignored1", // These values are never used. See FiatPermissionEvaluator.
+            "ignored2",
+            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+        ));
+
+    val ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(auth);
+    SecurityContextHolder.setContext(ctx);
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void destroy() {
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
+
+import java.io.Serializable;
+
+@Component
+@Slf4j
+public class FiatPermissionEvaluator implements PermissionEvaluator {
+
+  @Autowired
+  @Setter
+  private FiatService fiatService;
+
+  @Value("${services.fiat.enabled:false}")
+  @Setter
+  private String fiatEnabled;
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Object resource, Object authorization) {
+    return false;
+  }
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Serializable resourceName, String resourceType, Object authorization) {
+    if (!Boolean.valueOf(fiatEnabled)) {
+      return true;
+    }
+
+    String username = getUsername(authentication);
+    Resource r = Resource.parse(resourceType);
+    Authorization a = Authorization.valueOf(authorization.toString());
+
+    return isAuthorized(username, r, resourceName.toString(), a);
+  }
+
+  private String getUsername(Authentication authentication) {
+    String username = "anonymous";
+    if (authentication instanceof PreAuthenticatedAuthenticationToken) {
+      PreAuthenticatedAuthenticationToken authToken = (PreAuthenticatedAuthenticationToken) authentication;
+      if (authToken.isAuthenticated()) {
+        username = authToken.getPrincipal().toString();
+      }
+    }
+    return username;
+  }
+
+  private boolean isAuthorized(String username, Resource resource, String resourceName, Authorization a) {
+    try {
+      fiatService.hasAuthorization(username, resource.toString(), resourceName, a.toString());
+    } catch (RetrofitError re) {
+      String message = String.format("Fiat authorization failed for user '%s' '%s'-ing '%s' " +
+                                         "resource named '%s'. Cause: %s", username, a, resource, resourceName, re.getMessage());
+      log.debug(message);
+      log.trace(message, re);
+      return false;
+    }
+    return true;
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.squareup.okhttp.Response;
+import retrofit.http.GET;
+import retrofit.http.Path;
+
+public interface FiatService {
+
+  @GET("/authorize/{userId}/{resourceType}/{resourceName}/{authorization}")
+  Response hasAuthorization(@Path("userId") String userId,
+                            @Path("resourceType") String resourceType,
+                            @Path("resourceName") String resourceName,
+                            @Path("authorization") String authorization);
+}

--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile spinnaker.dependency("springContext")
   compile spinnaker.dependency("guava")
   compile spinnaker.dependency("bootActuator")
+  compile spinnaker.dependency('korkWeb')
 
   compile "org.apache.commons:commons-lang3:3.4"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.4"

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.config.OkHttpClientConfiguration;
+import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.util.backoff.BackOffExecution;
+import org.springframework.util.backoff.ExponentialBackOff;
+import retrofit.RestAdapter;
+import retrofit.client.OkClient;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This package is placed in fiat-core in order to be shared by fiat-web and fiat-shared.
+ */
+@Configuration
+public class RetrofitConfig {
+
+  @Autowired
+  @Setter
+  private OkHttpClientConfiguration okHttpClientConfig;
+
+  @Value("${okHttpClient.connectionPool.maxIdleConnections:5}")
+  @Setter
+  private int maxIdleConnections;
+
+  @Value("${okHttpClient.connectionPool.keepAliveDurationMs:300000}")
+  @Setter
+  private int keepAliveDurationMs;
+
+  @Value("${okHttpClient.retryOnConnectionFailure:true}")
+  @Setter
+  private boolean retryOnConnectionFailure;
+
+  @Value("${okHttpClient.retries.maxElapsedBackoffMs:5000}")
+  @Setter
+  private long maxElapsedBackoffMs;
+
+  @Bean
+  @Primary
+  ObjectMapper objectMapper() {
+    return new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  @Bean
+  RestAdapter.LogLevel retrofitLogLevel(@Value("${retrofit.logLevel:NONE}") String logLevel) {
+    return RestAdapter.LogLevel.valueOf(logLevel);
+  }
+
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  OkClient okClient() {
+    val client = okHttpClientConfig.create();
+    client.setConnectionPool(new ConnectionPool(maxIdleConnections, keepAliveDurationMs));
+    client.setRetryOnConnectionFailure(retryOnConnectionFailure);
+    client.interceptors().add(new RetryingInterceptor(maxElapsedBackoffMs));
+    return new OkClient(client);
+  }
+
+  @Slf4j
+  @AllArgsConstructor
+  private static class RetryingInterceptor implements Interceptor {
+
+    // http://restcookbook.com/HTTP%20Methods/idempotency/
+    private static final List<String> NON_RETRYABLE_METHODS = ImmutableList.of("POST", "PATCH");
+
+    private long maxElapsedBackoffMs;
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+      ExponentialBackOff backoff = new ExponentialBackOff();
+      backoff.setMaxElapsedTime(maxElapsedBackoffMs);
+      BackOffExecution backOffExec = backoff.start();
+
+      Response response = null;
+      long waitTime = 0;
+      while (waitTime != BackOffExecution.STOP) {
+        Request request = chain.request();
+        response = chain.proceed(request);
+        if (response.isSuccessful() ||
+            NON_RETRYABLE_METHODS.contains(request.method()) ||
+            response.code() == 404) {
+          return response;
+        }
+
+        try {
+          waitTime = backOffExec.nextBackOff();
+          if (waitTime != BackOffExecution.STOP) {
+            response.body().close();
+            log.warn("Request for " + request.urlString() + " failed. Backing off for " + waitTime + "ms");
+            Thread.sleep(waitTime);
+          }
+        } catch (Throwable ignored) {
+          break;
+        }
+      }
+      return response;
+    }
+  }
+}

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
@@ -18,11 +18,13 @@ package com.netflix.spinnaker.fiat.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.resources.Named;
+import com.netflix.spinnaker.fiat.model.resources.Viewable;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
-public class ServiceAccount implements Named {
+public class ServiceAccount implements Named, Viewable {
   private String name;
 
   @JsonIgnore
@@ -32,11 +34,16 @@ public class ServiceAccount implements Named {
 
   @JsonIgnore
   public View getView() {
-    return new View();
+    return new View(this);
   }
 
   @Data
-  public class View {
-    String name = ServiceAccount.this.name;
+  @NoArgsConstructor
+  public static class View extends BaseView implements Named {
+    String name;
+
+    public View(ServiceAccount serviceAccount) {
+      this.name = serviceAccount.name;
+    }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -20,26 +20,33 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 @Data
-public class Account implements Named {
+public class Account implements Named,Viewable {
   private String name;
   private String cloudProvider;
   private List<String> requiredGroupMembership = new ArrayList<>();
 
   @JsonIgnore
   public View getView() {
-    return new View();
+    return new View(this);
   }
 
   @Data
-  public class View {
-    String name = Account.this.name;
+  @NoArgsConstructor
+  public static class View extends BaseView implements Authorizable {
+    String name;
     Set<Authorization> authorizations = ImmutableSet.of(Authorization.READ,
                                                         Authorization.WRITE);
+
+    public View(Account account) {
+      this.name = account.name;
+    }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -20,26 +20,32 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 @Data
-public class Application implements Named {
+public class Application implements Named, Viewable {
   private String name;
   private List<String> requiredGroupMembership = new ArrayList<>();
 
   @JsonIgnore
   public View getView() {
-    return new View();
+    return new View(this);
   }
 
   @Data
-  public class View {
-    String name = Application.this.name;
+  @NoArgsConstructor
+  public static class View extends BaseView implements Authorizable {
+    String name;
     Set<Authorization> authorizations = ImmutableSet.of(Authorization.CREATE,
                                                         Authorization.READ,
                                                         Authorization.WRITE);
+
+    public View(Application application) {
+      this.name = application.name;
+    }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Authorizable.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Authorizable.java
@@ -16,24 +16,10 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
-import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
+import com.netflix.spinnaker.fiat.model.Authorization;
 
-public enum Resource {
-  ACCOUNT,
-  APPLICATION,
-  SERVICE_ACCOUNT; // Fiat service account.
+import java.util.Set;
 
-  // TODO(ttomsu): This is Redis-specific, so it probably shouldn't go here.
-  public static Resource parse(@NonNull String pluralOrKey) {
-    if (pluralOrKey.contains(":")) {
-      pluralOrKey = StringUtils.substringAfterLast(pluralOrKey, ":");
-    }
-    String singular = StringUtils.removeEnd(pluralOrKey, "s");
-    return Resource.valueOf(singular.toUpperCase());
-  }
-
-  public String keySuffix() {
-    return this.toString().toLowerCase() + "s";
-  }
+public interface Authorizable extends Named {
+  Set<Authorization> getAuthorizations();
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Viewable.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Viewable.java
@@ -16,24 +16,10 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
-import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
+public interface Viewable {
+  BaseView getView();
 
-public enum Resource {
-  ACCOUNT,
-  APPLICATION,
-  SERVICE_ACCOUNT; // Fiat service account.
-
-  // TODO(ttomsu): This is Redis-specific, so it probably shouldn't go here.
-  public static Resource parse(@NonNull String pluralOrKey) {
-    if (pluralOrKey.contains(":")) {
-      pluralOrKey = StringUtils.substringAfterLast(pluralOrKey, ":");
-    }
-    String singular = StringUtils.removeEnd(pluralOrKey, "s");
-    return Resource.valueOf(singular.toUpperCase());
-  }
-
-  public String keySuffix() {
-    return this.toString().toLowerCase() + "s";
+  // Empty class used for referencing Resource-specific View objects.
+  class BaseView {
   }
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ResourceSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ResourceSpec.groovy
@@ -30,6 +30,9 @@ class ResourceSpec extends Specification {
     "abc:accounts"     || Resource.ACCOUNT
     "abc:def:accounts" || Resource.ACCOUNT
     ":applications"    || Resource.APPLICATION
+    "account"          || Resource.ACCOUNT
+    "accounts"         || Resource.ACCOUNT
+    "aCCoUnTs"         || Resource.ACCOUNT
   }
 
   def "should throw exception on invalid parse input"() {
@@ -43,7 +46,6 @@ class ResourceSpec extends Specification {
     input       || e
     null        || IllegalArgumentException.class
     ""          || IllegalArgumentException.class
-    "account"   || IllegalArgumentException.class
     "account:"  || IllegalArgumentException.class
     "account:s" || IllegalArgumentException.class
   }

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -18,7 +18,6 @@ configurations.all {
 dependencies {
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
-  compile spinnaker.dependency('korkWeb')
   compile project(':fiat-core')
   compile project(':fiat-roles')
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -1,73 +1,23 @@
 package com.netflix.spinnaker.fiat.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.netflix.spinnaker.fiat.permissions.InMemoryPermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
-import com.squareup.okhttp.ConnectionPool;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
-import lombok.AllArgsConstructor;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Scope;
-import org.springframework.util.backoff.BackOffExecution;
-import org.springframework.util.backoff.ExponentialBackOff;
-import retrofit.RestAdapter;
-import retrofit.client.OkClient;
+import org.springframework.context.annotation.Import;
 
-import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
+@Import(RetrofitConfig.class)
 public class FiatConfig {
-
-  @Autowired
-  @Setter
-  private OkHttpClientConfiguration okHttpClientConfig;
-
-  @Value("${okHttpClient.connectionPool.maxIdleConnections:5}")
-  @Setter
-  private int maxIdleConnections;
-
-  @Value("${okHttpClient.connectionPool.keepAliveDurationMs:300000}")
-  @Setter
-  private int keepAliveDurationMs;
-
-  @Value("${okHttpClient.retryOnConnectionFailure:true}")
-  @Setter
-  private boolean retryOnConnectionFailure;
-
-  @Value("${okHttpClient.retries.maxElapsedBackoffMs:5000}")
-  @Setter
-  private long maxElapsedBackoffMs;
 
   @Bean
   @ConditionalOnMissingBean(PermissionsRepository.class)
   PermissionsRepository permissionsRepository() {
     return new InMemoryPermissionsRepository();
-  }
-
-  @Bean
-  @Primary
-  ObjectMapper objectMapper() {
-    return new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 
   @Bean
@@ -84,59 +34,5 @@ public class FiatConfig {
         return new ArrayList<>();
       }
     };
-  }
-
-  @Bean
-  RestAdapter.LogLevel retrofitLogLevel(@Value("${retrofit.logLevel:NONE}") String logLevel) {
-    return RestAdapter.LogLevel.valueOf(logLevel);
-  }
-
-  @Bean
-  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  OkClient okClient() {
-    val client = okHttpClientConfig.create();
-    client.setConnectionPool(new ConnectionPool(maxIdleConnections, keepAliveDurationMs));
-    client.setRetryOnConnectionFailure(retryOnConnectionFailure);
-    client.interceptors().add(new RetryingInterceptor(maxElapsedBackoffMs));
-    return new OkClient(client);
-  }
-
-  @Slf4j
-  @AllArgsConstructor
-  private static class RetryingInterceptor implements Interceptor {
-
-    // http://restcookbook.com/HTTP%20Methods/idempotency/
-    private static final List<String> NON_RETRYABLE_METHODS = ImmutableList.of("POST", "PATCH");
-
-    private long maxElapsedBackoffMs;
-
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-      ExponentialBackOff backoff = new ExponentialBackOff();
-      backoff.setMaxElapsedTime(maxElapsedBackoffMs);
-      BackOffExecution backOffExec = backoff.start();
-
-      Response response = null;
-      long waitTime = 0;
-      while (waitTime != BackOffExecution.STOP) {
-        Request request = chain.request();
-        response = chain.proceed(request);
-        if (response.isSuccessful() || NON_RETRYABLE_METHODS.contains(request.method())) {
-          return response;
-        }
-
-        try {
-          waitTime = backOffExec.nextBackOff();
-          if (waitTime != BackOffExecution.STOP) {
-            response.body().close();
-            log.warn("Request for " + request.urlString() + " failed. Backing off for " + waitTime + "ms");
-            Thread.sleep(waitTime);
-          }
-        } catch (Throwable ignored) {
-          break;
-        }
-      }
-      return response;
-    }
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.fiat.controllers;
 
+import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import io.swagger.annotations.ApiOperation;
 import lombok.Setter;
@@ -28,6 +31,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -85,6 +90,63 @@ public class AuthorizeController {
                                 .filter(account -> accountName.equalsIgnoreCase(account.getName()))
                                 .findFirst()
                                 .map(Account::getView)
+                                .orElseThrow(NotFoundException::new);
+  }
+
+  @RequestMapping(value = "/{userId:.+}/{resourceType:.+}/{resourceName:.+}/{authorization:.+}", method = RequestMethod.GET)
+  public void getUserAuthorization(@PathVariable String userId,
+                                   @PathVariable String resourceType,
+                                   @PathVariable String resourceName,
+                                   @PathVariable String authorization,
+                                   HttpServletResponse response) throws IOException {
+    Authorization a = Authorization.valueOf(authorization.toUpperCase());
+    Resource r = Resource.parse(resourceType);
+    Set<Authorization> authorizations = new HashSet<>(0);
+
+    try {
+      switch (r) {
+        case ACCOUNT:
+          authorizations = getUserAccount(userId, resourceName).getAuthorizations();
+          break;
+        case APPLICATION:
+          authorizations = getUserApplication(userId, resourceName).getAuthorizations();
+          break;
+        default:
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Resource type " + resourceType +
+              " does not contain authorizations");
+          return;
+      }
+    } catch (NotFoundException nfe) {
+      // Ignore. Will return 404 below.
+    }
+
+    if (authorizations.contains(a)) {
+      response.setStatus(HttpServletResponse.SC_OK);
+      return;
+    }
+
+    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  @RequestMapping(value = "/{userId:.+}/applications", method = RequestMethod.GET)
+  public Set<Application.View> getUserApplications(@PathVariable String userId) {
+    return permissionsRepository.get(ControllerSupport.decode(userId))
+                                .orElseThrow(NotFoundException::new)
+                                .getApplications()
+                                .stream()
+                                .map(Application::getView)
+                                .collect(Collectors.toSet());
+  }
+
+  @RequestMapping(value = "/{userId:.+}/applications/{applicationName:.+}", method = RequestMethod.GET)
+  public Application.View getUserApplication(@PathVariable String userId, @PathVariable String applicationName) {
+    return permissionsRepository.get(ControllerSupport.decode(userId))
+                                .orElseThrow(NotFoundException::new)
+                                .getApplications()
+                                .stream()
+                                .filter(application -> applicationName.equalsIgnoreCase(application.getName()))
+                                .findFirst()
+                                .map(Application::getView)
                                 .orElseThrow(NotFoundException::new);
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name="fiat"
 
-include 'fiat-core', 'fiat-roles', 'fiat-web'
+include 'fiat-api', 'fiat-core', 'fiat-roles', 'fiat-web'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
The `fiat-api` module is a shared library that can be used by all of the other Spinnaker microservices to check if a user is authorized to view a particular resource.

The module defines the necessary pieces for Fiat integration, including: 
* A `Filter` to pull the Spinnaker username and put it into the Spring Security context.
* A Spring Security `PermissionEvaluator` that is used by the `PreAuthorize` and `PostFilter` annotations that will go on the secured endpoints.  
* A Retrofit interface for (strongly typed!!) REST calls going to Fiat.
* A config files to make it all work out-of-the-box when the `fiat-api` library is included in the classpath.

This is a relatively big PR, but I've broken it down into common commits for easier reviewability. Notes on the non `fiat-api` commits:
1.) Nested, non-static View classes are *really* nice for serialization - but not very nice (as in impossible) for ***de***serialization. So I had to make them static. In the process I introduced a new base class (`BaseView`) and interface (`Authorizable`) that are used in future commits.

2.) Filled out the `/authorize` API surface with `applications` and, more importantly, a generic "does user X have access to [read|write] resource Y"

(Personal aside: the strongly typed Retrofit interface would probably be better served with a protocol buffer interface, but maybe I'm showing my Google bias there ;-)  

@duftler @jtk54 @cfieber @ajordens PTAL

