### PR TITLE
feat(core): Support a fallback to legacy account permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.157.9'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.fiat.shared;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.stereotype.Component;
 
 @Data
 @ConfigurationProperties("services.fiat")
@@ -28,6 +27,8 @@ public class FiatClientConfigurationProperties {
   private boolean enabled;
 
   private String baseUrl;
+
+  private boolean legacyFallback = false;
 
   @NestedConfigurationProperty
   private PermissionsCache cache = new PermissionsCache();

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
@@ -32,6 +32,7 @@ public class FiatStatus {
 
   private final DynamicConfigService dynamicConfigService;
   private final AtomicBoolean enabled;
+  private final AtomicBoolean legacyFallbackEnabled;
 
   @Autowired
   public FiatStatus(Registry registry,
@@ -41,18 +42,27 @@ public class FiatStatus {
     this.enabled = new AtomicBoolean(
         dynamicConfigService.isEnabled("fiat", fiatClientConfigurationProperties.isEnabled())
     );
+    this.legacyFallbackEnabled = new AtomicBoolean(
+        dynamicConfigService.isEnabled("fiat.legacyFallback", fiatClientConfigurationProperties.isLegacyFallback())
+    );
 
     registry.gauge("fiat.enabled", enabled, value -> enabled.get() ? 1 : 0);
+    registry.gauge("fiat.legacyFallback.enabled", legacyFallbackEnabled, value -> legacyFallbackEnabled.get() ? 1 : 0);
   }
 
   public boolean isEnabled() {
     return enabled.get();
   }
 
+  public boolean isLegacyFallbackEnabled() {
+    return legacyFallbackEnabled.get();
+  }
+
   @Scheduled(fixedDelay = 30000L)
   void refreshStatus() {
     try {
       enabled.set(dynamicConfigService.isEnabled("fiat", enabled.get()));
+      legacyFallbackEnabled.set(dynamicConfigService.isEnabled("legacyFallback", legacyFallbackEnabled.get()));
     } catch (Exception e) {
       log.warn("Unable to refresh fiat status, reason: {}", e.getMessage());
     }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -106,6 +106,7 @@ public class UserPermission {
     Set<ServiceAccount.View> serviceAccounts;
     Set<Role.View> roles;
     boolean admin;
+    boolean legacyFallback = false;
 
     public View(UserPermission permission) {
       this.name = permission.id;

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
+import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Request;
@@ -87,11 +89,13 @@ public class RetrofitConfig {
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  OkClient okClient() {
+  OkClient okClient(Registry registry) {
     val client = okHttpClientConfig.create();
     client.setConnectionPool(new ConnectionPool(maxIdleConnections, keepAliveDurationMs));
     client.setRetryOnConnectionFailure(retryOnConnectionFailure);
     client.interceptors().add(new RetryingInterceptor(maxElapsedBackoffMs));
+    client.interceptors().add(new OkHttpMetricsInterceptor(registry));
+
     return new OkClient(client);
   }
 


### PR DESCRIPTION
Should `fiat` ever be unavailable, this supports a fallback to a
`UserPermission` that is constructed based on the contents of
the `AuthenticatedRequest`.

In the event of a legacy fallback, access to _all_ applications will be
explicitly granted.

It is not on by default and must be explicited opt'd enabled via:

```
fiat:
  services:
    legacyFallback: true
```

or by setting the `fiat.legacyFallback.enabled` dynamic property.
