### PR TITLE
Adds ability to hardcode group membership to service accounts. This i…

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
@@ -17,19 +17,31 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.fiat.model.UserPermission;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 public class ServiceAccount implements GroupAccessControlled, Viewable {
   private final ResourceType resourceType = ResourceType.SERVICE_ACCOUNT;
 
   private String name;
+  private List<String> memberOf = new ArrayList<>();
+
+  public UserPermission toUserPermission() {
+    val roles = memberOf.stream()
+                        .map(membership -> new Role(membership).setSource(Role.Source.EXTERNAL))
+                        .collect(Collectors.toSet());
+    return new UserPermission().setId(name).setRoles(roles);
+  }
 
   @JsonIgnore
   public List<String> getRequiredGroupMembership() {

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ServiceAccountSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ServiceAccountSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.model.resources
+
+import spock.lang.Specification
+
+class ServiceAccountSpec extends Specification {
+
+  def 'should convert to UserPermission'() {
+    setup:
+    ServiceAccount acct = new ServiceAccount().setName("my-svc-acct")
+                                              .setMemberOf(["foo", "bar"])
+
+    when:
+    def result = acct.toUserPermission()
+
+    then:
+    result.id == "my-svc-acct"
+    result.roles.containsAll([
+        new Role("foo").setSource(Role.Source.EXTERNAL),
+        new Role("bar").setSource(Role.Source.EXTERNAL)
+    ])
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicator;
 import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
 import com.netflix.spinnaker.fiat.permissions.PermissionResolutionException;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
@@ -134,7 +135,7 @@ public class UserRolesSyncer {
     return serviceAccountProvider
         .getAll()
         .stream()
-        .map(serviceAccount -> new UserPermission().setId(serviceAccount.getName()))
+        .map(ServiceAccount::toUserPermission)
         .collect(Collectors.toMap(UserPermission::getId, Functions.identity()));
   }
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -98,7 +98,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.hgetAll("unittests:permissions:testUser:applications") ==
         ['app': '{"name":"app","requiredGroupMembership":[]}']
     jedis.hgetAll("unittests:permissions:testUser:service_accounts") ==
-        ['serviceAccount': '{"name":"serviceAccount"}']
+        ['serviceAccount': '{"name":"serviceAccount","memberOf":[]}']
     jedis.hgetAll("unittests:permissions:testUser:roles") ==
         ['role1': '{"name":"role1"}']
   }


### PR DESCRIPTION
…s especially useful in SAML environments, where neither Fiat nor Gate can reach out to an external service to resolve roles/permissions.

Fixes https://github.com/spinnaker/fiat/issues/126

@duftler @jtk54 @cfieber @ajordens PTAL