### PR TITLE
chore(build): add debug flag to fiat build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ There are currently two user role providers: Google Groups (through a Google App
 ---
 
 Roadmap/Implementation Punch list has been moved to [Milestone 1 Issues](https://github.com/spinnaker/fiat/milestone/1)
+
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 7103.  The JVM will _not_ wait for the debugger
+to be attached before starting Fiat; the relevant JVM arguments can be seen and modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ allprojects {
   tasks.withType(Javadoc) {
     failOnError = false
   }
+
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7103'
+    }
+  }
 }
 
 subprojects { project ->


### PR DESCRIPTION
Starting fiat with ./gradlew -DDEBUG=true now causes the JVM to listen for a remote debugger on port 7103.