### PR TITLE
create fiat log dir on package install instead of clouddriver.

### DIFF
--- a/fiat-web/pkg_scripts/postInstall.sh
+++ b/fiat-web/pkg_scripts/postInstall.sh
@@ -11,4 +11,4 @@ if [ -z `getent passwd spinnaker` ]; then
   useradd --gid spinnaker spinnaker -m --home-dir /home/spinnaker
 fi
 
-install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/clouddriver 
+install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/fiat


### PR DESCRIPTION
fix(install):  fix log dir

deb package created clouddriver dir on install, this makes the fiat log dir instead.