### PR TITLE
fix(service): disable content negotiation via URI path extension

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -11,6 +11,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -37,6 +39,12 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
                                                             pathVarsToTag,
                                                             exclude);
     registry.addInterceptor(interceptor);
+  }
+
+  @Override
+  public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    super.configureContentNegotiation(configurer);
+    configurer.favorPathExtension(false).defaultContentType(MediaType.APPLICATION_JSON);
   }
 
   @Bean


### PR DESCRIPTION
fix a problem treating URIs that end with `.com` as a request for content-type
`application/ms-download`

turns out some people have email addresses that end with `.com` [1]


[1] - @cfieber, just now
