### PR TITLE
feat(core): Support allowing default access to all unknown applications

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -227,6 +227,15 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
       case ACCOUNT:
         return containsAuth.apply(permission.getAccounts());
       case APPLICATION:
+        boolean applicationHasPermissions = permission
+            .getApplications()
+            .stream().anyMatch(a -> a.getName().equalsIgnoreCase(resourceName));
+
+        if (!applicationHasPermissions && permission.isAllowAccessToUnknownApplications()) {
+          // allow access to any applications w/o explicit permissions
+          return true;
+        }
+
         return permission.isLegacyFallback() || containsAuth.apply(permission.getApplications());
       case SERVICE_ACCOUNT:
         return permission.getServiceAccounts()

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -107,6 +107,7 @@ public class UserPermission {
     Set<Role.View> roles;
     boolean admin;
     boolean legacyFallback = false;
+    boolean allowAccessToUnknownApplications = false;
 
     public View(UserPermission permission) {
       this.name = permission.id;

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -84,6 +84,10 @@ public class Permissions {
     return !getAuthorizations(userRoles).isEmpty();
   }
 
+  public boolean isEmpty() {
+    return permissions.isEmpty();
+  }
+
   public Set<Authorization> getAuthorizations(Set<Role> userRoles) {
     val r = userRoles.stream().map(Role::getName).collect(Collectors.toList());
     return getAuthorizations(r);

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -4,6 +4,9 @@ import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
+import com.netflix.spinnaker.fiat.providers.DefaultApplicationProvider;
+import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
+import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter;
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor;
@@ -66,6 +69,17 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
         return new ArrayList<>();
       }
     };
+  }
+
+  @Bean
+  DefaultApplicationProvider applicationProvider(Front50Service front50Service,
+                                                 ClouddriverService clouddriverService,
+                                                 FiatServerConfigurationProperties properties) {
+    return new DefaultApplicationProvider(
+        front50Service,
+        clouddriverService,
+        properties.isAllowAccessToUnknownApplications()
+    );
   }
 
   /**

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -30,6 +30,8 @@ public class FiatServerConfigurationProperties {
 
   private boolean defaultToUnrestrictedUser = false;
 
+  private boolean allowAccessToUnknownApplications = false;
+
   private WriteMode writeMode = new WriteMode();
 
   @Data


### PR DESCRIPTION
An unknown application is one that does not have explicitly specified
permissions. It may exist in `front50` or it may not.

Can be enabled by `fiat.allowAccessToUnknownApplications: true`.
