### PR TITLE
Adds new Roles resource, to capture the roles a user received as part…

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.resources.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.Collection;
@@ -31,14 +32,11 @@ import java.util.stream.Collectors;
 @Data
 public class UserPermission implements Viewable {
   private String id;
+
   private Set<Account> accounts = new HashSet<>();
   private Set<Application> applications = new HashSet<>();
   private Set<ServiceAccount> serviceAccounts = new HashSet<>();
-
-  @JsonIgnore
-  public boolean isEmpty() {
-    return accounts.isEmpty() && applications.isEmpty();
-  }
+  private Set<Role> roles = new HashSet<>();
 
   public void addResource(Resource resource) {
     addResources(Collections.singleton(resource));
@@ -56,6 +54,8 @@ public class UserPermission implements Viewable {
         applications.add((Application) resource);
       } else if (resource instanceof ServiceAccount) {
         serviceAccounts.add((ServiceAccount) resource);
+      } else if (resource instanceof Role) {
+        roles.add((Role) resource);
       } else {
         throw new IllegalArgumentException("Cannot add unknown resource " + resource);
       }
@@ -68,6 +68,7 @@ public class UserPermission implements Viewable {
     retVal.addAll(accounts);
     retVal.addAll(applications);
     retVal.addAll(serviceAccounts);
+    retVal.addAll(roles);
     return retVal;
   }
 
@@ -86,6 +87,7 @@ public class UserPermission implements Viewable {
   }
 
   @Data
+  @EqualsAndHashCode(callSuper = false)
   @NoArgsConstructor
   @SuppressWarnings("unchecked")
   public static class View extends BaseView {
@@ -93,6 +95,7 @@ public class UserPermission implements Viewable {
     Set<Account.View> accounts;
     Set<Application.View> applications;
     Set<ServiceAccount.View> serviceAccounts;
+    Set<Role.View> roles;
 
     public View(UserPermission permission) {
       this.name = permission.id;
@@ -105,6 +108,7 @@ public class UserPermission implements Viewable {
       this.accounts = (Set<Account.View>) toViews.apply(permission.getAccounts());
       this.applications = (Set<Application.View>) toViews.apply(permission.getApplications());
       this.serviceAccounts = (Set<ServiceAccount.View>) toViews.apply(permission.getServiceAccounts());
+      this.roles = (Set<Role.View>) toViews.apply((permission.getRoles()));
     }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ public class Application implements GroupAccessControlled, Resource, Viewable {
   }
 
   @Data
+  @EqualsAndHashCode(callSuper = false)
   @NoArgsConstructor
   public static class View extends BaseView implements Authorizable {
     String name;

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
@@ -22,7 +22,8 @@ import org.apache.commons.lang3.StringUtils;
 public enum ResourceType {
   ACCOUNT(Account.class),
   APPLICATION(Application.class),
-  SERVICE_ACCOUNT(ServiceAccount.class); // Fiat service account.
+  SERVICE_ACCOUNT(ServiceAccount.class), // Fiat service account.
+  ROLE(Role.class);
 
   public Class<? extends Resource> modelClass;
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -17,23 +17,36 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ImmutableSet;
-import com.netflix.spinnaker.fiat.model.Authorization;
+import com.google.common.collect.ImmutableList;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Data
-public class Account implements GroupAccessControlled, Resource, Viewable {
-  final ResourceType resourceType = ResourceType.ACCOUNT;
+@NoArgsConstructor
+public class Role implements GroupAccessControlled, Resource, Viewable {
 
+  private final ResourceType resourceType = ResourceType.ROLE;
   private String name;
-  private String cloudProvider;
-  private List<String> requiredGroupMembership = new ArrayList<>();
+
+  public enum Source {
+    EXTERNAL,
+    GOOGLE_GROUPS,
+    GITHUB_TEAMS
+  }
+
+  private Source source;
+
+  public Role(String name) {
+    this.name = name;
+  }
+
+  @JsonIgnore
+  public List<String> getRequiredGroupMembership() {
+    return ImmutableList.of(name); // duh.
+  }
 
   @JsonIgnore
   public View getView() {
@@ -43,13 +56,15 @@ public class Account implements GroupAccessControlled, Resource, Viewable {
   @Data
   @EqualsAndHashCode(callSuper = false)
   @NoArgsConstructor
-  public static class View extends BaseView implements Authorizable {
-    String name;
-    Set<Authorization> authorizations = ImmutableSet.of(Authorization.READ,
-                                                        Authorization.WRITE);
+  public static class View extends BaseView {
+    private String name;
+    private Source source;
 
-    public View(Account account) {
-      this.name = account.name;
+    public View(Role role) {
+      this.name = role.name;
+      this.source = role.getSource();
     }
   }
 }
+
+

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
@@ -17,19 +17,26 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableList;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
+
 @Data
-public class ServiceAccount implements Resource, Viewable {
-  final ResourceType resourceType = ResourceType.SERVICE_ACCOUNT;
+public class ServiceAccount implements GroupAccessControlled, Viewable {
+  private final ResourceType resourceType = ResourceType.SERVICE_ACCOUNT;
 
   private String name;
 
   @JsonIgnore
-  public String getNameWithoutDomain() {
-    return StringUtils.substringBefore(name, "@");
+  public List<String> getRequiredGroupMembership() {
+    // There is a potential here for a naming collision where service account
+    // "my-svc-account@abc.com" and "my-svc-account@xyz.com" each allow one another's users to use
+    // their service account. In practice, though, I don't think this will be an issue.
+    return ImmutableList.of(StringUtils.substringBefore(name, "@"));
   }
 
   @JsonIgnore
@@ -38,9 +45,10 @@ public class ServiceAccount implements Resource, Viewable {
   }
 
   @Data
+  @EqualsAndHashCode(callSuper = false)
   @NoArgsConstructor
   public static class View extends BaseView {
-    String name;
+    private String name;
 
     public View(ServiceAccount serviceAccount) {
       this.name = serviceAccount.name;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 
 import java.util.Collection;
 import java.util.Map;
@@ -39,7 +40,7 @@ public interface PermissionsResolver {
    * Resolves a single user's permissions, taking into account externally
    * provided list of roles.
    */
-  Optional<UserPermission> resolveAndMerge(String userId, Collection<String> externalRoles);
+  Optional<UserPermission> resolveAndMerge(String userId, Collection<Role> externalRoles);
 
   /**
    * Resolves multiple user's permissions. Returned map is keyed by userId.

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers;
 
 import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import lombok.NonNull;
 import lombok.Setter;
@@ -50,10 +51,11 @@ public class DefaultAccountProvider extends BaseProvider implements AccountProvi
   }
 
   @Override
-  public Set<Account> getAllRestricted(@NonNull Collection<String> groups) throws ProviderException {
+  public Set<Account> getAllRestricted(@NonNull Collection<Role> roles) throws ProviderException {
+    val groupNames = roles.stream().map(Role::getName).collect(Collectors.toList());
     return getAll()
         .stream()
-        .filter(account -> !Collections.disjoint(account.getRequiredGroupMembership(), groups))
+        .filter(account -> !Collections.disjoint(account.getRequiredGroupMembership(), groupNames))
         .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers;
 
 import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import lombok.NonNull;
 import lombok.val;
@@ -50,10 +51,11 @@ public class DefaultApplicationProvider extends BaseProvider implements Applicat
   }
 
   @Override
-  public Set<Application> getAllRestricted(@NonNull Collection<String> groups) throws ProviderException {
+  public Set<Application> getAllRestricted(@NonNull Collection<Role> roles) throws ProviderException {
+    val groupNames = roles.stream().map(Role::getName).collect(Collectors.toList());
     return getAll()
         .stream()
-        .filter(application -> !Collections.disjoint(application.getRequiredGroupMembership(), groups))
+        .filter(application -> !Collections.disjoint(application.getRequiredGroupMembership(), groupNames))
         .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers;
 
 import com.netflix.spinnaker.fiat.model.resources.Resource;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 
 import java.util.Collection;
 import java.util.Set;
@@ -25,7 +26,7 @@ public interface ResourceProvider<R extends Resource> {
 
   Set<R> getAll() throws ProviderException;
 
-  Set<R> getAllRestricted(Collection<String> groups) throws ProviderException;
+  Set<R> getAllRestricted(Collection<Role> roles) throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesProvider.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.roles;
 
+import com.netflix.spinnaker.fiat.model.resources.Role;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +30,7 @@ public interface UserRolesProvider {
    * @param userId identify a user. Can be email or username.
    * @return Roles assigned to the {@link com.netflix.spinnaker.security.User User} with the given userEmail.
    */
-  List<String> loadRoles(String userId);
+  List<Role> loadRoles(String userId);
 
   /**
    * Load the roles assigned to each {@link com.netflix.spinnaker.security.User User's} email in userEmails.
@@ -37,5 +39,5 @@ public interface UserRolesProvider {
    * @return Map whose keys are the {@link com.netflix.spinnaker.security.User User's} email and values are their
    * assigned roles.
    */
-  Map<String, Collection<String>> multiLoadRoles(Collection<String> userIds);
+  Map<String, Collection<Role>> multiLoadRoles(Collection<String> userIds);
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers
 
 import com.netflix.spinnaker.fiat.model.resources.Account
+import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import spock.lang.Specification
 import spock.lang.Subject
@@ -40,7 +41,7 @@ class DefaultAccountProviderSpec extends Specification {
     )
 
     when:
-    def result = accountProvider.getAllRestricted(input)
+    def result = accountProvider.getAllRestricted(input.collect {new Role(it)})
 
     then:
     result*.name.containsAll(values)

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers
 
 import com.netflix.spinnaker.fiat.model.resources.Application
+import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import spock.lang.Specification
 import spock.lang.Subject
@@ -39,7 +40,7 @@ class DefaultApplicationProviderSpec extends Specification {
     provider = new DefaultApplicationProvider(front50Service: front50Service)
 
     when:
-    def result = provider.getAllRestricted(input)
+    def result = provider.getAllRestricted(input.collect {new Role(it)})
 
     then:
     result*.name.containsAll(values)

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.providers
 
+import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import spock.lang.Shared
@@ -42,7 +43,7 @@ class DefaultServiceAccountProviderSpec extends Specification {
 
   def "should return all accounts the specified groups has access to"() {
     when:
-    def result = provider.getAllRestricted(input)
+    def result = provider.getAllRestricted(input.collect {new Role(it)})
 
     then:
     result.containsAll(values)

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.fiat.config;
 
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.InMemoryPermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
@@ -25,13 +26,13 @@ public class FiatConfig {
   UserRolesProvider defaultUserRolesProvider() {
     return new UserRolesProvider() {
       @Override
-      public Map<String, Collection<String>> multiLoadRoles(Collection<String> userIds) {
-        return new HashMap<>();
+      public Map<String, Collection<Role>> multiLoadRoles(Collection<String> userIds) {
+        return Collections.emptyMap();
       }
 
       @Override
-      public List<String> loadRoles(String userId) {
-        return new ArrayList<>();
+      public List<Role> loadRoles(String userId) {
+        return Collections.emptyList();
       }
     };
   }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.config;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.squareup.okhttp.ConnectionPool;
@@ -75,6 +76,7 @@ public class RetrofitConfig {
   ObjectMapper objectMapper() {
     return new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(SerializationFeature.INDENT_OUTPUT, true)
         .setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -16,17 +16,21 @@
 
 package com.netflix.spinnaker.fiat.controllers;
 
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
 import com.netflix.spinnaker.fiat.roles.UserRolesSyncer;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/roles")
@@ -55,8 +59,12 @@ public class RolesController {
   @RequestMapping(value = "/{userId:.+}", method = RequestMethod.PUT)
   public void putUserPermission(@PathVariable String userId,
                                 @RequestBody @NonNull List<String> externalRoles) {
+    Set<Role> convertedRoles = externalRoles
+        .stream()
+        .map(extRole -> new Role().setSource(Role.Source.EXTERNAL).setName(extRole))
+        .collect(Collectors.toSet());
     permissionsRepository.put(
-        permissionsResolver.resolveAndMerge(ControllerSupport.decode(userId), externalRoles)
+        permissionsResolver.resolveAndMerge(ControllerSupport.decode(userId), convertedRoles)
                            .orElseThrow(UserPermissionModificationException::new)
     );
   }


### PR DESCRIPTION
… of the login process, or through the UserRoleProvider.

This new `Roles` object replaces various `String` types when constructing new `UserPermission` objects. It's primary advantage is specifying where the role came from.

The second big item in this PR is the establishment of a reverse index of roles. So each user has username --> `Map<String /*role name*/, Role>`, so now will there be a role name --> `Set<String /* username*/`. This reverse index is needed when new, restricted applications are created, and each member of a specified set of roles needs to have this new application added to its whitelist.

@duftler @jtk54 @ajordens @cfieber PTAL

tags: https://github.com/spinnaker/fiat/issues/53, https://github.com/spinnaker/fiat/issues/41