### PR TITLE
fix(ldap): Return mutable list to support "addAll" operation (#269)

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -71,7 +71,7 @@ public class LdapUserRolesProvider implements UserRolesProvider {
     if (fullUserDn == null) {
       // Likely a service account
       log.debug("fullUserDn is null for {}", userId);
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
 
     String[] params = new String[]{fullUserDn, userId};


### PR DESCRIPTION
Cherry-pick of https://github.com/spinnaker/fiat/pull/269 into Spinnaker 1.10

Fixed UnsupportedOperationException for service accounts which DO NOT exist in User Role Provider Service (e.g: LDAP)

