### PR TITLE
Make anonymous user principal be 'anonymous'

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
@@ -42,8 +42,8 @@ public class FiatAuthenticationFilter implements Filter {
                                                                                   null,
                                                                                   new ArrayList<>()))
         .orElseGet(() -> new AnonymousAuthenticationToken(
-            "ignored1", // These values are never used. See FiatPermissionEvaluator.
-            "ignored2",
+            "anonymous",
+            "anonymous",
             AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
         ));
 


### PR DESCRIPTION
I see logs where the cache calls of various other components (gate, echo, etc) get rejected for user 'ignored2'. 

@jtk54 @duftler PTAL