### PR TITLE
fix(hystrix): prevent silent NPE after timeout

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
@@ -72,7 +72,7 @@ public class ClouddriverService implements HealthTrackable, InitializingBean {
           return accountCache.get();
         },
         (Throwable cause) -> {
-          log.warn("Falling back to account cache. Cause: " + cause.getMessage());
+          logFallback("account", cause);
           List<Account> accounts = accountCache.get();
           if (accounts == null) {
             throw new HystrixBadRequestException("Clouddriver is unavailable", cause);
@@ -91,7 +91,7 @@ public class ClouddriverService implements HealthTrackable, InitializingBean {
           return applicationCache.get();
         },
         (Throwable cause) -> {
-          log.warn("Falling back to application cache. Cause: " + cause.getMessage());
+          logFallback("application", cause);
           List<Application> applications = applicationCache.get();
           if (applications == null) {
             throw new HystrixBadRequestException("Clouddriver is unavailable", cause);
@@ -99,5 +99,10 @@ public class ClouddriverService implements HealthTrackable, InitializingBean {
           return applications;
         })
         .execute();
+  }
+
+  private static void logFallback(String resource, Throwable cause) {
+    String message = cause != null ? "Cause: " + cause.getMessage() : "";
+    log.info("Falling back to {} cache. {}", resource, message);
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -68,7 +68,7 @@ public class Front50Service implements HealthTrackable, InitializingBean {
           return applicationCache.get();
         },
         (Throwable cause) -> {
-          log.warn("Falling back to application cache. Cause: " + cause.getMessage());
+          logFallback("application", cause);
           List<Application> applications = applicationCache.get();
           if (applications == null) {
             throw new HystrixBadRequestException("Front50 is unavailable", cause);
@@ -87,12 +87,17 @@ public class Front50Service implements HealthTrackable, InitializingBean {
           return serviceAccountCache.get();
         },
         (Throwable cause) -> {
-          log.warn("Falling back to service account cache. Cause: " + cause.getMessage());
+          logFallback("service account", cause);
           List<ServiceAccount> serviceAccounts = serviceAccountCache.get();
           if (serviceAccounts == null) {
             throw new HystrixBadRequestException("Front50 is unavailable", cause);
           }
           return serviceAccounts;
         }).execute();
+  }
+
+  private static void logFallback(String resource, Throwable cause) {
+    String message = cause != null ? "Cause: " + cause.getMessage() : "";
+    log.info("Falling back to {} cache. {}", resource, message);
   }
 }


### PR DESCRIPTION
If Hystrix times out the command, `cause` is `null`. Hystrix gobbles the NPE and just rethrows the timeout, so we lose the fallback behavior.
