### PR TITLE
Replaces optional anonymous user with non-opptional 'unrestricted' us…

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/ServiceAccount.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
+import com.netflix.spinnaker.fiat.model.resources.ResourceType;
 import com.netflix.spinnaker.fiat.model.resources.Viewable;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,6 +26,8 @@ import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class ServiceAccount implements Resource, Viewable {
+  final ResourceType resourceType = ResourceType.SERVICE_ACCOUNT;
+
   private String name;
 
   @JsonIgnore

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -17,12 +17,14 @@
 package com.netflix.spinnaker.fiat.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
 import com.netflix.spinnaker.fiat.model.resources.Viewable;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.val;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Data
 public class UserPermission implements Viewable {
@@ -55,6 +58,10 @@ public class UserPermission implements Viewable {
   }
 
   public void addResources(Collection<Resource> resources) {
+    if (resources == null) {
+      return;
+    }
+
     resources.forEach(resource -> {
       if (resource instanceof Account) {
         accounts.add((Account) resource);
@@ -66,6 +73,23 @@ public class UserPermission implements Viewable {
         throw new IllegalArgumentException("Cannot add unknown resource " + resource);
       }
     });
+  }
+
+  @JsonIgnore
+  public Set<Resource> getAllResources() {
+    Set<Resource> retVal = new HashSet<>();
+    retVal.addAll(accounts);
+    retVal.addAll(applications);
+    retVal.addAll(serviceAccounts);
+    return retVal;
+  }
+
+  /**
+   * This method adds all of other's resources to this one.
+   * @param other
+   */
+  public void merge(UserPermission other) {
+    this.addResources(other.getAllResources());
   }
 
   @JsonIgnore

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -88,8 +88,9 @@ public class UserPermission implements Viewable {
    * This method adds all of other's resources to this one.
    * @param other
    */
-  public void merge(UserPermission other) {
+  public UserPermission merge(UserPermission other) {
     this.addResources(other.getAllResources());
+    return this;
   }
 
   @JsonIgnore

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -41,13 +41,6 @@ public class UserPermission implements Viewable {
   private Set<Application> applications = new HashSet<>();
   private Set<ServiceAccount> serviceAccounts = new HashSet<>();
 
-  /**
-   * True if any of the resources listed above are incomplete for whatever reason - usually because
-   * an external provider was down.
-   */
-  @JsonIgnore
-  private boolean isPartialPermission = false;
-
   @JsonIgnore
   public boolean isEmpty() {
     return accounts.isEmpty() && applications.isEmpty();

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -100,7 +100,7 @@ public class UserPermission implements Viewable {
   @Data
   @NoArgsConstructor
   @SuppressWarnings("unchecked")
-  public static class View extends BaseView implements Resource {
+  public static class View extends BaseView {
     String name;
     Set<Account.View> accounts;
     Set<Application.View> applications;

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 @Data
 public class Account implements GroupAccessControlled, Resource, Viewable {
+  final ResourceType resourceType = ResourceType.ACCOUNT;
+
   private String name;
   private String cloudProvider;
   private List<String> requiredGroupMembership = new ArrayList<>();

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 @Data
 public class Application implements GroupAccessControlled, Resource, Viewable {
+  final ResourceType resourceType = ResourceType.APPLICATION;
+
   private String name;
   private List<String> requiredGroupMembership = new ArrayList<>();
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Authorizable.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Authorizable.java
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.fiat.model.Authorization;
 
 import java.util.Set;
 
-public interface Authorizable extends Resource {
+public interface Authorizable {
+  String getName();
+
   Set<Authorization> getAuthorizations();
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Resource.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Resource.java
@@ -16,6 +16,11 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public interface Resource {
   String getName();
+
+  @JsonIgnore
+  ResourceType getResourceType();
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
@@ -16,13 +16,20 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
+import com.netflix.spinnaker.fiat.model.ServiceAccount;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 
 public enum ResourceType {
-  ACCOUNT,
-  APPLICATION,
-  SERVICE_ACCOUNT; // Fiat service account.
+  ACCOUNT(Account.class),
+  APPLICATION(Application.class),
+  SERVICE_ACCOUNT(ServiceAccount.class); // Fiat service account.
+
+  public Class<? extends Resource> modelClass;
+
+  ResourceType(Class<? extends Resource> modelClass) {
+    this.modelClass = modelClass;
+  }
 
   // TODO(ttomsu): This is Redis-specific, so it probably shouldn't go here.
   public static ResourceType parse(@NonNull String pluralOrKey) {

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -28,7 +28,7 @@ public interface PermissionsResolver {
    * @return The UserPermission for an anonymous user. May return empty if anonymous users are
    * disabled.
    */
-  Optional<UserPermission> resolveAnonymous();
+  Optional<UserPermission> resolveUnrestrictedUser();
 
   /**
    * Resolves a single user's permissions.

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -50,12 +50,18 @@ public class DefaultAccountProvider extends BaseProvider implements AccountProvi
   }
 
   @Override
-  public Set<Account> getAll(@NonNull Collection<String> groups) throws ProviderException {
+  public Set<Account> getAllRestricted(@NonNull Collection<String> groups) throws ProviderException {
     return getAll()
         .stream()
-        .filter(account ->
-                    account.getRequiredGroupMembership().isEmpty() ||
-                        !Collections.disjoint(account.getRequiredGroupMembership(), groups))
+        .filter(account -> !Collections.disjoint(account.getRequiredGroupMembership(), groups))
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<Account> getAllUnrestricted() throws ProviderException {
+    return getAll()
+        .stream()
+        .filter(account -> account.getRequiredGroupMembership().isEmpty())
         .collect(Collectors.toSet());
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -50,12 +50,18 @@ public class DefaultApplicationProvider extends BaseProvider implements Applicat
   }
 
   @Override
-  public Set<Application> getAll(@NonNull Collection<String> groups) throws ProviderException {
+  public Set<Application> getAllRestricted(@NonNull Collection<String> groups) throws ProviderException {
     return getAll()
         .stream()
-        .filter(application ->
-                    application.getRequiredGroupMembership().isEmpty() ||
-                        !Collections.disjoint(application.getRequiredGroupMembership(), groups))
+        .filter(application -> !Collections.disjoint(application.getRequiredGroupMembership(), groups))
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<Application> getAllUnrestricted() throws ProviderException {
+    return getAll()
+        .stream()
+        .filter(application -> application.getRequiredGroupMembership().isEmpty())
         .collect(Collectors.toSet());
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -61,7 +62,7 @@ public class DefaultServiceAccountProvider extends BaseProvider implements Servi
    * after the "@" symbol for the purposes of service account/group matching.
    */
   @Override
-  public Set<ServiceAccount> getAll(@NonNull Collection<String> groups) {
+  public Set<ServiceAccount> getAllRestricted(@NonNull Collection<String> groups) {
     // There is a potential here for a naming collision where service account
     // "my-svc-account@abc.com" and "my-svc-account@xyz.com" each allow one another's users to use
     // their service account. In practice, though, I don't think this will be an issue.
@@ -73,5 +74,10 @@ public class DefaultServiceAccountProvider extends BaseProvider implements Servi
         .filter(serviceAccountsByName::containsKey)
         .map(serviceAccountsByName::get)
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<ServiceAccount> getAllUnrestricted() throws ProviderException {
+    return Collections.emptySet();
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -25,5 +25,7 @@ public interface ResourceProvider<R extends Resource> {
 
   Set<R> getAll() throws ProviderException;
 
-  Set<R> getAll(Collection<String> groups) throws ProviderException;
+  Set<R> getAllRestricted(Collection<String> groups) throws ProviderException;
+
+  Set<R> getAllUnrestricted() throws ProviderException;
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
@@ -20,9 +20,11 @@ import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class DefaultAccountProviderSpec extends Specification {
 
+  @Unroll
   def "should get all accounts based on supplied roles"() {
     setup:
     ClouddriverService clouddriverService = Mock(ClouddriverService) {
@@ -38,24 +40,24 @@ class DefaultAccountProviderSpec extends Specification {
     )
 
     when:
-    def result = accountProvider.getAll(input)
+    def result = accountProvider.getAllRestricted(input)
 
     then:
     result*.name.containsAll(values)
 
     when:
-    accountProvider.getAll(null)
+    accountProvider.getAllRestricted(null)
 
     then:
     thrown IllegalArgumentException
 
     where:
     input                || values
-    []                   || ["noReqGroups"]
-    ["group1"]           || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
-    ["group2"]           || ["noReqGroups", "reqGroup1and2"]
-    ["group1", "group2"] || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
-    ["group3"]           || ["noReqGroups"]
-    ["group2", "group3"] || ["noReqGroups", "reqGroup1and2"]
+    []                   || []
+    ["group1"]           || ["reqGroup1", "reqGroup1and2"]
+    ["group2"]           || ["reqGroup1and2"]
+    ["group1", "group2"] || ["reqGroup1", "reqGroup1and2"]
+    ["group3"]           || []
+    ["group2", "group3"] || ["reqGroup1and2"]
   }
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -18,14 +18,15 @@ package com.netflix.spinnaker.fiat.providers
 
 import com.netflix.spinnaker.fiat.model.resources.Application
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
-import org.apache.commons.io.FileUtils
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class DefaultApplicationProviderSpec extends Specification {
 
   @Subject DefaultApplicationProvider provider
 
+  @Unroll
   def "should get all accounts based on supplied roles"() {
     setup:
     Front50Service front50Service = Mock(Front50Service) {
@@ -38,24 +39,24 @@ class DefaultApplicationProviderSpec extends Specification {
     provider = new DefaultApplicationProvider(front50Service: front50Service)
 
     when:
-    def result = provider.getAll(input)
+    def result = provider.getAllRestricted(input)
 
     then:
     result*.name.containsAll(values)
 
     when:
-    provider.getAll(null)
+    provider.getAllRestricted(null)
 
     then:
     thrown IllegalArgumentException
 
     where:
     input                || values
-    []                   || ["noReqGroups"]
-    ["group1"]           || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
-    ["group2"]           || ["noReqGroups", "reqGroup1and2"]
-    ["group1", "group2"] || ["noReqGroups", "reqGroup1", "reqGroup1and2"]
-    ["group3"]           || ["noReqGroups"]
-    ["group2", "group3"] || ["noReqGroups", "reqGroup1and2"]
+    []                   || []
+    ["group1"]           || ["reqGroup1", "reqGroup1and2"]
+    ["group2"]           || ["reqGroup1and2"]
+    ["group1", "group2"] || ["reqGroup1", "reqGroup1and2"]
+    ["group3"]           || []
+    ["group2", "group3"] || ["reqGroup1and2"]
   }
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -42,13 +42,13 @@ class DefaultServiceAccountProviderSpec extends Specification {
 
   def "should return all accounts the specified groups has access to"() {
     when:
-    def result = provider.getAll(input)
+    def result = provider.getAllRestricted(input)
 
     then:
     result.containsAll(values)
 
     when:
-    provider.getAll(null)
+    provider.getAllRestricted(null)
 
     then:
     thrown IllegalArgumentException

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
@@ -18,20 +18,18 @@ package com.netflix.spinnaker.fiat.config;
 
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty("auth.anonymous.enabled")
-public class AnonymousUserConfig {
+public class UnrestrictedResourceConfig {
 
-  public static String ANONYMOUS_USERNAME = "anonymous";
+  public static String UNRESTRICTED_USERNAME = "__unrestricted_user__";
 
   @Bean
-  String addAnonymousUser(PermissionsRepository permissionsRepository,
-                          PermissionsResolver permissionsResolver) {
-    permissionsResolver.resolveAnonymous().ifPresent(permissionsRepository::put);
-    return ANONYMOUS_USERNAME;
+  String addUnrestrictedUser(PermissionsRepository permissionsRepository,
+                             PermissionsResolver permissionsResolver) {
+    permissionsResolver.resolveUnrestrictedUser().ifPresent(permissionsRepository::put);
+    return UNRESTRICTED_USERNAME;
   }
 }

--- a/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.fiat.roles;
 
-import com.netflix.spinnaker.fiat.config.AnonymousUserConfig;
+import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
 import com.netflix.spinnaker.fiat.providers.ProviderException;
@@ -103,8 +103,8 @@ public class UserRolesSyncer {
   private long updateUserPermissions() {
     val permissionMap = permissionsRepository.getAllById();
 
-    if (permissionMap.remove(AnonymousUserConfig.ANONYMOUS_USERNAME) != null) {
-      permissionsResolver.resolveAnonymous().ifPresent(permission -> {
+    if (permissionMap.remove(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME) != null) {
+      permissionsResolver.resolveUnrestrictedUser().ifPresent(permission -> {
         permissionsRepository.put(permission);
         log.info("Synced anonymous user role.");
       });

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.fiat.roles
 
-import com.netflix.spinnaker.fiat.config.AnonymousUserConfig
+import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig
 import com.netflix.spinnaker.fiat.model.ServiceAccount
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
@@ -38,13 +38,13 @@ class UserRolesSyncerSpec extends Specification {
     def user2 = new UserPermission()
         .setId("user2")
         .setAccounts([new Account().setName("account2")] as Set)
-    def anonUser = new UserPermission()
-        .setId(AnonymousUserConfig.ANONYMOUS_USERNAME)
-        .setAccounts([new Account().setName("anonAccount")] as Set)
+    def unrestrictedUser = new UserPermission()
+        .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
+        .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
 
     permissionsRepo.put(user1)
     permissionsRepo.put(user2)
-    permissionsRepo.put(anonUser)
+    permissionsRepo.put(unrestrictedUser)
 
     def newUser2 = new UserPermission()
         .setId("user2")
@@ -59,19 +59,19 @@ class UserRolesSyncerSpec extends Specification {
     expect:
     permissionsRepo.get("user1").get() == user1
     permissionsRepo.get("user2").get() == user2
-    permissionsRepo.get(AnonymousUserConfig.ANONYMOUS_USERNAME).get() == anonUser
+    permissionsRepo.get(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME).get() == unrestrictedUser
 
     when:
     syncer.updateUserPermissions()
 
     then:
     permissionsResolver.resolve(_ as Set) >> ["user1": user1, "user2": newUser2]
-    permissionsResolver.resolveAnonymous() >> Optional.of(anonUser)
+    permissionsResolver.resolveUnrestrictedUser() >> Optional.of(unrestrictedUser)
 
     expect:
     permissionsRepo.get("user1").get() == user1
     permissionsRepo.get("user2").get() == newUser2
-    permissionsRepo.get(AnonymousUserConfig.ANONYMOUS_USERNAME).get() == anonUser
+    permissionsRepo.get(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME).get() == unrestrictedUser
   }
 
 


### PR DESCRIPTION
…er, which keeps a single list of all unrestricted resources. These are merged at request time with the user's list of restricted access.

This one is kind of a big PR. It primarily removes the inclusion of unrestricted resources (accounts, applications, etc) from each individual user's Redis resource entries.

Secondly, it consolidates some of the annoying Resource switch statements in the RedisPermissionRepo now that the Resources have a common superclass.

Thirdly, it makes some of the test explicitly match known return values, rather than only comparing a handful of properties (such as size of accounts returns, account[0].name == "acct1", etc)

@duftler, @jtk54, @cfieber @ajordens PTAL

Closes https://github.com/spinnaker/fiat/issues/52