### PR TITLE
fix(cats): default timeout on interval to avoid over polling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.109.2'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.115.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -25,9 +25,9 @@ dependencies {
   compile spinnaker.dependency("bootWeb")
   compile spinnaker.dependency("korkHystrix")
   // TODO(ttomsu): expose this in spinnaker-dependencies
-  compile "com.netflix.spinnaker.clouddriver:cats-redis:1.643.0"
+  compile "com.netflix.spinnaker.clouddriver:cats-redis:1.690.3"
 
-  compile "redis.clients:jedis:2.6.2"
+  compile "redis.clients:jedis:${spinnaker.version('jedis')}"
   compile "com.google.api-client:google-api-client:1.21.0"
   compile "com.google.apis:google-api-services-admin-directory:directory_v1-rev65-1.21.0"
   compile "com.squareup.retrofit:converter-simplexml:1.9.0"

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.fiat.config;
 
-import com.netflix.spinnaker.cats.redis.JedisPoolSource;
-import com.netflix.spinnaker.cats.redis.JedisSource;
+import com.netflix.spinnaker.cats.redis.JedisClientDelegate;
+import com.netflix.spinnaker.cats.redis.RedisClientDelegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -27,8 +27,8 @@ import java.net.URI;
 public class RedisConfig {
 
   @Bean
-  public JedisSource jedisSource(JedisPool jedisPool) {
-    return new JedisPoolSource(jedisPool);
+  RedisClientDelegate redisClientDelegate(JedisPool jedisPool) {
+    return new JedisClientDelegate(jedisPool);
   }
 
   @Bean

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -1,4 +1,8 @@
 apply plugin: 'spring-boot'
+// Applying the spring-boot plugin pulls in a newer version of jedis that we can't use yet. The
+// other ways to override versions (namely the subprojects.configurations.all.resolutionStrategy in
+// build.gradle) didn't work.
+ext['jedis.version'] = spinnaker.version('jedis')
 apply plugin: 'spinnaker.package'
 
 ext {
@@ -40,5 +44,3 @@ dependencies {
 
 applicationName = 'fiat'
 tasks.bootRepackage.enabled = project.repackage
-
-

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/EmbeddedRedisConfig.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/EmbeddedRedisConfig.groovy
@@ -17,14 +17,15 @@
 
 package com.netflix.spinnaker.config
 
-import com.netflix.spinnaker.cats.redis.JedisSource
+import com.netflix.spinnaker.cats.redis.JedisClientDelegate
+import com.netflix.spinnaker.cats.redis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
 import redis.clients.jedis.Jedis
-import redis.clients.util.Pool
+import redis.clients.jedis.JedisPool
 
 @Configuration
 class EmbeddedRedisConfig {
@@ -40,14 +41,13 @@ class EmbeddedRedisConfig {
   }
 
   @Bean
-  Pool<Jedis> jedisPool() {
+  JedisPool jedisPool() {
     redisServer().pool
   }
 
   @Bean
-  JedisSource jedisSource() {
-    return {
-      jedisPool().getResource()
-    }
+  RedisClientDelegate redisClientDelegate(JedisPool jedisPool) {
+    return new JedisClientDelegate(jedisPool);
   }
+
 }


### PR DESCRIPTION
After upgrading to Spinnaker 1.1 we noticed github rate limiting being triggered.   After some investigation it was noted that fiat was attempting to re-sync roles approximately every 10s.

I believe this was introduced from https://github.com/spinnaker/fiat/commit/e775f0d8a26b8df1cc59474180844f6115eb9e48 which introduced the cats feature.

It was not apparent to me when first look but the timeout on the AgentIntervalProvider is used as the ttl for the initial runkey.  If the agent is unable to complete in 10s the key expires and the when attempting to setup the next run (10min by default) the key has expired already.   The ClusteredAgentScheduler then schedules the agent again ~10s later.

This change will set the timeout to the default value of 2x the interval.
