### PR TITLE
Slims container by deleting compile-time requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ COPY . workdir/
 
 WORKDIR workdir
 
-RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test
-
-RUN dpkg -i ./fiat-web/build/distributions/*.deb
+RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test && \
+  dpkg -i ./fiat-web/build/distributions/*.deb && \
+  cd .. && \
+  rm -rf workdir
 
 CMD ["/opt/fiat/bin/fiat"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,12 @@
+FROM openjdk:8u111-jre-alpine
+
+MAINTAINER delivery-engineering@netflix.com
+
+COPY ./fiat-web/build/distributions/fiat.zip /opt/fiat.zip
+
+RUN apk add --update bash && \
+      unzip /opt/fiat.zip -d /opt && \
+      rm /opt/fiat.zip && \
+      rm -rf /var/cache/apk/*
+
+CMD ["/opt/fiat/bin/fiat"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,11 @@
 steps:
 - name: 'gcr.io/cloud-builders/git'
   args: ['fetch', '--unshallow']
+- name: 'java:8'
+  env: ["GRADLE_USER_HOME=cache"]
+  entrypoint: "bash"
+  args: [ "-c", "./gradlew fiat-web:distZip -x test"]
 - name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA", "-f", "Dockerfile", "."]
+  args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA", "-f", "Dockerfile.slim", "."]
 images:
 - 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'


### PR DESCRIPTION
This PR drops the generated docker container from 533MB to **270MB**, and if using Google Cloud Builder (via cloudbuilder.yaml), it shrinks even further to **113.6MB** (which is basically Alpine container + Java 8 JRE + Fiat binary & libs).

I still have to ensure the thing actually _runs_, but at least it's building successfully. Will tackle that piece tomorrow.

@cfieber @duftler @skim1420 @lwander 