### PR TITLE
Adds Clouddriver as source of applications.

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.providers.internal;
 
 import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
 import retrofit.http.GET;
 
 import java.util.List;
@@ -25,4 +26,7 @@ public interface ClouddriverService {
 
   @GET("/credentials")
   List<Account> getAccounts();
+
+  @GET("/applications?restricted=false&expand=false")
+  List<Application> getApplications();
 }


### PR DESCRIPTION
Depends on https://github.com/spinnaker/clouddriver/pull/1115

Uses unrestricted getAllApplications endpoint from Clouddriver to operate on the _complete_ list of Spinnaker applications.

@jtk54 @duftler @ajordens @cfieber PTAL 
/cc @gbougeard 