### PR TITLE
refactor(rpc): Introduces a wrapper around Retrofit APIs.

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import lombok.NonNull;
-import lombok.Setter;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -34,9 +33,12 @@ import java.util.stream.Collectors;
 @Component
 public class DefaultAccountProvider extends BaseProvider implements AccountProvider {
 
+  private final ClouddriverService clouddriverService;
+
   @Autowired
-  @Setter
-  private ClouddriverService clouddriverService;
+  public DefaultAccountProvider(ClouddriverService clouddriverService) {
+    this.clouddriverService = clouddriverService;
+  }
 
   @Override
   public Set<Account> getAll() throws ProviderException {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -37,11 +37,15 @@ import java.util.stream.Collectors;
 @Component
 public class DefaultApplicationProvider extends BaseProvider implements ApplicationProvider {
 
-  @Autowired
-  private Front50Service front50Service;
+  private final Front50Service front50Service;
+
+  private final ClouddriverService clouddriverService;
 
   @Autowired
-  private ClouddriverService clouddriverService;
+  public DefaultApplicationProvider(Front50Service front50Service, ClouddriverService clouddriverService) {
+    this.front50Service = front50Service;
+    this.clouddriverService = clouddriverService;
+  }
 
   @Override
   public Set<Application> getAll() throws ProviderException {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApi.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,14 @@ package com.netflix.spinnaker.fiat.providers.internal;
 
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
-import org.springframework.beans.factory.annotation.Autowired;
 import retrofit.http.GET;
 
 import java.util.List;
 
-public class ClouddriverService {
+public interface ClouddriverApi {
+  @GET("/credentials")
+  List<Account> getAccounts();
 
-  private final ClouddriverApi clouddriverApi;
-
-  public ClouddriverService(ClouddriverApi clouddriverApi) {
-    this.clouddriverApi = clouddriverApi;
-  }
-
-  public List<Account> getAccounts() {
-    return clouddriverApi.getAccounts();
-  }
-
-  public List<Application> getApplications() {
-    return clouddriverApi.getApplications();
-  }
+  @GET("/applications?restricted=false&expand=false")
+  List<Application> getApplications();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,16 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
-import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import retrofit.http.GET;
 
 import java.util.List;
 
-public class ClouddriverService {
+public interface Front50Api {
+  @GET("/permissions/applications")
+  List<Application> getAllApplicationPermissions();
 
-  private final ClouddriverApi clouddriverApi;
-
-  public ClouddriverService(ClouddriverApi clouddriverApi) {
-    this.clouddriverApi = clouddriverApi;
-  }
-
-  public List<Account> getAccounts() {
-    return clouddriverApi.getAccounts();
-  }
-
-  public List<Application> getApplications() {
-    return clouddriverApi.getApplications();
-  }
+  @GET("/serviceAccounts")
+  List<ServiceAccount> getAllServiceAccounts();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -18,15 +18,24 @@ package com.netflix.spinnaker.fiat.providers.internal;
 
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import org.springframework.beans.factory.annotation.Autowired;
 import retrofit.http.GET;
 
 import java.util.List;
 
-public interface Front50Service {
+public class Front50Service {
 
-  @GET("/permissions/applications")
-  List<Application> getAllApplicationPermissions();
+  private final Front50Api front50Api;
 
-  @GET("/serviceAccounts")
-  List<ServiceAccount> getAllServiceAccounts();
+  public Front50Service(Front50Api front50Api) {
+    this.front50Api = front50Api;
+  }
+
+  public List<Application> getAllApplicationPermissions() {
+    return front50Api.getAllApplicationPermissions();
+  }
+
+  public List<ServiceAccount> getAllServiceAccounts() {
+    return front50Api.getAllServiceAccounts();
+  }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -48,9 +48,7 @@ class DefaultPermissionsResolverSpec extends Specification {
   }
 
   @Shared
-  DefaultAccountProvider accountProvider = new DefaultAccountProvider(
-      clouddriverService: clouddriverService
-  )
+  DefaultAccountProvider accountProvider = new DefaultAccountProvider(clouddriverService)
 
   @Shared ServiceAccount group1SvcAcct = new ServiceAccount().setName("group1")
   @Shared ServiceAccount group2SvcAcct = new ServiceAccount().setName("group2@domain.com")

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultAccountProviderSpec.groovy
@@ -36,9 +36,7 @@ class DefaultAccountProviderSpec extends Specification {
       ]
     }
     @Subject
-    DefaultAccountProvider accountProvider = new DefaultAccountProvider(
-        clouddriverService: clouddriverService
-    )
+    DefaultAccountProvider accountProvider = new DefaultAccountProvider(clouddriverService)
 
     when:
     def result = accountProvider.getAllRestricted(input.collect {new Role(it)})

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -45,8 +45,7 @@ class DefaultApplicationProviderSpec extends Specification {
       ]
     }
 
-    provider = new DefaultApplicationProvider(front50Service: front50Service,
-                                              clouddriverService: clouddriverService)
+    provider = new DefaultApplicationProvider(front50Service, clouddriverService)
 
     when:
     def result = provider.getAllRestricted(input.collect {new Role(it)})

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.fiat.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.providers.internal.ClouddriverApi;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
+import com.netflix.spinnaker.fiat.providers.internal.Front50Api;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import lombok.Setter;
 import org.slf4j.Logger;
@@ -54,27 +56,37 @@ public class ResourcesConfig {
   private String clouddriverEndpoint;
 
   @Bean
-  Front50Service front50Service() {
+  Front50Api front50Api() {
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(front50Endpoint))
         .setClient(okClient)
         .setConverter(new JacksonConverter(objectMapper))
         .setLogLevel(retrofitLogLevel)
-        .setLog(new Slf4jRetrofitLogger(Front50Service.class))
+        .setLog(new Slf4jRetrofitLogger(Front50Api.class))
         .build()
-        .create(Front50Service.class);
+        .create(Front50Api.class);
   }
 
   @Bean
-  ClouddriverService clouddriverService() {
+  Front50Service front50Service(Front50Api front50Api) {
+    return new Front50Service(front50Api);
+  }
+
+  @Bean
+  ClouddriverApi clouddriverApi() {
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(clouddriverEndpoint))
         .setClient(okClient)
         .setConverter(new JacksonConverter(objectMapper))
         .setLogLevel(retrofitLogLevel)
-        .setLog(new Slf4jRetrofitLogger(ClouddriverService.class))
+        .setLog(new Slf4jRetrofitLogger(ClouddriverApi.class))
         .build()
-        .create(ClouddriverService.class);
+        .create(ClouddriverApi.class);
+  }
+
+  @Bean
+  ClouddriverService clouddriverService(ClouddriverApi clouddriverApi) {
+    return new ClouddriverService(clouddriverApi);
   }
 
   private static class Slf4jRetrofitLogger implements RestAdapter.Log {


### PR DESCRIPTION
A subsequent change will make use of the wrapper classes to provide some temporary caching/
circuit breakers/fallbacks around calls to clouddriver and front50
