### PR TITLE
Adds writeMode to restrict the UserRoleSyncer and UserPermission muta…

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
@@ -43,7 +43,7 @@ import retrofit.converter.JacksonConverter;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
-@EnableConfigurationProperties(FiatConfigurationProperties.class)
+@EnableConfigurationProperties(FiatClientConfigurationProperties.class)
 @ComponentScan("com.netflix.spinnaker.fiat.shared")
 public class FiatAuthenticationConfig {
 
@@ -60,7 +60,7 @@ public class FiatAuthenticationConfig {
   private OkClient okClient;
 
   @Bean
-  public FiatService fiatService(FiatConfigurationProperties fiatConfigurationProperties) {
+  public FiatService fiatService(FiatClientConfigurationProperties fiatConfigurationProperties) {
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(fiatConfigurationProperties.getBaseUrl()))
         .setClient(okClient)

--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatClientConfigurationProperties.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("services.fiat")
-public class FiatConfigurationProperties {
+public class FiatClientConfigurationProperties {
 
   private boolean enabled;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProvidersHealthIndicator.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProvidersHealthIndicator.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Component
+@ConditionalOnExpression("${fiat.writeMode.enabled:true}")
 public class ResourceProvidersHealthIndicator extends AbstractHealthIndicator {
 
   @Autowired

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UnrestrictedResourceConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.config;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +29,7 @@ public class UnrestrictedResourceConfig {
   public static String UNRESTRICTED_USERNAME = "__unrestricted_user__";
 
   @Bean
+  @ConditionalOnExpression("${fiat.writeMode.enabled:true}")
   String addUnrestrictedUser(PermissionsRepository permissionsRepository) {
     permissionsRepository.put(new UserPermission().setId(UNRESTRICTED_USERNAME));
     return UNRESTRICTED_USERNAME;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -32,6 +32,7 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.backoff.BackOffExecution;
@@ -47,6 +48,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @Component
+@ConditionalOnExpression("${fiat.writeMode.enabled:true}")
 public class UserRolesSyncer {
 
   @Autowired
@@ -65,12 +67,11 @@ public class UserRolesSyncer {
   @Setter
   private ResourceProvidersHealthIndicator healthIndicator;
 
-  @Value("${auth.userSync.retryIntervalMs:10000}")
+  @Value("${fiat.writeMode.retryIntervalMs:10000}")
   @Setter
   private long retryIntervalMs;
 
-  // TODO(ttomsu): Acquire a lock in order to make this scale to multiple instances.
-  @Scheduled(fixedDelayString = "${auth.userSync.intervalMs:600000}")
+  @Scheduled(fixedDelayString = "${fiat.writeMode.syncDelayMs:600000}")
   public void sync() {
     syncAndReturn();
   }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.fiat.config;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 @Configuration
 @Import(RetrofitConfig.class)
+@EnableConfigurationProperties(FiatServerConfigurationProperties.class)
 public class FiatConfig {
 
   @Bean

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("fiat")
+public class FiatServerConfigurationProperties {
+
+  /**
+   * True if the /authorize endpoint should be available to dump all users in the repo.
+   */
+  private boolean getAllEnabled = false;
+
+  private WriteMode writeMode = new WriteMode();
+
+  @Data
+  static class WriteMode {
+    /**
+     * True if the /roles endpoint should be enabled. Also turns on the UserRoleSyncer.
+     */
+    private boolean enabled = true;
+
+    /**
+     * How much of a delay between the end of one sync and the beginning of the next.
+     */
+    private int syncDelayMs = 60000;
+
+    /**
+     * How much time to between retries of dependent resource providers if they are down.
+     */
+    private int retryIntervalMs = 10000;
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.controllers;
 
+import com.netflix.spinnaker.fiat.config.FiatServerConfigurationProperties;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
@@ -26,6 +27,8 @@ import io.swagger.annotations.ApiOperation;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -44,16 +47,16 @@ public class AuthorizeController {
   @Autowired
   private PermissionsRepository permissionsRepository;
 
-  @Value("${auth.getAll.enabled:false}")
-  @Setter
-  private boolean getAllEnabled;
+  @Autowired
+  FiatServerConfigurationProperties configProps;
 
   @ApiOperation(value = "Used mostly for testing. Not really any real value to the rest of " +
       "the system. Disabled by default.")
   @RequestMapping(method = RequestMethod.GET)
-  public Set<UserPermission.View> getAll() {
-    if (!getAllEnabled) {
-      return new HashSet<>(0);
+  public Set<UserPermission.View> getAll(HttpServletResponse response) throws IOException {
+    if (!configProps.isGetAllEnabled()) {
+      response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "/authorize is disabled");
+      return null;
     }
 
     return permissionsRepository

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -26,6 +26,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestController
 @RequestMapping("/roles")
+@ConditionalOnExpression("${fiat.writeMode.enabled:true}")
 public class RolesController {
 
   @Autowired


### PR DESCRIPTION
…ting operations. Renames a few config properties.

The intent is to add the ability to horizontally scale Fiat the same way we do clouddriver - by having a single "master/write" instance, and multiple slave/read instances, all hooked up to the same Redis cluster.

@jtk54 @duftler @lwander @cfieber @ajordens PTAL

Fixes https://github.com/spinnaker/fiat/issues/33