### PR TITLE
Don't delete clouddriver when uninstalling fiat

### DIFF
--- a/fiat-web/pkg_scripts/postUninstall.sh
+++ b/fiat-web/pkg_scripts/postUninstall.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm -rf /var/log/spinnaker/clouddriver
+rm -rf /var/log/spinnaker/fiat


### PR DESCRIPTION
I was looking through the project structure for help starting Halyard, and realized this file here probably doesn't do what it's intended to do.

@ttomsu 