### PR TITLE
feat(logging): Adds user header propagation to Fiat API, which is the…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.87.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.93.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -20,6 +20,7 @@ dependencies {
   compileOnly spinnaker.dependency("bootWeb")
   compileOnly spinnaker.dependency("frigga")
   compileOnly spinnaker.dependency("korkSecurity")
+  compileOnly spinnaker.dependency("korkWeb")
   compileOnly spinnaker.dependency("lombok")
   compileOnly spinnaker.dependency("okHttp")
   compileOnly spinnaker.dependency("okHttpUrlconnection")

--- a/fiat-web/config/fiat.yml
+++ b/fiat-web/config/fiat.yml
@@ -14,9 +14,5 @@ endpoints:
 
 # For options, see com.netflix.spinnaker.fiat.config.FiatServerConfigurationProperties
 
-fiat:
-  permissions:
-    read:
-      - foo
-    write:
-      - bar
+logging:
+  config: classpath:logback-defaults.xml

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -32,7 +32,6 @@ dependencies {
   compile project(':fiat-github')
   compile project(':fiat-google-groups')
   compile project(':fiat-ldap')
-  compile project(':fiat-api')
 
   testCompile spinnaker.dependency('korkJedisTest')
   testCompile "org.skyscreamer:jsonassert:1.3.0"

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -4,13 +4,17 @@ import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
+import com.netflix.spinnaker.filters.AuthenticatedRequestFilter;
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -61,5 +65,16 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
         return new ArrayList<>();
       }
     };
+  }
+
+  /**
+   * This AuthenticatedRequestFilter pulls the email and accounts out of the Spring
+   * security context in order to enabling forwarding them to downstream components.
+   */
+  @Bean
+  FilterRegistrationBean authenticatedRequestFilter() {
+    val frb = new FilterRegistrationBean(new AuthenticatedRequestFilter(true));
+    frb.setOrder(Ordered.LOWEST_PRECEDENCE);
+    return frb;
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +40,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RestController
 @RequestMapping("/authorize")
 public class AuthorizeController {
@@ -57,6 +60,7 @@ public class AuthorizeController {
       return null;
     }
 
+    log.debug("UserPermissions requested for all users");
     return permissionsRepository
         .getAllById()
         .values()
@@ -67,7 +71,9 @@ public class AuthorizeController {
 
   @RequestMapping(value = "/{userId:.+}", method = RequestMethod.GET)
   public UserPermission.View getUserPermission(@PathVariable String userId) {
-    return permissionsRepository.get(ControllerSupport.convert(userId))
+    val user = ControllerSupport.convert(userId);
+    log.debug("UserPermission requested for " + user);
+    return permissionsRepository.get(user)
                                 .orElseThrow(NotFoundException::new)
                                 .getView();
   }

--- a/fiat-web/src/main/resources/logback-defaults.xml
+++ b/fiat-web/src/main/resources/logback-defaults.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} [%X{X-SPINNAKER-USER}] %m%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
…n optionally logged via MDC.

This PR is two sides of the same coin:

1. Adds header propagation in the API module, so that calls from other services will include the `X-SPINNAKER-USER` header.
2. In the Fiat server, extract those headers and stuff them in the Spring security context & MDC. They can be yanked out for logging if needed (which this PR also enables).
