### PR TITLE
fix(build): fix fiat-web to build normal jar

### DIFF
--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -39,6 +39,7 @@ dependencies {
 }
 
 applicationName = 'fiat'
-tasks.bootRepackage.enabled = project.repackage
+tasks.bootRepackage.enabled = Boolean.valueOf(project.repackage)
+
 
 


### PR DESCRIPTION
bootRepackage flag was using string interpretation of groovy truth
