### PR TITLE
fix(roles): Avoid filtering when `allowAccessToUnknownApplications` is enabled

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -42,6 +42,8 @@ import org.springframework.util.backoff.ExponentialBackOff;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -289,8 +291,13 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     Function<Set<? extends Authorizable>, Boolean> containsAuth = resources ->
         resources
             .stream()
-            .anyMatch(view -> view.getName().equalsIgnoreCase(resourceName) &&
-                view.getAuthorizations().contains(authorization));
+            .anyMatch(view -> {
+              Set<Authorization> authorizations = Optional.ofNullable(
+                  view.getAuthorizations()
+              ).orElse(Collections.emptySet());
+
+              return view.getName().equalsIgnoreCase(resourceName) && authorizations.contains(authorization);
+            });
 
     switch (resourceType) {
       case ACCOUNT:


### PR DESCRIPTION
This flag was originally added to allow sites with large numbers of
applications to avoid needlessly serializing the same set of applications
for each user.

Unfortunately it doesn't play nice when an application was explicitly
filtered out because a user was not granted access to it!

This PR will no longer filter applications but rather include them in
the permission with _no_ authorizations.

It only applies when `allowAccessToUnknownApplications` is enabled.

```
[
  {
    "name": "clouddriver",
    "authorizations": [
      "READ",
      "WRITE"
    ]
  },
  {
    "name": "orca",
    "authorizations": [

    ]
  }
]
```

vs

```
[
  {
    "name": "clouddriver",
    "authorizations": [
      "READ",
      "WRITE"
    ]
  }
]
```

