### PR TITLE
feat(application/add): add endpoint for updating applications

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.shared;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.squareup.okhttp.Response;
+import org.springframework.http.ResponseEntity;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
@@ -27,8 +28,16 @@ import retrofit.http.Path;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public interface FiatService {
+
+  /**
+   * @param applicationName The name of the application
+   * @return The full UserPermission of the user.
+   */
+  @PUT("/applications/{applicationName}")
+  Map<String, String> createApplication(@Path("applicationName") String applicationName, @Body String ignored /* retrofit requires this */ );
 
   /**
    * @param userId The username of the user

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -34,7 +34,7 @@ public interface FiatService {
 
   /**
    * @param applicationName The name of the application
-   * @return The full UserPermission of the user.
+   * @return A map with "status": "[success/failure]".
    */
   @PUT("/applications/{applicationName}")
   Map<String, String> createApplication(@Path("applicationName") String applicationName, @Body String ignored /* retrofit requires this */ );

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
@@ -36,9 +36,9 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class BaseProvider<R extends Resource> implements ResourceProvider<R> {
 
-  private static final Integer CACHE_KEY = 0;
+  protected static final Integer CACHE_KEY = 0;
 
-  private Cache<Integer, Set<R>> cache = buildCache(20);
+  protected Cache<Integer, Set<R>> cache = buildCache(20);
 
   @Override
   @SuppressWarnings("unchecked")
@@ -74,6 +74,11 @@ public abstract class BaseProvider<R extends Resource> implements ResourceProvid
       }
       throw new ProviderException(this.getClass(), e.getCause());
     }
+  }
+
+  @Override
+  public Set<R> addItem(R item) {
+    return getAll();
   }
 
   @Autowired

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -92,7 +92,7 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
     Set<Application> applicationSet = getAll();
     if (applicationSet == null) {
       log.error("The application cache is empty. (This is ok if you do not have any applications at all.)");
-      applicationSet = new HashSet<>(); // new HashSet if this is the first application that gets added to spinnaker
+      applicationSet = new HashSet<>();
     }
     Set<Application> applicationSetMutable = new HashSet<>(applicationSet);
     if (applicationSetMutable.contains(application)) {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -29,4 +29,6 @@ public interface ResourceProvider<R extends Resource> {
   Set<R> getAllRestricted(Set<Role> roles, boolean isAdmin) throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
+
+  Set<R> addItem(R item);
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
@@ -19,12 +19,16 @@ package com.netflix.spinnaker.fiat.providers.internal;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import retrofit.http.GET;
+import retrofit.http.Path;
 
 import java.util.List;
 
 public interface Front50Api {
   @GET("/permissions/applications")
   List<Application> getAllApplicationPermissions();
+
+  @GET("/permissions/applications/{appName}")
+  Application getApplicationPermissions(@Path("appName") String appName);
 
   @GET("/serviceAccounts")
   List<ServiceAccount> getAllServiceAccounts();

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -82,9 +82,9 @@ public class Front50Service implements HealthTrackable, InitializingBean {
     try {
       return front50Api.getApplicationPermissions(appName);
     } catch (RetrofitError retrofitError) {
-      log.warn("Could not retrieve application {}, status code was {}",
+      log.warn("Could not retrieve application {}, status code: {}, reason: {}",
           appName,
-          retrofitError.getResponse().getStatus());
+          retrofitError.getResponse().getStatus(), retrofitError.getResponse().getReason());
     } catch (Exception e) {
       log.error("Retrieving application {} failed in an unexpected way", e.getCause());
     }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.controllers;
+
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.providers.ResourceProvider;
+import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/applications")
+public class ApplicationsController {
+
+  private final ResourceProvider<Application> applicationProvider;
+
+  private final Front50Service front50Service;
+
+  public ApplicationsController(ResourceProvider<Application> applicationProvider, Front50Service front50Service) {
+    this.applicationProvider = applicationProvider;
+    this.front50Service = front50Service;
+  }
+
+  @RequestMapping(value = "/{applicationName:.+}", method = RequestMethod.PUT)
+  public ResponseEntity<Map<String, String>> updateApplication(@PathVariable String applicationName) {
+    log.info("Updating application {}", applicationName);
+    Application app = front50Service.getApplicationPermissions(applicationName.toLowerCase());
+    if (app == null) {
+      return getResponseEntity("failure", HttpStatus.CONFLICT);
+    }
+    log.info("some info {}", app.getName());
+    applicationProvider.addItem(app);
+    return getResponseEntity("success", HttpStatus.CREATED);
+
+  }
+
+  private ResponseEntity<Map<String,String>> getResponseEntity(String status, HttpStatus httpStatus) {
+    Map<String, String> body = Collections.singletonMap("status", status);
+    return new ResponseEntity(body, httpStatus);
+  }
+
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.Map;
 
@@ -45,21 +46,15 @@ public class ApplicationsController {
   }
 
   @RequestMapping(value = "/{applicationName:.+}", method = RequestMethod.PUT)
-  public ResponseEntity<Map<String, String>> updateApplication(@PathVariable String applicationName) {
+  public Map<String, String> updateApplication(@PathVariable String applicationName, HttpServletResponse response) {
     log.info("Updating application {}", applicationName);
     Application app = front50Service.getApplicationPermissions(applicationName.toLowerCase());
     if (app == null) {
-      return getResponseEntity("failure", HttpStatus.CONFLICT);
+      response.setStatus(HttpServletResponse.SC_CONFLICT);
+      return Collections.singletonMap("status", "failure");
     }
-    log.info("some info {}", app.getName());
     applicationProvider.addItem(app);
-    return getResponseEntity("success", HttpStatus.CREATED);
-
-  }
-
-  private ResponseEntity<Map<String,String>> getResponseEntity(String status, HttpStatus httpStatus) {
-    Map<String, String> body = Collections.singletonMap("status", status);
-    return new ResponseEntity(body, httpStatus);
+    return Collections.singletonMap("status", "success");
   }
 
 }


### PR DESCRIPTION
This endpoint enables front50 to tell fiat about application permission updates.
Without this, new applications might not be available to the user after
creation.

Depends on https://github.com/spinnaker/front50/pull/403