### PR TITLE
fix(authn): invalidatePermission from cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
   ext {
-    springBootVersion = "1.5.7.RELEASE"
+    springBootVersion = "1.5.10.RELEASE"
   }
   repositories {
     jcenter()
@@ -36,7 +36,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.155.1'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.157.3'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -123,6 +123,10 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     return username;
   }
 
+  public void invalidatePermission(String username) {
+    permissionsCache.invalidate(username);
+  }
+
   public UserPermission.View getPermission(String username) {
     UserPermission.View view = null;
     if (StringUtils.isEmpty(username)) {


### PR DESCRIPTION
During login we want to read a fresh view of the permission
from fiat to support populating allowed accounts headers.

Also some cleanup in FiatAuthenticationConfig for easier autoconfigging.
