### PR TITLE
feat(admin) Add admin functionality to fiat

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -43,6 +43,7 @@ public class UserPermission {
   private Set<Application> applications = new LinkedHashSet<>();
   private Set<ServiceAccount> serviceAccounts = new LinkedHashSet<>();
   private Set<Role> roles = new LinkedHashSet<>();
+  private boolean admin = false;
 
   public void addResource(Resource resource) {
     addResources(Collections.singleton(resource));
@@ -104,19 +105,21 @@ public class UserPermission {
     Set<Application.View> applications;
     Set<ServiceAccount.View> serviceAccounts;
     Set<Role.View> roles;
+    boolean admin;
 
     public View(UserPermission permission) {
       this.name = permission.id;
 
       Function<Set<? extends Viewable>, Set<? extends Viewable.BaseView>> toViews = sourceSet ->
           sourceSet.stream()
-                   .map(viewable -> viewable.getView(permission.getRoles()))
+                   .map(viewable -> viewable.getView(permission.getRoles(), permission.isAdmin()))
                    .collect(Collectors.toSet());
 
       this.accounts = (Set<Account.View>) toViews.apply(permission.getAccounts());
       this.applications = (Set<Application.View>) toViews.apply(permission.getApplications());
       this.serviceAccounts = (Set<ServiceAccount.View>) toViews.apply(permission.getServiceAccounts());
       this.roles = (Set<Role.View>) toViews.apply((permission.getRoles()));
+      this.admin = permission.isAdmin();
     }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -17,12 +17,14 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.Sets;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashSet;
 import java.util.Set;
 
 @Data
@@ -35,8 +37,8 @@ public class Account extends BaseAccessControlled implements Viewable {
   private Permissions permissions = Permissions.EMPTY;
 
   @JsonIgnore
-  public View getView(Set<Role> userRoles) {
-    return new View(this, userRoles);
+  public View getView(Set<Role> userRoles, boolean isAdmin) {
+    return new View(this, userRoles, false);
   }
 
   @Data
@@ -46,9 +48,13 @@ public class Account extends BaseAccessControlled implements Viewable {
     String name;
     Set<Authorization> authorizations;
 
-    public View(Account account, Set<Role> userRoles) {
+    public View(Account account, Set<Role> userRoles, boolean isAdmin) {
       this.name = account.name;
-      this.authorizations = account.permissions.getAuthorizations(userRoles);
+      if (isAdmin) {
+        this.authorizations = Sets.newHashSet(Authorization.READ, Authorization.WRITE);
+      } else {
+        this.authorizations = account.permissions.getAuthorizations(userRoles);
+      }
     }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.Sets;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -34,8 +35,8 @@ public class Application extends BaseAccessControlled implements Viewable {
   private Permissions permissions = Permissions.EMPTY;
   
   @JsonIgnore
-  public View getView(Set<Role> userRoles) {
-    return new View(this, userRoles);
+  public View getView(Set<Role> userRoles, boolean isAdmin) {
+    return new View(this, userRoles, isAdmin);
   }
 
   @Data
@@ -45,9 +46,13 @@ public class Application extends BaseAccessControlled implements Viewable {
     String name;
     Set<Authorization> authorizations;
 
-    public View(Application application, Set<Role> userRoles) {
+    public View(Application application, Set<Role> userRoles, boolean isAdmin) {
       this.name = application.name;
-      this.authorizations = application.permissions.getAuthorizations(userRoles);
+      if (isAdmin) {
+        this.authorizations = Sets.newHashSet(Authorization.READ, Authorization.WRITE);
+      } else {
+        this.authorizations = application.permissions.getAuthorizations(userRoles);
+      }
     }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -57,7 +57,7 @@ public class Role implements Resource, Viewable {
   }
 
   @JsonIgnore
-  public View getView(Set<Role> ignored) {
+  public View getView(Set<Role> ignored, boolean isAdmin) {
     return new View(this);
   }
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
@@ -55,7 +55,7 @@ public class ServiceAccount implements Resource, Viewable {
   }
 
   @JsonIgnore
-  public View getView(Set<Role> ignored) {
+  public View getView(Set<Role> ignored, boolean isAdmin) {
     return new View(this);
   }
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Viewable.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Viewable.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.fiat.model.resources;
 import java.util.Set;
 
 public interface Viewable {
-  BaseView getView(Set<Role> userRoles);
+  BaseView getView(Set<Role> userRoles, boolean isAdmin);
 
   // Empty class used for referencing Resource-specific View objects.
   class BaseView {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatAdminConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatAdminConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Configuration
+@ConfigurationProperties("fiat")
+public class FiatAdminConfig implements InitializingBean {
+
+    private AdminRoles admin = new AdminRoles();
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        admin.roles = admin.roles.stream()
+            .map(String::toLowerCase)
+            .map(String::trim)
+            .collect(Collectors.toList());
+    }
+
+    @Data
+    public static class AdminRoles {
+        private List<String> roles = new ArrayList<>();
+    }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
@@ -42,14 +42,14 @@ public abstract class BaseProvider<R extends Resource> implements ResourceProvid
 
   @Override
   @SuppressWarnings("unchecked")
-  public Set<R> getAllRestricted(@NonNull Set<Role> roles)
+  public Set<R> getAllRestricted(@NonNull Set<Role> roles, boolean isAdmin)
       throws ProviderException {
     return (Set<R>) getAll()
         .stream()
         .filter(resource -> resource instanceof Resource.AccessControlled)
         .map(resource -> (Resource.AccessControlled) resource)
         .filter(resource -> resource.getPermissions().isRestricted())
-        .filter(resource -> resource.getPermissions().isAuthorized(roles))
+        .filter(resource -> resource.getPermissions().isAuthorized(roles) || isAdmin)
         .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
@@ -53,12 +53,12 @@ public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount> 
   }
 
   @Override
-  public Set<ServiceAccount> getAllRestricted(@NonNull Set<Role> roles) throws ProviderException {
+  public Set<ServiceAccount> getAllRestricted(@NonNull Set<Role> roles, boolean isAdmin) throws ProviderException {
     List<String> roleNames = roles.stream().map(Role::getName).collect(Collectors.toList());
     return getAll()
         .stream()
         .filter(svcAcct -> !svcAcct.getMemberOf().isEmpty())
-        .filter(svcAcct -> roleNames.containsAll(svcAcct.getMemberOf()))
+        .filter(svcAcct -> roleNames.containsAll(svcAcct.getMemberOf()) || isAdmin)
         .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -26,7 +26,7 @@ public interface ResourceProvider<R extends Resource> {
 
   Set<R> getAll() throws ProviderException;
 
-  Set<R> getAllRestricted(Set<Role> roles) throws ProviderException;
+  Set<R> getAllRestricted(Set<Role> roles, boolean isAdmin) throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseProviderSpec.groovy
@@ -76,14 +76,14 @@ class BaseProviderSpec extends Specification {
 
     when:
     provider.all = [noReqGroups]
-    def result = provider.getAllRestricted([new Role("group1")] as Set)
+    def result = provider.getAllRestricted([new Role("group1")] as Set, false)
 
     then:
     result.isEmpty()
 
     when:
     provider.all = [reqGroup1]
-    result = provider.getAllRestricted([new Role("group1")] as Set)
+    result = provider.getAllRestricted([new Role("group1")] as Set, false)
 
     then:
     result.size() == 1
@@ -91,21 +91,21 @@ class BaseProviderSpec extends Specification {
 
     when:
     provider.all = [reqGroup1and2]
-    result = provider.getAllRestricted([new Role("group1")] as Set)
+    result = provider.getAllRestricted([new Role("group1")] as Set, false)
 
     then:
     result.size() == 1
     result.first() == reqGroup1and2
 
     when: "use additional groups that grants additional authorizations."
-    result = provider.getAllRestricted([new Role("group1"), new Role("group2")] as Set)
+    result = provider.getAllRestricted([new Role("group1"), new Role("group2")] as Set, false)
 
     then:
     result.size() == 1
     result.first() == reqGroup1and2
 
     when:
-    provider.getAllRestricted(null)
+    provider.getAllRestricted(null, false)
 
     then:
     thrown IllegalArgumentException

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -34,8 +34,11 @@ class DefaultServiceAccountProviderSpec extends Specification {
   ServiceAccount bAcct = new ServiceAccount(name: "b", memberOf: ["a", "b"])
 
   @Shared
+  ServiceAccount cAcct = new ServiceAccount(name: "c", memberOf: [])
+
+  @Shared
   Front50Service front50Service = Mock(Front50Service) {
-    getAllServiceAccounts() >> [aAcct, bAcct]
+    getAllServiceAccounts() >> [aAcct, bAcct, cAcct]
   }
 
   @Subject
@@ -44,24 +47,26 @@ class DefaultServiceAccountProviderSpec extends Specification {
   @Unroll
   def "should return all accounts the specified groups has access to"() {
     when:
-    def result = provider.getAllRestricted(input.collect { new Role(it) } as Set)
+    def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)
 
     then:
     CollectionUtils.disjunction(result, expected).isEmpty()
 
     when:
-    provider.getAllRestricted(null)
+    provider.getAllRestricted(null, false)
 
     then:
     thrown IllegalArgumentException
 
     where:
-    input           || expected
-    []              || []
-    ["a"]           || [aAcct]
-    ["b"]           || []
-    ["c"]           || []
-    ["a", "b"]      || [aAcct, bAcct]
-    ["a", "b", "c"] || [aAcct, bAcct]
+    input           | isAdmin || expected
+    []              | false   || []
+    ["a"]           | false   || [aAcct]
+    ["b"]           | false   || []
+    ["c"]           | false   || []
+    ["a", "b"]      | false   || [aAcct, bAcct]
+    ["a", "b", "c"] | false   || [aAcct, bAcct]
+    []              | true    || [aAcct, bAcct]
+    []              | true    || [aAcct, bAcct]
   }
 }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -181,14 +181,14 @@ class AuthorizeControllerSpec extends Specification {
 
     then:
     1 * repository.get("foo") >> Optional.of(foo)
-    result == [bar.getView([] as Set)] as Set
+    result == [bar.getView([] as Set, false)] as Set
 
     when:
     result = controller.getUserAccount("foo", "bar")
 
     then:
     1 * repository.get("foo") >> Optional.of(foo)
-    result == bar.getView([] as Set)
+    result == bar.getView([] as Set, false)
   }
 
   def "should get service accounts from repo"() {
@@ -197,7 +197,7 @@ class AuthorizeControllerSpec extends Specification {
     permissionsRepository.put(roleServiceAccountUser)
 
     when:
-    def expected = objectMapper.writeValueAsString([serviceAccount.getView([] as Set)])
+    def expected = objectMapper.writeValueAsString([serviceAccount.getView([] as Set, false)])
 
     then:
     mockMvc.perform(get("/authorize/roleServiceAccountUser/serviceAccounts"))
@@ -205,7 +205,7 @@ class AuthorizeControllerSpec extends Specification {
            .andExpect(content().json(expected))
 
     when:
-    expected = objectMapper.writeValueAsString(serviceAccount.getView([] as Set))
+    expected = objectMapper.writeValueAsString(serviceAccount.getView([] as Set, false))
 
     then:
     mockMvc.perform(get("/authorize/roleServiceAccountUser/serviceAccounts/svcAcct"))
@@ -219,7 +219,7 @@ class AuthorizeControllerSpec extends Specification {
     permissionsRepository.put(roleAroleBUser)
 
     when:
-    def expected = objectMapper.writeValueAsString(roleAUser.getRoles()*.getView([] as Set))
+    def expected = objectMapper.writeValueAsString(roleAUser.getRoles()*.getView([] as Set, false))
 
     then:
     mockMvc.perform(get("/authorize/roleAUser/roles"))
@@ -227,7 +227,7 @@ class AuthorizeControllerSpec extends Specification {
            .andExpect(content().json(expected))
 
     when:
-    expected = objectMapper.writeValueAsString(roleAroleBUser.getRoles()*.getView([] as Set))
+    expected = objectMapper.writeValueAsString(roleAroleBUser.getRoles()*.getView([] as Set, false))
 
     then:
     mockMvc.perform(get("/authorize/roleAroleBUser/roles"))


### PR DESCRIPTION
A quick summary of how it works is:

In the fiat configuration file, it will be possible to set a list of groups that will have admin capabilities.
```
fiat:
  admin:
    roles: 
      - sre_team
      - security_team
```
This will be merged with the permissions in each permissioned object (applications, accounts and service users). Members belonging to a group that is configured as Admin, have no restrictions in Spinnaker - meaning that they can access and change any resources.

The above example will mean that `sre_team` and `security_team` will have access (to view and to modify) to everything in Spinnaker.

Feedback is highly appreciated, thanks!

