### PR TITLE
Makes fiat-api module Gate friendly. Most notably this PR merges in

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -35,4 +35,5 @@ dependencies {
   testCompile spinnaker.dependency("okHttp")
   testCompile spinnaker.dependency("slf4jApi")
   testCompile spinnaker.dependency("frigga")
+  testCompile spinnaker.dependency("korkSecurity")
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +48,7 @@ import retrofit.converter.JacksonConverter;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
 @EnableConfigurationProperties(FiatClientConfigurationProperties.class)
+@ConditionalOnExpression("${services.fiat.autoConfig:true}")
 @ComponentScan("com.netflix.spinnaker.fiat.shared")
 public class FiatAuthenticationConfig {
 
@@ -62,6 +65,7 @@ public class FiatAuthenticationConfig {
   private OkClient okClient;
 
   @Bean
+  @ConditionalOnMissingBean(FiatService.class) // Allows for override
   public FiatService fiatService(FiatClientConfigurationProperties fiatConfigurationProperties) {
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(fiatConfigurationProperties.getBaseUrl()))

--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatClientConfigurationProperties.java
@@ -18,12 +18,16 @@ package com.netflix.spinnaker.config;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 @Data
+@Component
 @ConfigurationProperties("services.fiat")
 public class FiatClientConfigurationProperties {
 
   private boolean enabled;
+
+  private boolean autoConfig;
 
   private String baseUrl;
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
+import com.netflix.spinnaker.security.User;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -91,10 +92,12 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
 
   private String getUsername(Authentication authentication) {
     String username = "anonymous";
-    if (authentication instanceof PreAuthenticatedAuthenticationToken) {
-      PreAuthenticatedAuthenticationToken authToken = (PreAuthenticatedAuthenticationToken) authentication;
-      if (authToken.isAuthenticated() && authToken.getPrincipal() != null) {
-        username = authToken.getPrincipal().toString();
+    if (authentication.isAuthenticated() && authentication.getPrincipal() != null) {
+      Object principal = authentication.getPrincipal();
+      if (principal instanceof User) {
+        username = ((User) principal).getUsername();
+      } else if (StringUtils.isNotEmpty(principal.toString())){
+        username = principal.toString();
       }
     }
     return username;

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -19,17 +19,31 @@ package com.netflix.spinnaker.fiat.shared;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.squareup.okhttp.Response;
 import retrofit.http.Body;
+import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
+import retrofit.http.PUT;
 import retrofit.http.Path;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FiatService {
 
+  /**
+   * @param userId The username of the user
+   * @return The full UserPermission of the user.
+   */
   @GET("/authorize/{userId}")
   UserPermission.View getUserPermission(@Path("userId") String userId);
 
+  /**
+   * @param userId The username of the user
+   * @param resourceType The resource type in question (application, account, etc.)
+   * @param resourceName The name of the resource
+   * @param authorization The authorization in question (read, write, etc)
+   * @return True if the user has access to the specified resource.
+   */
   @GET("/authorize/{userId}/{resourceType}/{resourceName}/{authorization}")
   Response hasAuthorization(@Path("userId") String userId,
                             @Path("resourceType") String resourceType,
@@ -37,10 +51,43 @@ public interface FiatService {
                             @Path("authorization") String authorization);
 
   /**
+   * Use to update all users.
+   * @return The number of non-anonymous users synced.
+   */
+  @POST("/roles/sync")
+  long sync();
+
+  /**
    * Use to update a subset of users. An empty list will update the anonymous/unrestricted user.
    *
+   * @param roles Users with any role listed should be updated.
    * @return The number of non-anonymous users synced.
    */
   @POST("/roles/sync")
   long sync(@Body List<String> roles);
+
+  /**
+   * @param userId The user being logged in
+   * @param ignored ignored.
+   * @return ignored.
+   */
+  @POST("/roles/{userId}")
+  Response loginUser(@Path("userId") String userId, @Body String ignored /* retrofit requires this */);
+
+
+  /**
+   * Used specifically for SAML assertions that contain the users roles/groups.
+   * @param userId The user being logged in
+   * @param roles Optional collection of roles from the SAML provider
+   * @return ignored.
+   */
+  @PUT("/roles/{userId}")
+  Response loginSAMLUser(@Path("userId") String userId, @Body Collection<String> roles);
+
+  /**
+   * @param userId The user being logged out
+   * @return ignored.
+   */
+  @DELETE("/roles/{userId}")
+  Response logoutUser(@Path("userId") String userId);
 }


### PR DESCRIPTION
... Gate's FiatService endpoints into fiat-api's shared version.

This PR also fixes an issue with the FiatService currently in Gate (https://github.com/spinnaker/fiat/issues/102), but I can't mark that bug as closed until this PR is released and Gate is updated to use the newly released `fiat-api` module.

@duftler @jtk54 @ajordens @cfieber PTAL
