### PR TITLE
feat(api): Support running with `management.security.enabled: false`

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -21,6 +21,7 @@ dependencies {
   compileOnly spinnaker.dependency("frigga")
   compileOnly spinnaker.dependency("korkSecurity")
   compileOnly spinnaker.dependency("korkWeb")
+  compileOnly spinnaker.dependency("kork")
   compileOnly spinnaker.dependency("lombok")
   compileOnly spinnaker.dependency("okHttp")
   compileOnly spinnaker.dependency("okHttpUrlconnection")
@@ -39,6 +40,7 @@ dependencies {
   testCompile spinnaker.dependency("slf4jApi")
   testCompile spinnaker.dependency("frigga")
   testCompile spinnaker.dependency("korkSecurity")
+  testCompile spinnaker.dependency("kork")
   testCompile spinnaker.dependency("bootAutoConfigure")
   testCompile spinnaker.dependency("spectatorApi")
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
@@ -24,14 +24,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
-import org.springframework.stereotype.Component;
 
 import javax.servlet.*;
 import java.io.IOException;
 import java.util.ArrayList;
 
 @Slf4j
-@Component
 public class FiatAuthenticationFilter implements Filter {
 
   @Override

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.fiat.model.resources.ResourceType
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 import spock.lang.Specification
@@ -32,11 +33,15 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 class FiatPermissionEvaluatorSpec extends Specification {
+  DynamicConfigService dynamicConfigService = Mock(DynamicConfigService) {
+    _ * isEnabled('fiat', true) >> { return true }
+  }
   FiatService fiatService = Mock(FiatService)
   Registry registry = new NoopRegistry();
 
   @Subject
   FiatPermissionEvaluator evaluator = new FiatPermissionEvaluator(
+      dynamicConfigService,
       registry,
       fiatService,
       buildConfigurationProperties()


### PR DESCRIPTION
This PR re-orders how the `FiatAuthenticationFilter` is inserted into
the http chain.

Previously when management security was disabled, the caller was
redirected to `/login`.

- introduce a metric to track how often the unregistered user fallback is hit
- support dynamically disabling the permission evaluator
