### PR TITLE
Improves startup behavior when dependent services are down.

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.config;
 
+import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +28,8 @@ public class UnrestrictedResourceConfig {
   public static String UNRESTRICTED_USERNAME = "__unrestricted_user__";
 
   @Bean
-  String addUnrestrictedUser(PermissionsRepository permissionsRepository,
-                             PermissionsResolver permissionsResolver) {
-    permissionsResolver.resolveUnrestrictedUser().ifPresent(permissionsRepository::put);
+  String addUnrestrictedUser(PermissionsRepository permissionsRepository) {
+    permissionsRepository.put(new UserPermission().setId(UNRESTRICTED_USERNAME));
     return UNRESTRICTED_USERNAME;
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionResolutionException.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionResolutionException.java
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.fiat.controllers;
+package com.netflix.spinnaker.fiat.permissions;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(HttpStatus.BAD_REQUEST)
-public class UserPermissionModificationException extends RuntimeException {
-  public UserPermissionModificationException() {
+public class PermissionResolutionException extends RuntimeException {
+  public PermissionResolutionException() {
   }
 
-  public UserPermissionModificationException(String message) {
+  public PermissionResolutionException(String message) {
     super(message);
   }
 
-  public UserPermissionModificationException(String message, Throwable cause) {
+  public PermissionResolutionException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public UserPermissionModificationException(Throwable cause) {
+  public PermissionResolutionException(Throwable cause) {
     super(cause);
   }
 
-  public UserPermissionModificationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+  public PermissionResolutionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -26,24 +26,23 @@ import java.util.Optional;
 public interface PermissionsResolver {
 
   /**
-   * @return The UserPermission for an anonymous user. May return empty if anonymous users are
-   * disabled.
+   * @return The UserPermission for an anonymous user.
    */
-  Optional<UserPermission> resolveUnrestrictedUser();
+  UserPermission resolveUnrestrictedUser() throws PermissionResolutionException;
 
   /**
    * Resolves a single user's permissions.
    */
-  Optional<UserPermission> resolve(String userId);
+  UserPermission resolve(String userId) throws PermissionResolutionException;
 
   /**
    * Resolves a single user's permissions, taking into account externally
    * provided list of roles.
    */
-  Optional<UserPermission> resolveAndMerge(String userId, Collection<Role> externalRoles);
+  UserPermission resolveAndMerge(String userId, Collection<Role> externalRoles) throws PermissionResolutionException;
 
   /**
    * Resolves multiple user's permissions. Returned map is keyed by userId.
    */
-  Map<String, UserPermission> resolve(Collection<String> userIds);
+  Map<String, UserPermission> resolve(Collection<String> userIds) throws PermissionResolutionException;
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -81,7 +81,7 @@ class DefaultPermissionsResolverSpec extends Specification {
         .setResourceProviders(resourceProviders)
 
     when:
-    def result = resolver.resolveUnrestrictedUser().get()
+    def result = resolver.resolveUnrestrictedUser()
 
     then:
     result == new UserPermission().setId("__unrestricted_user__")
@@ -106,7 +106,7 @@ class DefaultPermissionsResolverSpec extends Specification {
     thrown IllegalArgumentException
 
     when:
-    def result = resolver.resolve(testUserId).get()
+    def result = resolver.resolve(testUserId)
 
     then:
     1 * userRolesProvider.loadRoles(testUserId) >> []
@@ -114,7 +114,7 @@ class DefaultPermissionsResolverSpec extends Specification {
     result == expected
 
     when:
-    result = resolver.resolve(testUserId).get()
+    result = resolver.resolve(testUserId)
 
     then:
     1 * userRolesProvider.loadRoles(testUserId) >> [role2]
@@ -124,7 +124,7 @@ class DefaultPermissionsResolverSpec extends Specification {
     result == expected
 
     when: "merge externally provided roles"
-    result = resolver.resolveAndMerge(testUserId, [role1]).get()
+    result = resolver.resolveAndMerge(testUserId, [role1])
 
     then:
     1 * userRolesProvider.loadRoles(testUserId) >> [role2]

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.controllers
 
 import com.netflix.spinnaker.fiat.model.UserPermission
+import com.netflix.spinnaker.fiat.permissions.PermissionResolutionException
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import spock.lang.Specification
@@ -29,8 +30,8 @@ class RolesControllerSpec extends Specification {
     def user = new UserPermission().setId("user")
     PermissionsRepository repo = Mock(PermissionsRepository)
     PermissionsResolver resolver = Mock(PermissionsResolver) {
-      resolve("empty") >> Optional.empty()
-      resolve("user") >> Optional.of(user)
+      resolve("empty") >> { throw new PermissionResolutionException()}
+      resolve("user") >> user
     }
     @Subject RolesController controller = new RolesController(permissionsResolver: resolver,
                                                               permissionsRepository: repo)


### PR DESCRIPTION
Fixes https://github.com/spinnaker/fiat/issues/46

Fiat is heavily dependent on Front50 and Clouddriver to get bootstrapped data. Previous efforts ensured Front50 was up in order to resolve service accounts, and included a HealthIndicator to the load balancer to ensure traffic wasn't sent until Fiat was able to connect to all resource providers.

Health checks aren't really helpful enough for single instance and/or load-balancer-less development, especially if Front50 was up, but Clouddriver down, because there was minimal logging indicating a problem.

The solution is to multi-fold:
* Merge and simplify the UserRoleSyncer's `updateServiceAccounts` with its `updateUserPermissions`.
* Changes the `PermissionResolver` interface to throw exceptions instead of returning `Optional`, because it turns out having that exception adds a lot of code flow control benefits.
* Use the `ResourceProviderHealthIndicator` to notify via log statements when the server goes in and out of the `Status.UP` state.


The log output is now much more helpful. For example, at server startup:

```
2016-09-25 13:25:38.473  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : Server is currently UNHEALTHY. User permission role synchronization and resolution may not complete until this server becomes healthy again.
2016-09-25 13:25:38.505  INFO 6479 --- [           main] s.b.c.e.t.TomcatEmbeddedServletContainer : Tomcat started on port(s): 7003 (http)
2016-09-25 13:25:38.507  INFO 6479 --- [           main] com.netflix.spinnaker.fiat.Main          : Started Main in 4.972 seconds (JVM running for 5.508)
2016-09-25 13:25:39.105  INFO 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : Synced anonymous user role.
2016-09-25 13:25:39.876  INFO 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : Synced 1 non-anonymous user roles.
2016-09-25 13:25:39.878  INFO 6479 --- [pool-1-thread-1] n.s.f.c.ResourceProvidersHealthIndicator : Server is now HEALTHY. Hooray!
```

If (and when) a dependent service goes down (in this example, Clouddriver), the following gets logged:
```
2016-09-25 13:35:40.057  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is UP. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:35:45.203  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is UP. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:35:50.359  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is UP. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:35:55.512  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is UP. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:36:00.736  WARN 6479 --- [pool-1-thread-1] n.s.f.c.ResourceProvidersHealthIndicator : Server is now UNHEALTHY
2016-09-25 13:36:00.736  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is DOWN. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:36:05.920  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is DOWN. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
...
```
and will continue every (configurable) 5s until the resource becomes healthy again:
```
...
2016-09-25 13:37:59.505  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is DOWN. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:38:04.740  WARN 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : User permission sync failed. Server status is DOWN. Trying again in 5000 ms. Cause:com.netflix.spinnaker.fiat.providers.ProviderException: retrofit.RetrofitError: Failed to connect to localhost/0:0:0:0:0:0:0:1:7002
2016-09-25 13:38:10.266  INFO 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : Synced anonymous user role.
2016-09-25 13:38:10.721  INFO 6479 --- [pool-1-thread-1] c.n.s.fiat.roles.UserRolesSyncer         : Synced 1 non-anonymous user roles.
2016-09-25 13:38:10.721  INFO 6479 --- [pool-1-thread-1] n.s.f.c.ResourceProvidersHealthIndicator : Server is now HEALTHY. Hooray!
```

@jtk54 @duftler @cfieber @ajordens PTAL

