### PR TITLE
feat(authZ/ldap): Adds userSearchBase and userSearchFilter properties for LDAP

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
@@ -55,6 +55,8 @@ public class LdapConfig {
 
     String groupSearchBase = "";
     MessageFormat userDnPattern = new MessageFormat("uid={0},ou=users");
+    String userSearchBase = "";
+    String userSearchFilter;
     String groupSearchFilter = "(uniqueMember={0})";
     String groupRoleAttributes = "cn";
   }


### PR DESCRIPTION
Exposes additional spring-security fields for the LDAP configuration that allow resolving the user via search instead of a user DN template.

In response to #30, with more detailed additional discussion [here](https://github.com/spinnaker/fiat/issues/30#issuecomment-289835132). Also created a PR for gate which adds the same fields for authn (https://github.com/spinnaker/gate/pull/369).