### PR TITLE
feat(api): Adds shared cache of user permissions.

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -27,6 +27,7 @@ dependencies {
   compileOnly spinnaker.dependency("retrofit")
   compileOnly spinnaker.dependency("retrofitJackson")
 
+  compile spinnaker.dependency("guava")
   compile spinnaker.dependency("springSecurityConfig")
   compile spinnaker.dependency("springSecurityCore")
   compile spinnaker.dependency("springSecurityWeb")

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.shared;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.stereotype.Component;
 
 @Data
@@ -27,4 +28,14 @@ public class FiatClientConfigurationProperties {
   private boolean enabled;
 
   private String baseUrl;
+
+  @NestedConfigurationProperty
+  private PermissionsCache cache = new PermissionsCache();
+
+  @Data
+  class PermissionsCache {
+    private Integer maxEntries = 1000;
+
+    private Integer expiresAfterWriteSeconds = 20;
+  }
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -76,13 +76,13 @@ public interface FiatService {
 
 
   /**
-   * Used specifically for SAML assertions that contain the users roles/groups.
+   * Used specifically for logins that contain the users roles/groups.
    * @param userId The user being logged in
-   * @param roles Optional collection of roles from the SAML provider
+   * @param roles Collection of roles from the identity provider
    * @return ignored.
    */
   @PUT("/roles/{userId}")
-  Response loginSAMLUser(@Path("userId") String userId, @Body Collection<String> roles);
+  Response loginWithRoles(@Path("userId") String userId, @Body Collection<String> roles);
 
   /**
    * @param userId The user being logged out


### PR DESCRIPTION
This PR introduces a new cache of UserPermissions for users of the Fiat API module. It stores the whole permission for 20s (by default), even if the request could be serviced by a simple authorize call. This is the first step to scaling Fiat to a NFLX sized deployment.

This also means we no longer store the whole permission in the `Authentication` object.

@cfieber @jtk54 PTAL
