### PR TITLE
Add endpoint to fetch user's roles

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +80,16 @@ public class AuthorizeController {
                                 .stream()
                                 .map(Account::getView)
                                 .collect(Collectors.toSet());
+  }
+
+  @RequestMapping(value = "/{userId:.+}/roles", method = RequestMethod.GET)
+  public Set<Role.View> getUserRoles(@PathVariable String userId) {
+    return permissionsRepository.get(ControllerSupport.convert(userId))
+            .orElseThrow(NotFoundException::new)
+            .getRoles()
+            .stream()
+            .map(Role::getView)
+            .collect(Collectors.toSet());
   }
 
   @RequestMapping(value = "/{userId:.+}/accounts/{accountName:.+}", method = RequestMethod.GET)

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -212,4 +212,26 @@ class AuthorizeControllerSpec extends Specification {
            .andExpect(status().isOk())
            .andExpect(content().json(expected))
   }
+
+  def "get list of roles for user"() {
+    setup:
+    permissionsRepository.put(roleAUser)
+    permissionsRepository.put(roleAroleBUser)
+
+    when:
+    def expected = objectMapper.writeValueAsString(roleAUser.getRoles().view)
+
+    then:
+    mockMvc.perform(get("/authorize/roleAUser/roles"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expected))
+
+    when:
+    expected = objectMapper.writeValueAsString(roleAroleBUser.getRoles().view)
+
+    then:
+    mockMvc.perform(get("/authorize/roleAroleBUser/roles"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expected))
+  }
 }


### PR DESCRIPTION
Create an endpoint to only fetch a user's roles - this makes it possible to get only the roles for a user without having to fetch the whole information as in the endpoint `getUserPermission`. Slightly more performant.