### PR TITLE
feat(serviceAccounts): Change group behaviour of service accounts

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProvider.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,7 @@ public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount> 
     return getAll()
         .stream()
         .filter(svcAcct -> !svcAcct.getMemberOf().isEmpty())
-        .filter(svcAcct -> roleNames.containsAll(svcAcct.getMemberOf()) || isAdmin)
+        .filter(svcAcct -> CollectionUtils.intersection(roleNames, svcAcct.getMemberOf()).size() > 0 || isAdmin)
         .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -61,8 +61,8 @@ class DefaultServiceAccountProviderSpec extends Specification {
     where:
     input           | isAdmin || expected
     []              | false   || []
-    ["a"]           | false   || [aAcct]
-    ["b"]           | false   || []
+    ["a"]           | false   || [aAcct, bAcct]
+    ["b"]           | false   || [bAcct]
     ["c"]           | false   || []
     ["a", "b"]      | false   || [aAcct, bAcct]
     ["a", "b", "c"] | false   || [aAcct, bAcct]


### PR DESCRIPTION
The current logic of service accounts is that if the service account is member of group a and b, the user that wants to use the service account needs to be a member of group a AND b. This patch changes this AND to an OR.

The rationale behind this is that when we have applications that are managed by multiple teams, they should be able to use a service account in the trigger and edit the pipelines without requiring the one to edit the pipelines to be a member of all the teams involved.
