### PR TITLE
fix(fiat): Remove services.fiat.autoconfig property in favor of @Enab…

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/EnableFiatAutoConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/EnableFiatAutoConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * For a component that uses this annotation, the Fiat Spring Security configuration will be
+ * applied. This does not mean that Fiat is required to be enabled, just that the whole service has
+ * Spring Security layers and filters for requests/responses.
+ *
+ * With this annotation and Fiat disabled, the biggest difference is the ability to access the
+ * Spring Management Server endpoints (/env, /beans, /autoconfig, etc). Most of these endpoints are
+ * considered "sensitive", and therefore are disabled from an unauthenticated user requesting them
+ * over HTTP. In order to still access them, you must use HTTP Basic authentication. See
+ * http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html
+ * for more details.
+ *
+ * With this annotation and Fiat enabled, @Controller invocations annotated with Fiat authorization
+ * checks will be performed and enforced. The above Management Server endpoint information still
+ * applies.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Import(FiatAuthenticationConfig.class)
+public @interface EnableFiatAutoConfig {
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config;
+package com.netflix.spinnaker.fiat.shared;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.fiat.shared.FiatAuthenticationFilter;
-import com.netflix.spinnaker.fiat.shared.FiatService;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -48,7 +46,6 @@ import retrofit.converter.JacksonConverter;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
 @EnableConfigurationProperties(FiatClientConfigurationProperties.class)
-@ConditionalOnExpression("${services.fiat.autoConfig:true}")
 @ComponentScan("com.netflix.spinnaker.fiat.shared")
 public class FiatAuthenticationConfig {
 
@@ -91,7 +88,7 @@ public class FiatAuthenticationConfig {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
       // TODO(ttomsu): Make management endpoints non-sensitive?
-      log.debug("Fiat service is disabled. Setting Spring Security to allow all traffic.");
+      log.info("Fiat service is disabled. Setting Spring Security to allow all traffic.");
       http.authorizeRequests().anyRequest().permitAll().and().csrf().disable();
     }
   }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config;
+package com.netflix.spinnaker.fiat.shared;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -25,8 +25,6 @@ import org.springframework.stereotype.Component;
 public class FiatClientConfigurationProperties {
 
   private boolean enabled;
-
-  private boolean autoConfig;
 
   private String baseUrl;
 }


### PR DESCRIPTION
…leFiatAutoConfig annotation

This PR does two things:

1. Moves `@Configuration` files in `fiat-api` module outside of `com.netflix.spinnaker.config`, meaning they won't be automatically picked up by a component scan. References to `FiatClientConfigurationProperties` will need to be updated.
1. Each Spinnaker service now must "opt-in" to Fiat auto-config.

The second point is intentional because Fiat auto config should not be controlled by the user at runtime - it's determined by the code of the service, i.e. whether or not it provides it's own Spring Security config. The only service, to date, that does such a thing is Gate, which will not 

@cfieber @jtk54 PTAL

@gbougeard @gardleopard FYI
 