### PR TITLE
Adds initial LDAP UserRoleProvider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,16 @@ allprojects {
     dependenciesVersion = spinnakerDependenciesVersion
   }
 
+  configurations.all {
+    resolutionStrategy {
+      eachDependency {
+        if (it.requested.group == 'org.springframework') {
+          it.useVersion '4.1.9.RELEASE'
+        }
+      }
+    }
+  }
+
   test {
     testLogging {
       exceptionFormat = 'full'

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -34,7 +34,8 @@ public class Role implements GroupAccessControlled, Resource, Viewable {
   public enum Source {
     EXTERNAL,
     GOOGLE_GROUPS,
-    GITHUB_TEAMS
+    GITHUB_TEAMS,
+    LDAP
   }
 
   private Source source;

--- a/fiat-ldap/fiat-ldap.gradle
+++ b/fiat-ldap/fiat-ldap.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+  compile project(":fiat-roles")
+
+  compileOnly spinnaker.dependency("retrofit")
+  compileOnly spinnaker.dependency("okHttp")
+  compileOnly spinnaker.dependency("okHttpUrlconnection")
+  compileOnly spinnaker.dependency("okHttpApache")
+  compileOnly spinnaker.dependency("retrofitJackson")
+
+  compileOnly spinnaker.dependency("lombok")
+
+  compile "org.springframework.security:spring-security-ldap:3.2.9.RELEASE"
+}

--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
+
+import java.text.MessageFormat;
+
+@Configuration
+@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "ldap")
+public class LdapConfig {
+
+  @Autowired
+  ConfigProps configProps;
+
+  @Bean
+  SpringSecurityLdapTemplate springSecurityLdapTemplate() throws Exception {
+    DefaultSpringSecurityContextSource contextSource = new DefaultSpringSecurityContextSource(configProps.url);
+    contextSource.setUserDn(configProps.managerDn);
+    contextSource.setPassword(configProps.managerPassword);
+    contextSource.afterPropertiesSet();
+
+    return new SpringSecurityLdapTemplate(contextSource);
+  }
+
+  @Data
+  @Configuration
+  @ConfigurationProperties("auth.groupMembership.ldap")
+  public static class ConfigProps {
+    String url;
+    String managerDn;
+    String managerPassword;
+
+    String groupSearchBase = "";
+    MessageFormat userDnPattern = new MessageFormat("uid={0},ou=users");
+    String groupSearchFilter = "(uniqueMember={0})";
+    String groupRoleAttributes = "cn";
+  }
+}

--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.roles.ldap;
+
+import com.netflix.spinnaker.fiat.config.LdapConfig;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.permissions.ExternalUser;
+import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.ldap.core.DistinguishedName;
+import org.springframework.ldap.core.LdapEncoder;
+import org.springframework.security.ldap.LdapUtils;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.naming.InvalidNameException;
+import javax.naming.Name;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "ldap")
+public class LdapUserRolesProvider implements UserRolesProvider {
+
+  @Autowired
+  @Setter
+  private SpringSecurityLdapTemplate ldapTemplate;
+
+  @Autowired
+  @Setter
+  private LdapConfig.ConfigProps configProps;
+
+  @Override
+  public List<Role> loadRoles(String userId) {
+    log.debug("loadRoles for user " + userId);
+    if (StringUtils.isEmpty(configProps.getGroupSearchBase())) {
+      return new ArrayList<>();
+    }
+
+    String[] params = new String[]{getUserFullDn(userId), userId};
+
+    if (log.isDebugEnabled()) {
+      log.debug(new StringBuilder("Searching for groups using ")
+                    .append("\ngroupSearchBase: ")
+                    .append(configProps.getGroupSearchBase())
+                    .append("\ngroupSearchFilter: ")
+                    .append(configProps.getGroupSearchFilter())
+                    .append("\nparams: ")
+                    .append(StringUtils.join(params, " :: "))
+                    .append("\ngroupRoleAttributes: ")
+                    .append(configProps.getGroupRoleAttributes())
+                    .toString());
+    }
+
+    // Copied from org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator.
+    Set<String> userRoles = ldapTemplate.searchForSingleAttributeValues(
+        configProps.getGroupSearchBase(),
+        configProps.getGroupSearchFilter(),
+        params,
+        configProps.getGroupRoleAttributes());
+
+    log.debug("Got roles for user " + userId + ": " + userRoles);
+    return userRoles.stream()
+                    .map(role -> new Role(role).setSource(Role.Source.LDAP))
+                    .collect(Collectors.toList());
+  }
+
+  @Override
+  public Map<String, Collection<Role>> multiLoadRoles(Collection<String> userIds) {
+    if (StringUtils.isEmpty(configProps.getGroupSearchBase())) {
+      return new HashMap<>();
+    }
+
+    // ExternalUser is used here as a simple data type to hold the username/roles combination.
+    return userIds.stream()
+                  .map(userId -> new ExternalUser().setId(userId).setExternalRoles(loadRoles(userId)))
+                  .collect(Collectors.toMap(ExternalUser::getId, ExternalUser::getExternalRoles));
+  }
+
+  private String getUserFullDn(String userId) {
+    String rootDn = LdapUtils.parseRootDnFromUrl(configProps.getUrl());
+    DistinguishedName root = new DistinguishedName(rootDn);
+    log.debug("Root DN: " + root.toString());
+
+    String[] formatArgs = new String[]{LdapEncoder.nameEncode(userId)};
+    String formattedUser = configProps.getUserDnPattern().format(formatArgs);
+    DistinguishedName user = new DistinguishedName(formattedUser);
+    log.debug("User portion: " + user.toString());
+
+    try {
+      Name fullUser = root.addAll(user);
+      log.debug("Full user DN: " + fullUser.toString());
+      return fullUser.toString();
+    } catch (InvalidNameException ine) {
+      log.error("Could not assemble full userDn", ine);
+    }
+    return null;
+  }
+}

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -31,6 +31,7 @@ dependencies {
 
   compile project(':fiat-github')
   compile project(':fiat-google-groups')
+  compile project(':fiat-ldap')
 
   testCompile spinnaker.dependency('korkJedisTest')
   testCompile "org.skyscreamer:jsonassert:1.3.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name="fiat"
 
-include 'fiat-api', 'fiat-core', 'fiat-github', 'fiat-google-groups', 'fiat-roles', 'fiat-web'
+include 'fiat-api', 'fiat-core', 'fiat-github', 'fiat-google-groups', 'fiat-ldap', 'fiat-roles', 'fiat-web'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
This enables Fiat to connect to an LDAP server to search for groups.

I attempted to write a test with an embedded LDAP server, but aparently ApacheDS uses an older, incompatible version of SLF4J, and I couldn't get it working.

PTAL @duftler @jtk54 

cc @scotmoor @rguthriemsft @ajordens @cfieber 
tag https://github.com/spinnaker/fiat/issues/30