### PR TITLE
Fix startup issue with FiatService

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/config/FiatAuthenticationConfig.java
@@ -56,18 +56,12 @@ public class FiatAuthenticationConfig {
   @Setter
   private RestAdapter.LogLevel retrofitLogLevel = RestAdapter.LogLevel.BASIC;
 
-  @Autowired
-  @Setter
-  private ObjectMapper objectMapper;
-
-  @Autowired
-  @Setter
-  private OkClient okClient;
-
   @Bean
   @ConditionalOnMissingBean(FiatService.class) // Allows for override
-  public FiatService fiatService(FiatClientConfigurationProperties fiatConfigurationProperties) {
+  public FiatService fiatService(FiatClientConfigurationProperties fiatConfigurationProperties,
+                                 OkClient okClient) {
     // New role providers break deserialization if this is not enabled.
+    val objectMapper = new ObjectMapper();
     objectMapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(fiatConfigurationProperties.getBaseUrl()))


### PR DESCRIPTION
Because Spring Security autoconfiguration happens early, current way of autoconfiguring FiatService will fail in later versions of Spring Boot. Instead, create a ObjectMapper on the fly to support creation.