### PR TITLE
feat(roles): Configurable `__unrestricted_user__` roles

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -70,8 +70,10 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
 
   @Override
   public UserPermission resolveUnrestrictedUser() {
-    return getUserPermission(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME,
-                             new HashSet<>() /* groups */);
+    return getUserPermission(
+        UnrestrictedResourceConfig.UNRESTRICTED_USERNAME,
+        new HashSet<>(userRolesProvider.loadUnrestrictedRoles())
+    );
   }
 
   @Override

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesProvider.java
@@ -19,11 +19,16 @@ package com.netflix.spinnaker.fiat.roles;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public interface UserRolesProvider {
+
+  default List<Role> loadUnrestrictedRoles() {
+    return new ArrayList<>();
+  }
 
   /**
    * Load the roles assigned to the {@link com.netflix.spinnaker.security.User User}.

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -34,6 +34,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class DefaultPermissionsResolverSpec extends Specification {
+  UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
 
   @Shared
   Account noReqGroupsAcct = new Account().setName("noReqGroups")
@@ -82,13 +83,17 @@ class DefaultPermissionsResolverSpec extends Specification {
         .setResourceProviders(resourceProviders)
         .setMapper(new ObjectMapper())
         .setFiatAdminConfig(new FiatAdminConfig())
+        .setUserRolesProvider(userRolesProvider)
 
     when:
     def result = resolver.resolveUnrestrictedUser()
 
     then:
+    1 * userRolesProvider.loadUnrestrictedRoles() >> { return [new Role("anonymous")] }
+
     def expected = new UserPermission().setId("__unrestricted_user__")
                                        .setAccounts([noReqGroupsAcct] as Set)
+                                       .setRoles([new Role("anonymous")] as Set)
     result == expected
   }
 


### PR DESCRIPTION
Delegates loading to the `UserRolesProvider` with the default remaining
an empty set.

We have a custom `UserRolesProvider` at Netflix and would like the
ability to specify one or more additional roles for the anonymous user.
