### PR TITLE
fix(fiat/log): Append to log instead of overwrite

### DIFF
--- a/fiat-web/etc/init/fiat.conf
+++ b/fiat-web/etc/init/fiat.conf
@@ -6,4 +6,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec sudo -u spinnaker -g spinnaker /opt/fiat/bin/fiat 2>&1 > /var/log/spinnaker/fiat/fiat.log &
+exec sudo -u spinnaker -g spinnaker /opt/fiat/bin/fiat 2>&1 >> /var/log/spinnaker/fiat/fiat.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.