### PR TITLE
fix(health): Caches downstream dependency calls (to Clouddriver/Front…

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -23,6 +23,7 @@ dependencies {
 
   compile spinnaker.dependency("bootActuator")
   compile spinnaker.dependency("bootWeb")
+  compile spinnaker.dependency("korkHystrix")
 
   compile "redis.clients:jedis:2.6.2"
   compile "com.google.api-client:google-api-client:1.21.0"

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
@@ -24,4 +24,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ProviderCacheConfig {
 
   private int expiresAfterWriteSeconds = 20;
+
+  private long maximumStalenessTimeMs = Long.MAX_VALUE;
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,12 +46,9 @@ public class DefaultAccountProvider extends BaseProvider<Account> implements Res
   @Override
   protected Set<Account> loadAll() throws ProviderException {
     try {
-      val returnVal = clouddriverService.getAccounts().stream().collect(Collectors.toSet());
-      success();
-      return returnVal;
+      return new HashSet<>(clouddriverService.getAccounts());
     } catch (Exception e) {
-      failure();
-      throw e;
+      throw new ProviderException(this.getClass(), e.getCause());
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -51,19 +51,16 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
           .stream()
           .collect(Collectors.toMap(Application::getName,
                                     Function.identity()));
-      success();
 
       clouddriverService
           .getApplications()
           .stream()
           .filter(app -> !appByName.containsKey(app.getName()))
           .forEach(app -> appByName.put(app.getName(), app));
-      success();
 
       return new HashSet<>(appByName.values());
     } catch (Exception e) {
-      failure();
-      throw e;
+      throw new ProviderException(this.getClass(), e.getCause());
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,15 +46,9 @@ public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount> 
   @Override
   protected Set<ServiceAccount> loadAll() throws ProviderException {
     try {
-      val returnVal = front50Service
-          .getAllServiceAccounts()
-          .stream()
-          .collect(Collectors.toSet());
-      success();
-      return returnVal;
+      return new HashSet<>(front50Service.getAllServiceAccounts());
     } catch (Exception e) {
-      failure();
-      throw e;
+      throw new ProviderException(this.getClass(), e.getCause());
     }
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
@@ -20,6 +20,11 @@ public class ProviderException extends RuntimeException {
 
   private Class provider;
 
+  public ProviderException(Class provider, String message) {
+    super(message);
+    this.provider = provider;
+  }
+
   public ProviderException(Class provider, Throwable cause) {
     super(cause);
     this.provider = provider;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
@@ -16,26 +16,77 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.providers.HealthTrackable;
+import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import retrofit.http.GET;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class ClouddriverService {
+/**
+ * This class makes and caches live calls to Clouddriver. In the event that Clouddriver is
+ * unavailable, the cached data is returned in stead. Failed calls are logged with the Clouddriver
+ * health tracker, which will turn unhealthy after X number of failed cache refreshes.
+ */
+@Slf4j
+public class ClouddriverService implements HealthTrackable {
+
+  private static final String GROUP_KEY = "clouddriverService";
 
   private final ClouddriverApi clouddriverApi;
+
+  @Autowired
+  @Getter
+  private ProviderHealthTracker healthTracker;
+
+  private AtomicReference<List<Application>> applicationCache = new AtomicReference<>();
+  private AtomicReference<List<Account>> accountCache = new AtomicReference<>();
 
   public ClouddriverService(ClouddriverApi clouddriverApi) {
     this.clouddriverApi = clouddriverApi;
   }
 
   public List<Account> getAccounts() {
-    return clouddriverApi.getAccounts();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getAccounts",
+        () -> {
+          accountCache.set(clouddriverApi.getAccounts());
+          healthTracker.success();
+          return accountCache.get();
+        },
+        (Throwable cause) -> {
+          log.warn("Falling back to account cache. Cause: " + cause.getMessage());
+          List<Account> accounts = accountCache.get();
+          if (accounts == null) {
+            throw new HystrixBadRequestException("Clouddriver is unavailable", cause);
+          }
+          return accounts;
+        }).execute();
   }
 
   public List<Application> getApplications() {
-    return clouddriverApi.getApplications();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getApplications",
+        () -> {
+          applicationCache.set(clouddriverApi.getApplications());
+          healthTracker.success();
+          return applicationCache.get();
+        },
+        (Throwable cause) -> {
+          log.warn("Falling back to application cache. Cause: " + cause.getMessage());
+          List<Application> applications = applicationCache.get();
+          if (applications == null) {
+            throw new HystrixBadRequestException("Clouddriver is unavailable", cause);
+          }
+          return applications;
+        })
+        .execute();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -16,26 +16,71 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.providers.HealthTrackable;
+import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import retrofit.http.GET;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class Front50Service {
+@Slf4j
+public class Front50Service implements HealthTrackable {
+
+  private static final String GROUP_KEY = "front50Service";
 
   private final Front50Api front50Api;
+
+  @Autowired
+  @Getter
+  private ProviderHealthTracker healthTracker;
+
+  private AtomicReference<List<Application>> applicationCache = new AtomicReference<>();
+  private AtomicReference<List<ServiceAccount>> serviceAccountCache = new AtomicReference<>();
 
   public Front50Service(Front50Api front50Api) {
     this.front50Api = front50Api;
   }
 
   public List<Application> getAllApplicationPermissions() {
-    return front50Api.getAllApplicationPermissions();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getAllApplicationPermissions",
+        () -> {
+          applicationCache.set(front50Api.getAllApplicationPermissions());
+          healthTracker.success();
+          return applicationCache.get();
+        },
+        (Throwable cause) -> {
+          log.warn("Falling back to application cache. Cause: " + cause.getMessage());
+          List<Application> applications = applicationCache.get();
+          if (applications == null) {
+            throw new HystrixBadRequestException("Front50 is unavailable", cause);
+          }
+          return applications;
+        }).execute();
   }
 
   public List<ServiceAccount> getAllServiceAccounts() {
-    return front50Api.getAllServiceAccounts();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getAccounts",
+        () -> {
+          serviceAccountCache.set(front50Api.getAllServiceAccounts());
+          healthTracker.success();
+          return serviceAccountCache.get();
+        },
+        (Throwable cause) -> {
+          log.warn("Falling back to service account cache. Cause: " + cause.getMessage());
+          List<ServiceAccount> serviceAccounts = serviceAccountCache.get();
+          if (serviceAccounts == null) {
+            throw new HystrixBadRequestException("Front50 is unavailable", cause);
+          }
+          return serviceAccounts;
+        }).execute();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/SimpleJava8HystrixCommand.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/SimpleJava8HystrixCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.fiat.providers.internal;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import groovy.util.logging.Slf4j;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Slf4j
+class SimpleJava8HystrixCommand<T> extends HystrixCommand<T> {
+
+  private final String groupKey;
+  private final String commandKey;
+
+  private final Supplier<T> work;
+  private final Function<Throwable, T> fallback;
+
+  public SimpleJava8HystrixCommand(String groupKey,
+                                   String commandKey,
+                                   Supplier<T> work) {
+    this(groupKey, commandKey, work, (ignored) -> null);
+  }
+
+  public SimpleJava8HystrixCommand(String groupKey,
+                                   String commandKey,
+                                   Supplier<T> work,
+                                   Function<Throwable, T> fallback) {
+    super(HystrixCommand.Setter.withGroupKey(toGroupKey(groupKey))
+                               .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey))
+                               .andCommandPropertiesDefaults(createHystrixCommandPropertiesSetter()));
+    this.groupKey = groupKey;
+    this.commandKey = commandKey;
+    this.work = work;
+    this.fallback = fallback;
+  }
+
+  @Override
+  protected T run() throws Exception {
+    return work.get();
+  }
+
+  protected T getFallback() {
+    T fallbackValue = fallback.apply(this.getFailedExecutionException());
+    if (fallbackValue == null) {
+      return super.getFallback();
+    }
+    return fallbackValue;
+  }
+
+  private static HystrixCommandGroupKey toGroupKey(String name) {
+    return HystrixCommandGroupKey.Factory.asKey(name);
+  }
+
+  private static HystrixCommandProperties.Setter createHystrixCommandPropertiesSetter() {
+    return HystrixCommandProperties.Setter();
+  }
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ProviderHealthTrackerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ProviderHealthTrackerSpec.groovy
@@ -23,22 +23,15 @@ class ProviderHealthTrackerSpec extends Specification {
 
   def "should start and remain unhealthy until first success"() {
     setup:
-    @Subject provider = new ProviderHealthTracker(unhealthyThreshold: 2)
+    def staleness = 500 // ms.
+    @Subject provider = new ProviderHealthTracker(staleness)
 
     expect:
     !provider.isProviderHealthy()
-    provider.failure()
-    !provider.isProviderHealthy()
-
     provider.success()
     provider.isProviderHealthy()
 
-    provider.failure()
-    provider.isProviderHealthy()
-    provider.failure()
+    Thread.sleep(2 * staleness)
     !provider.isProviderHealthy()
-
-    provider.success()
-    provider.isProviderHealthy()
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverApi;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Api;
@@ -26,9 +27,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import retrofit.Endpoints;
 import retrofit.RestAdapter;
 import retrofit.client.OkClient;
@@ -89,6 +92,12 @@ public class ResourcesConfig {
   @Bean
   ClouddriverService clouddriverService(ClouddriverApi clouddriverApi) {
     return new ClouddriverService(clouddriverApi);
+  }
+
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  ProviderHealthTracker providerHealthTracker(ProviderCacheConfig config) {
+    return new ProviderHealthTracker(config.getMaximumStalenessTimeMs());
   }
 
   private static class Slf4jRetrofitLogger implements RestAdapter.Log {

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.fiat.Main;
 import com.netflix.spinnaker.fiat.config.RedisConfig;
 import com.netflix.spinnaker.fiat.config.ResourcesConfig;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -18,6 +19,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @WebAppConfiguration()
 @TestPropertySource("/fiat.properties")
+@DirtiesContext
 @ContextConfiguration(classes = {
     RedisConfig.class,
     TestUserRoleProviderConfig.class,

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.hystrix.strategy.HystrixPlugins
 import com.netflix.spinnaker.config.FiatSystemTest
 import com.netflix.spinnaker.config.TestUserRoleProviderConfig
 import com.netflix.spinnaker.fiat.config.FiatServerConfigurationProperties
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
@@ -38,7 +38,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@DirtiesContext
 @FiatSystemTest
 class AuthorizeControllerSpec extends Specification {
 
@@ -73,6 +72,7 @@ class AuthorizeControllerSpec extends Specification {
   MockMvc mockMvc;
 
   def setup() {
+    HystrixPlugins.reset();
     this.mockMvc = MockMvcBuilders
         .webAppContextSetup(this.wac)
         .defaultRequest(get("/").content().contentType("application/json"))
@@ -133,7 +133,7 @@ class AuthorizeControllerSpec extends Specification {
                                                 roleAUser.view,
                                                 roleBUser.view,
                                                 roleAroleBUser.view])
-    
+
     then:
     mockMvc.perform(get("/authorize/"))
            .andExpect(status().isOk())
@@ -223,15 +223,15 @@ class AuthorizeControllerSpec extends Specification {
 
     then:
     mockMvc.perform(get("/authorize/roleAUser/roles"))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expected))
+           .andExpect(status().isOk())
+           .andExpect(content().json(expected))
 
     when:
     expected = objectMapper.writeValueAsString(roleAroleBUser.getRoles()*.getView([] as Set))
 
     then:
     mockMvc.perform(get("/authorize/roleAroleBUser/roles"))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expected))
+           .andExpect(status().isOk())
+           .andExpect(content().json(expected))
   }
 }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -16,16 +16,15 @@
 
 package com.netflix.spinnaker.fiat.controllers
 
+import com.netflix.hystrix.strategy.HystrixPlugins
 import com.netflix.spinnaker.config.FiatSystemTest
 import com.netflix.spinnaker.config.TestUserRoleProviderConfig.TestUserRoleProvider
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
-import com.netflix.spinnaker.fiat.providers.ResourceProvider
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
@@ -36,7 +35,6 @@ import spock.lang.Specification
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@DirtiesContext
 @FiatSystemTest
 class RolesControllerSpec extends Specification {
 
@@ -65,6 +63,7 @@ class RolesControllerSpec extends Specification {
   MockMvc mockMvc;
 
   def setup() {
+    HystrixPlugins.reset();
     this.mockMvc = MockMvcBuilders
         .webAppContextSetup(this.wac)
         .defaultRequest(get("/").content().contentType("application/json"))


### PR DESCRIPTION
…50) and removes failure-count-based health indicator. This should prevent cascading failure scenarios where CD/F50 are down, and after some time Fiat would go down, causing the rest of the system to go down too.

`/health` will now return unhealthy until a successful call is returned from CD/F50, which is then cached. The server will remain healthy until the last successful call was `fiat.cache.maximumStalenessTimeMs` ago (default: Long.MAX_VALUE, effectively infinite)

Fixes https://github.com/spinnaker/fiat/issues/163
Fixes https://github.com/spinnaker/fiat/issues/120
