### PR TITLE
feat(web): Support defaulting to `__unrestricted_user__` when no permissions found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.154.3'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.155.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -27,6 +27,7 @@ dependencies {
   compileOnly spinnaker.dependency("okHttpApache")
   compileOnly spinnaker.dependency("retrofit")
   compileOnly spinnaker.dependency("retrofitJackson")
+  compileOnly spinnaker.dependency("spectatorApi")
 
   compile spinnaker.dependency("guava")
   compile spinnaker.dependency("springSecurityConfig")
@@ -39,4 +40,5 @@ dependencies {
   testCompile spinnaker.dependency("frigga")
   testCompile spinnaker.dependency("korkSecurity")
   testCompile spinnaker.dependency("bootAutoConfigure")
+  testCompile spinnaker.dependency("spectatorApi")
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -28,6 +28,8 @@ public class FiatServerConfigurationProperties {
    */
   private boolean getAllEnabled = false;
 
+  private boolean defaultToUnrestrictedUser = false;
+
   private WriteMode writeMode = new WriteMode();
 
   @Data


### PR DESCRIPTION
This PR handles the case where a user attempts to access a service
directly without going through `gate`.

It is a common operational requirement to be able to access internal
APIs directly.

- bump spinnaker-dependencies to suppress 404 stack traces
- emit a metric from `getPermission` vs a debug log message
