### PR TITLE
feat(serviceAccounts): Simplifies service accounts.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -60,6 +60,7 @@ public class FiatAuthenticationConfig {
     // New role providers break deserialization if this is not enabled.
     val objectMapper = new ObjectMapper();
     objectMapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+    objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(fiatConfigurationProperties.getBaseUrl()))
         .setClient(okClient)

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -72,6 +72,21 @@ class PermissionsSpec extends Specification {
     permissionJson ==  mapper.writeValueAsString(b.build())
   }
 
+  def "can deserialize to builder from serialized Permissions"() {
+    setup:
+    Permissions.Builder b1 = new Permissions.Builder().add(W, "batman").add(R, "robin")
+    Permissions p1 = b1.build()
+
+    when:
+    def serialized = mapper.writeValueAsString(p1)
+    Permissions.Builder b2 = mapper.readValue(serialized, Permissions.Builder)
+    Permissions p2 = b2.build()
+
+    then:
+    p1 == p2
+    b1 == b2
+  }
+
   def "should trim and lower"() {
     when:
     Permissions.Builder b = new Permissions.Builder()

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.fiat.providers;
+package com.netflix.spinnaker.fiat.config;
 
-import com.netflix.spinnaker.fiat.model.resources.Resource;
-import com.netflix.spinnaker.fiat.model.resources.Role;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.Collection;
-import java.util.Set;
+@Data
+@ConfigurationProperties("fiat.cache")
+public class ProviderCacheConfig {
 
-public interface ResourceProvider<R extends Resource> {
-
-  Set<R> getAll() throws ProviderException;
-
-  Set<R> getAllRestricted(Set<Role> roles) throws ProviderException;
-
-  Set<R> getAllUnrestricted() throws ProviderException;
+  private int expiresAfterWriteSeconds = 20;
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProvidersHealthIndicator.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProvidersHealthIndicator.java
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.fiat.config;
 
-import com.netflix.spinnaker.fiat.providers.BaseProvider;
-import com.netflix.spinnaker.fiat.providers.ProviderException;
-import com.netflix.spinnaker.fiat.providers.ResourceProvider;
+import com.netflix.spinnaker.fiat.providers.HealthTrackable;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,16 +35,16 @@ public class ResourceProvidersHealthIndicator extends AbstractHealthIndicator {
 
   @Autowired
   @Setter
-  List<BaseProvider> providers;
+  List<HealthTrackable> providers;
 
   private AtomicBoolean previousHealthCheckIsUp = new AtomicBoolean(false);
 
   @Override
   protected void doHealthCheck(Health.Builder builder) throws Exception {
     boolean isDown = false;
-    for (BaseProvider provider : providers) {
-      builder.withDetail(provider.getClass().getSimpleName(), provider.getHealthView());
-      isDown = isDown || !provider.isProviderHealthy();
+    for (HealthTrackable provider : providers) {
+      builder.withDetail(provider.getClass().getSimpleName(), provider.getHealthTracker().getHealthView());
+      isDown = isDown || !provider.getHealthTracker().isProviderHealthy();
     }
 
     if (isDown) {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -36,18 +36,19 @@ public class DefaultAccountProvider extends BaseProvider<Account> implements Res
 
   @Autowired
   public DefaultAccountProvider(ClouddriverService clouddriverService) {
+    super();
     this.clouddriverService = clouddriverService;
   }
 
   @Override
-  public Set<Account> getAll() throws ProviderException {
+  protected Set<Account> loadAll() throws ProviderException {
     try {
       val returnVal = clouddriverService.getAccounts().stream().collect(Collectors.toSet());
       success();
       return returnVal;
-    } catch (RetrofitError re) {
+    } catch (Exception e) {
       failure();
-      throw new ProviderException(re);
+      throw e;
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -38,12 +38,13 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
 
   @Autowired
   public DefaultApplicationProvider(Front50Service front50Service, ClouddriverService clouddriverService) {
+    super();
     this.front50Service = front50Service;
     this.clouddriverService = clouddriverService;
   }
 
   @Override
-  public Set<Application> getAll() throws ProviderException {
+  protected Set<Application> loadAll() throws ProviderException {
     try {
       Map<String, Application> appByName = front50Service
           .getAllApplicationPermissions()
@@ -60,9 +61,9 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
       success();
 
       return new HashSet<>(appByName.values());
-    } catch (RetrofitError re) {
+    } catch (Exception e) {
       failure();
-      throw new ProviderException(re);
+      throw e;
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/HealthTrackable.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/HealthTrackable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,7 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-import com.netflix.spinnaker.fiat.model.resources.Resource;
-import com.netflix.spinnaker.fiat.model.resources.Role;
+public interface HealthTrackable {
 
-import java.util.Collection;
-import java.util.Set;
-
-public interface ResourceProvider<R extends Resource> {
-
-  Set<R> getAll() throws ProviderException;
-
-  Set<R> getAllRestricted(Set<Role> roles) throws ProviderException;
-
-  Set<R> getAllUnrestricted() throws ProviderException;
+  ProviderHealthTracker getHealthTracker();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderHealthTracker.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderHealthTracker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import lombok.Data;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ProviderHealthTracker {
+
+  private static int unhealthyThreshold = 5;
+
+  private AtomicInteger failureCountSinceLastSuccess = new AtomicInteger(-1);
+
+  public void success() {
+    failureCountSinceLastSuccess.set(0);
+  }
+
+  public boolean isProviderHealthy() {
+    int count = failureCountSinceLastSuccess.get();
+    return 0 <= count && count < unhealthyThreshold;
+  }
+
+  public void failure() {
+    // Increment the failure count only if there has been at least 1 success() call. Otherwise,
+    // leave the default, which is considered unhealthy.
+    if (!failureCountSinceLastSuccess.compareAndSet(-1, -1)) {
+      failureCountSinceLastSuccess.incrementAndGet();
+    }
+  }
+
+  public HealthView getHealthView() {
+    return new HealthView();
+  }
+
+  @Data
+  class HealthView {
+    boolean providerHealthy = ProviderHealthTracker.this.isProviderHealthy();
+    int failureCountSinceLastSuccess = ProviderHealthTracker.this.failureCountSinceLastSuccess.get();
+  }
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -79,6 +79,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     Account account1 = new Account().setName("account")
     Application app1 = new Application().setName("app")
     ServiceAccount serviceAccount1 = new ServiceAccount().setName("serviceAccount")
+                                                         .setMemberOf(["role1"])
     Role role1 = new Role("role1")
 
     when:
@@ -98,7 +99,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.hgetAll("unittests:permissions:testUser:applications") ==
         ['app': '{"name":"app","permissions":{}}']
     jedis.hgetAll("unittests:permissions:testUser:service_accounts") ==
-        ['serviceAccount': '{"name":"serviceAccount","memberOf":[],"permissions":{}}']
+        ['serviceAccount': '{"name":"serviceAccount","memberOf":["role1"]}']
     jedis.hgetAll("unittests:permissions:testUser:roles") ==
         ['role1': '{"name":"role1"}']
   }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
@@ -111,29 +111,13 @@ class BaseProviderSpec extends Specification {
     thrown IllegalArgumentException
   }
 
-  def "should start and remain unhealthy until first success"() {
-    setup:
-    @Subject provider = new TestResourceProvider(unhealthyThreshold: 2)
-
-    expect:
-    !provider.isProviderHealthy()
-    provider.failure()
-    !provider.isProviderHealthy()
-
-    provider.success()
-    provider.isProviderHealthy()
-
-    provider.failure()
-    provider.isProviderHealthy()
-    provider.failure()
-    !provider.isProviderHealthy()
-
-    provider.success()
-    provider.isProviderHealthy()
-  }
-
   class TestResourceProvider extends BaseProvider<TestResource> {
     Set<TestResource> all = new HashSet<>()
+
+    @Override
+    protected Set<TestResource> loadAll() throws ProviderException {
+      return all
+    }
   }
 
   @Builder(builderStrategy = SimpleStrategy, prefix = "set")

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ProviderHealthTrackerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ProviderHealthTrackerSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ProviderHealthTrackerSpec extends Specification {
+
+  def "should start and remain unhealthy until first success"() {
+    setup:
+    @Subject provider = new ProviderHealthTracker(unhealthyThreshold: 2)
+
+    expect:
+    !provider.isProviderHealthy()
+    provider.failure()
+    !provider.isProviderHealthy()
+
+    provider.success()
+    provider.isProviderHealthy()
+
+    provider.failure()
+    provider.isProviderHealthy()
+    provider.failure()
+    !provider.isProviderHealthy()
+
+    provider.success()
+    provider.isProviderHealthy()
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit.Endpoints;
@@ -34,6 +35,7 @@ import retrofit.client.OkClient;
 import retrofit.converter.JacksonConverter;
 
 @Configuration
+@EnableConfigurationProperties(ProviderCacheConfig.class)
 public class ResourcesConfig {
   @Autowired
   @Setter

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -208,7 +208,7 @@ class AuthorizeControllerSpec extends Specification {
     expected = objectMapper.writeValueAsString(serviceAccount.getView([] as Set))
 
     then:
-    mockMvc.perform(get("/authorize/roleServiceAccountUser/serviceAccounts/svcAcct%40group.com"))
+    mockMvc.perform(get("/authorize/roleServiceAccountUser/serviceAccounts/svcAcct"))
            .andExpect(status().isOk())
            .andExpect(content().json(expected))
   }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/FiatSystemTestSupport.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/FiatSystemTestSupport.groovy
@@ -44,8 +44,8 @@ class FiatSystemTestSupport {
                                            .setPermissions(new Permissions.Builder().add(R, roleB.name)
                                                                                     .build())
 
-  ServiceAccount serviceAccount = new ServiceAccount().setName("svcAcct@group.com")
-  Role roleServiceAccount = new Role(serviceAccount.requiredGroupMembership.first())
+  ServiceAccount serviceAccount = new ServiceAccount().setName("svcAcct").setMemberOf(["svcAcct"])
+  Role roleServiceAccount = new Role(serviceAccount.memberOf.first())
 
   UserPermission unrestrictedUser = new UserPermission().setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
                                                         .setAccounts([unrestrictedAccount] as Set)

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -18,9 +18,9 @@ package com.netflix.spinnaker.fiat.controllers
 
 import com.netflix.spinnaker.config.FiatSystemTest
 import com.netflix.spinnaker.config.TestUserRoleProviderConfig.TestUserRoleProvider
-import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
+import com.netflix.spinnaker.fiat.providers.ResourceProvider
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
@@ -68,7 +68,7 @@ class RolesControllerSpec extends Specification {
     this.mockMvc = MockMvcBuilders
         .webAppContextSetup(this.wac)
         .defaultRequest(get("/").content().contentType("application/json"))
-        .build();
+        .build()
   }
 
   def "should put user in the repo"() {
@@ -92,20 +92,18 @@ class RolesControllerSpec extends Specification {
 
     when:
     mockMvc.perform(post("/roles/roleAUser@group.com")).andExpect(status().isOk())
-    def restrictedAppWithAuth = restrictedApp
     expected = new UserPermission().setId("roleAUser@group.com")
                                    .setRoles([roleA] as Set)
-                                   .setApplications([restrictedAppWithAuth] as Set)
+                                   .setApplications([restrictedApp] as Set)
 
     then:
     permissionsRepository.get("roleAUser@group.com").get() == expected
 
     when:
     mockMvc.perform(put("/roles/roleBUser@group.com").content('["roleB"]')).andExpect(status().isOk())
-    def restrictedAccountWithAuth = restrictedAccount
     expected = new UserPermission().setId("roleBUser@group.com")
                                    .setRoles([roleB] as Set)
-                                   .setAccounts([restrictedAccountWithAuth] as Set)
+                                   .setAccounts([restrictedAccount] as Set)
 
     then:
     permissionsRepository.get("roleBUser@group.com").get() == expected
@@ -114,8 +112,8 @@ class RolesControllerSpec extends Specification {
     mockMvc.perform(put("/roles/roleAroleBUser@group.com").content('["roleB"]')).andExpect(status().isOk())
     expected = new UserPermission().setId("roleAroleBUser@group.com")
                                    .setRoles([roleA, roleB] as Set)
-                                   .setApplications([restrictedAppWithAuth] as Set)
-                                   .setAccounts([restrictedAccountWithAuth] as Set)
+                                   .setApplications([restrictedApp] as Set)
+                                   .setAccounts([restrictedAccount] as Set)
 
     then:
     permissionsRepository.get("roleAroleBUser@group.com").get() == expected

--- a/fiat-web/src/test/resources/fiat.properties
+++ b/fiat-web/src/test/resources/fiat.properties
@@ -1,2 +1,4 @@
 services.front50.baseUrl=ignored
 services.clouddriver.baseUrl=ignored
+
+fiat.cache.expiresAfterWriteSeconds=0


### PR DESCRIPTION
Also pulls out provider health into it's own class, and caches response from
all resource providers for 20s.

As discussed in https://github.com/spinnaker/fiat/issues/164, this PR simplifies services accounts to just:
```
{
name: foo,
memberOf: [bar, baz]
}
```

additional tags: https://github.com/spinnaker/fiat/issues/163

PTAL @jtk54 @cfieber 
