### PR TITLE
fix(authz/api): Perform a full sync on empty specificRoles input

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -97,7 +97,7 @@ public class RolesController {
   @RequestMapping(value = "/sync", method = RequestMethod.POST)
   public long sync(HttpServletResponse response,
                    @RequestBody(required = false) List<String> specificRoles) throws IOException {
-    if (specificRoles == null) {
+    if (specificRoles == null || specificRoles.isEmpty()) {
       log.info("Full role sync invoked by web request.");
       long count = syncer.syncAndReturn();
       if (count == 0) {


### PR DESCRIPTION
Needed for spinnaker/front50#329 and spinnaker/spinnaker#2948
