### PR TITLE
feat(serviceAccounts/orMode): Change group behaviour of service accounts

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatRoleConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatRoleConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties("fiat.role")
+public class FiatRoleConfig {
+
+  private boolean orMode = false;
+
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.permissions
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.fiat.config.FiatAdminConfig
+import com.netflix.spinnaker.fiat.config.FiatRoleConfig
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.model.resources.Application
@@ -65,7 +66,12 @@ class DefaultPermissionsResolverSpec extends Specification {
   }
 
   @Shared
-  DefaultServiceAccountProvider serviceAccountProvider = new DefaultServiceAccountProvider(front50Service)
+  FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
+    isOrMode() >> false
+  }
+
+  @Shared
+  DefaultServiceAccountProvider serviceAccountProvider = new DefaultServiceAccountProvider(front50Service, fiatRoleConfig)
 
   @Shared
   ResourceProvider<Application> applicationProvider = Mock(ResourceProvider) {


### PR DESCRIPTION
The current logic of service accounts is that if the service account is member of group a and b, the user that wants to use the service account needs to be a member of group a AND b. This patch changes this AND to an OR.

The rationale behind this is that when we have applications that are managed by multiple teams, they should be able to use a service account in the trigger and edit the pipelines without requiring the one to edit the pipelines to be a member of all the teams involved.

To enable this behaviour one sets `fiat.role.orMode=true` in the fiat
configuration

This is an opt in version of https://github.com/spinnaker/fiat/pull/229