### PR TITLE
Modular builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,21 @@ Fiat Service Accounts are groups that act as a user during automated triggers (s
 ---
 
 ### User Role/Authorization Providers
-There are currently two user role providers: Google Groups (through a Google Apps for Work organization) and GitHub Teams. If you would like to see additional providers, see [this issue](https://github.com/spinnaker/spinnaker/issues/2437).
+Currently supported user role providers are: 
+* Google Groups (through a Google Apps for Work organization) 
+* GitHub Teams
+* LDAP
+* File based role provider
 
 ---
 
-Roadmap/Implementation Punch list has been moved to [Milestone 1 Issues](https://github.com/spinnaker/fiat/milestone/1)
+### Modular builds
+ By default, Fiat is built with authorization included. To build only a subset of 
+providers, use the `includeProviders` flag:
+ ```
+./gradlew -PincludeProviders=google-groups,ldap clean build
+```
+ You can view the list of all providers in `gradle.properties`.
 
 ### Debugging
 

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -28,10 +28,14 @@ dependencies {
   compile spinnaker.dependency("korkStackdriver")
   compile spinnaker.dependency("korkSwagger")
 
-  compile project(':fiat-file')
-  compile project(':fiat-github')
-  compile project(':fiat-google-groups')
-  compile project(':fiat-ldap')
+  compile project(':fiat-core')
+  compile project(':fiat-api')
+  compile project(':fiat-roles')
+
+  // Add each included authz provider as a runtime dependency
+  gradle.includedProviderProjects.each {
+    runtime project(it)
+  }
 
   testCompile spinnaker.dependency('korkJedisTest')
   testCompile "org.skyscreamer:jsonassert:1.3.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.parallel=true
+includeProviders=file,github,google-groups,ldap

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,3 +36,6 @@ rootProject.children.each {
   setBuildFile(it)
 }
 
+
+// Set as an ext variable so that build scripts can access it
+gradle.ext.includedProviderProjects = includeProviders.split(',').collect{ ':fiat-' + it.toLowerCase() }


### PR DESCRIPTION
Allows building Fiat with only a subset of role providers. Defaults to all providers