### PR TITLE
fix(authz): ensure anonymous role is not cleared

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -96,10 +96,10 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
 
     for (ResourceProvider provider : resourceProviders) {
       try {
-        if (!roles.isEmpty()) {
-          permission.addResources(provider.getAllRestricted(roles));
-        } else if (UnrestrictedResourceConfig.UNRESTRICTED_USERNAME.equalsIgnoreCase(userId)) {
+        if (UnrestrictedResourceConfig.UNRESTRICTED_USERNAME.equalsIgnoreCase(userId)) {
           permission.addResources(provider.getAllUnrestricted());
+        } else if (!roles.isEmpty()) {
+          permission.addResources(provider.getAllRestricted(roles));
         }
       } catch (ProviderException pe) {
         throw new PermissionResolutionException(pe);


### PR DESCRIPTION
regularly seeing a PUT `/roles/anonymous` with payload `["anonymous"]` (I think this is from /health endpoints or something being polled by ELB)

Without this change, that PUT request clears out all the `__unrestricted_user__` authorizations effectively nuking the anonymous permission set.