### PR TITLE
fix(ldap): Return a new ExternalUser from multiLoadRoles in LDAP

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -101,7 +101,7 @@ public class LdapUserRolesProvider implements UserRolesProvider {
 
     // ExternalUser is used here as a simple data type to hold the username/roles combination.
     return users.stream()
-        .map(u -> u.setExternalRoles(loadRoles(u)))
+        .map(u -> new ExternalUser().setId(u.getId()).setExternalRoles(loadRoles(u)))
         .collect(Collectors.toMap(ExternalUser::getId, ExternalUser::getExternalRoles));
   }
 


### PR DESCRIPTION
For the LDAP provider, we were overwriting external roles if they were already set. This resulted in fiat service accounts getting synced with no roles at all.

Huge thanks to @emptywee for helping debug this!

@lwander we should cherry pick this into 1.9

Fixes https://github.com/spinnaker/spinnaker/issues/3214