### PR TITLE
fix(roles): Introduce cache / short refresh around clouddriver calls

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderHealthTracker.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderHealthTracker.java
@@ -29,7 +29,6 @@ public class ProviderHealthTracker {
   private final long maximumStalenessTimeMs;
   private AtomicLong lastSuccessfulUpdateTimeMs = new AtomicLong(-1);
 
-  @Autowired
   public ProviderHealthTracker(long maximumStalenessTimeMs) {
     this.maximumStalenessTimeMs = maximumStalenessTimeMs;
   }


### PR DESCRIPTION
Cuts down on the number of calls to clouddriver for metadata that does
not change all that frequently.

Noticed a fairly high volume of calls falling through from x509
authentication attempts, more than seemed reasonable.
