### PR TITLE
Updates RolesController to accept a set of roles to update.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.fiat.shared.FiatAuthenticationFilter;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import lombok.Setter;
 import lombok.val;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -46,7 +48,7 @@ public class FiatAuthenticationConfig {
 
   @Autowired(required = false)
   @Setter
-  private RestAdapter.LogLevel retrofitLogLevel = RestAdapter.LogLevel.NONE;
+  private RestAdapter.LogLevel retrofitLogLevel = RestAdapter.LogLevel.BASIC;
 
   @Autowired
   @Setter
@@ -67,6 +69,7 @@ public class FiatAuthenticationConfig {
         .setClient(okClient)
         .setConverter(new JacksonConverter(objectMapper))
         .setLogLevel(retrofitLogLevel)
+        .setLog(new Slf4jRetrofitLogger(FiatService.class))
         .build()
         .create(FiatService.class);
   }
@@ -89,6 +92,23 @@ public class FiatAuthenticationConfig {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
       http.authorizeRequests().anyRequest().permitAll().and().csrf().disable();
+    }
+  }
+
+  private static class Slf4jRetrofitLogger implements RestAdapter.Log {
+    private final Logger logger;
+
+    Slf4jRetrofitLogger(Class type) {
+      this(LoggerFactory.getLogger(type));
+    }
+
+    Slf4jRetrofitLogger(Logger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    public void log(String message) {
+      logger.info(message);
     }
   }
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -18,8 +18,12 @@ package com.netflix.spinnaker.fiat.shared;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.squareup.okhttp.Response;
+import retrofit.http.Body;
 import retrofit.http.GET;
+import retrofit.http.POST;
 import retrofit.http.Path;
+
+import java.util.List;
 
 public interface FiatService {
 
@@ -31,4 +35,12 @@ public interface FiatService {
                             @Path("resourceType") String resourceType,
                             @Path("resourceName") String resourceName,
                             @Path("authorization") String authorization);
+
+  /**
+   * Use to update a subset of users. An empty list will update the anonymous/unrestricted user.
+   *
+   * @return The number of non-anonymous users synced.
+   */
+  @POST("/roles/sync")
+  long sync(@Body List<String> roles);
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
@@ -52,9 +52,10 @@ public interface PermissionsRepository {
 
   /**
    * Gets all UserPermissions in the repository that has at least 1 of the specified roles, keyed
-   * by user ID. If anyRoles is null, returns the same result as getAllById() (which
-   * includes the unrestricted user). If anyRoles is empty, it returns a map with a single entry for
-   * the unrestricted user.
+   * by user ID. The returned map will not contain the unrestricted user. If anyRoles is null,
+   * returns the same result as getAllById() (which includes the unrestricted user). If anyRoles is
+   * empty, this is an indication to sync the anonymous/unrestricted user. When this is the case,
+   * this method returns a map with a single entry for the unrestricted user.
    * @param anyRoles
    * @return
    */

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,6 +49,16 @@ public interface PermissionsRepository {
    * Gets all UserPermissions in the repository keyed by user ID.
    */
   Map<String, UserPermission> getAllById();
+
+  /**
+   * Gets all UserPermissions in the repository that has at least 1 of the specified roles, keyed
+   * by user ID. If anyRoles is null, returns the same result as getAllById() (which
+   * includes the unrestricted user). If anyRoles is empty, it returns a map with a single entry for
+   * the unrestricted user.
+   * @param anyRoles
+   * @return
+   */
+  Map<String, UserPermission> getAllByRoles(List<String> anyRoles);
 
   /**
    * Delete the specified user permission.


### PR DESCRIPTION
This change enables other services (such as Front50) to invoke an update on a subset of users when a new resource is created (such as an application). It uses the reverse index of roles created in https://github.com/spinnaker/fiat/pull/60 to make the operation fast. 

Also creates a Logger to match the output of the rest of the logging output.

@jtk54 @duftler @ajordens @cfieber PTAL

Closes https://github.com/spinnaker/fiat/issues/51 after cutting a release. 