### PR TITLE
feat(api): FiatPermissionEvaluator reliablity

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -33,10 +33,20 @@ public class FiatClientConfigurationProperties {
   @NestedConfigurationProperty
   private PermissionsCache cache = new PermissionsCache();
 
+  @NestedConfigurationProperty
+  private RetryConfiguration retry = new RetryConfiguration();
+
   @Data
   class PermissionsCache {
     private Integer maxEntries = 1000;
 
     private Integer expiresAfterWriteSeconds = 20;
+  }
+
+  @Data
+  class RetryConfiguration {
+    private long maxBackoffMillis = 10000;
+    private long initialBackoffMillis = 500;
+    private double retryMultiplier = 1.5;
   }
 }


### PR DESCRIPTION
Adds retry support for calls to fiat in FiatPermissionEvaluator
Invalidates cached users if they contain legacyFallback permissions
