### PR TITLE
fix(api): Stop parsing application names in fiat using frigga.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -103,11 +103,8 @@ public class FiatPermissionEvaluator implements PermissionEvaluator, Initializin
       a = Authorization.valueOf(authorization.toString());
     }
 
-    if (r == ResourceType.APPLICATION) {
-      val parsedName = Names.parseName(resourceName.toString()).getApp();
-      if (StringUtils.isNotEmpty(parsedName)) {
-        resourceName = parsedName;
-      }
+    if (r == ResourceType.APPLICATION && StringUtils.isNotEmpty(resourceName.toString())) {
+        resourceName = resourceName.toString();
     }
 
     UserPermission.View permission = getPermission(getUsername(authentication));

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -73,21 +73,18 @@ class FiatPermissionEvaluatorSpec extends Specification {
     then:
     1 * fiatService.getUserPermission("testUser") >> new UserPermission(
             applications: [
-                new Application(name: "abc",
+                new Application(name: "abc-def",
                                 permissions: Permissions.factory([
                                     (Authorization.READ): ["testRole"]
-                                ]))
+                                ])),
             ],
             roles: [new Role("testRole")]
         ).getView()
     result
 
     where:
-    resource           | resourceName | resourceType
-    "abc"              | "abc"        | ResourceType.APPLICATION
-    "abc-def"          | "abc"        | ResourceType.APPLICATION
-    "abc-def-ghi"      | "abc"        | ResourceType.APPLICATION
-    "abc-def-ghi-1234" | "abc"        | ResourceType.APPLICATION
+    resource           | resourceName         | resourceType
+    "abc-def"          | "abc-def"            | ResourceType.APPLICATION
 
     authorization = 'READ'
   }


### PR DESCRIPTION
I tested this on my local setup. Before this fix, application names with dashes in them would return a 403 from Gate. Post this change, they work fine.

Clouddriver, Orca, Gate, and Front50 all need to be updated to the new version of fiat-api for this fix to work.

spinnaker/spinnaker#2513