### PR TITLE
feat(application/add): add endpoint for updating applications and service accounts

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.fiat.shared;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import com.squareup.okhttp.Response;
+import org.springframework.http.ResponseEntity;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
@@ -27,8 +29,16 @@ import retrofit.http.Path;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public interface FiatService {
+
+  /**
+   * @param applicationName The name of the application
+   * @return A map with "status": "[success/failure]".
+   */
+  @PUT("/applications/{applicationName}")
+  Map<String, String> createApplication(@Path("applicationName") String applicationName, @Body String ignored /* retrofit requires this */ );
 
   /**
    * @param userId The username of the user
@@ -90,4 +100,13 @@ public interface FiatService {
    */
   @DELETE("/roles/{userId}")
   Response logoutUser(@Path("userId") String userId);
+
+  /**
+   * @param serviceAccountName The name of the service account
+   * @return A map with "status": "[success/failure]".
+   */
+
+  @PUT("/serviceAccounts/{serviceAccountName}")
+  Map<String, String> createServiceAccount(@Path("serviceAccountName") String serviceAccountName, @Body Collection<String> memberOf );
+
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,6 +29,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class DefaultApplicationProvider extends BaseProvider<Application> implements ResourceProvider<Application> {
 
   private final Front50Service front50Service;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -29,4 +29,6 @@ public interface ResourceProvider<R extends Resource> {
   Set<R> getAllRestricted(Set<Role> roles, boolean isAdmin) throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
+
+  Set<R> addItem(R item);
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
@@ -19,12 +19,16 @@ package com.netflix.spinnaker.fiat.providers.internal;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import retrofit.http.GET;
+import retrofit.http.Path;
 
 import java.util.List;
 
 public interface Front50Api {
   @GET("/permissions/applications")
   List<Application> getAllApplicationPermissions();
+
+  @GET("/permissions/applications/{appName}")
+  Application getApplicationPermissions(@Path("appName") String appName);
 
   @GET("/serviceAccounts")
   List<ServiceAccount> getAllServiceAccounts();

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import retrofit.RetrofitError;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,13 +69,26 @@ public class Front50Service implements HealthTrackable, InitializingBean {
           return applicationCache.get();
         },
         (Throwable cause) -> {
-          logFallback("application", cause);
+          logFallback("applications", cause);
           List<Application> applications = applicationCache.get();
           if (applications == null) {
             throw new HystrixBadRequestException("Front50 is unavailable", cause);
           }
           return applications;
         }).execute();
+  }
+
+  public Application getApplicationPermissions(String appName) {
+    try {
+      return front50Api.getApplicationPermissions(appName);
+    } catch (RetrofitError retrofitError) {
+      log.warn("Could not retrieve application {}, status code: {}, reason: {}",
+          appName,
+          retrofitError.getResponse().getStatus(), retrofitError.getResponse().getReason());
+    } catch (Exception e) {
+      log.error("Retrieving application {} failed in an unexpected way", e.getCause());
+    }
+    return null;
   }
 
   public List<ServiceAccount> getAllServiceAccounts() {

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ApplicationsController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.controllers;
+
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.providers.ResourceProvider;
+import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/applications")
+public class ApplicationsController {
+
+  private final ResourceProvider<Application> applicationProvider;
+
+  private final Front50Service front50Service;
+
+  public ApplicationsController(ResourceProvider<Application> applicationProvider, Front50Service front50Service) {
+    this.applicationProvider = applicationProvider;
+    this.front50Service = front50Service;
+  }
+
+  @RequestMapping(value = "/{applicationName:.+}", method = RequestMethod.PUT)
+  public Map<String, String> updateApplication(@PathVariable String applicationName, HttpServletResponse response) {
+    log.info("Updating application {}", applicationName);
+    Application app = front50Service.getApplicationPermissions(applicationName.toLowerCase());
+    if (app == null) {
+      response.setStatus(HttpServletResponse.SC_CONFLICT);
+      return Collections.singletonMap("status", "failure");
+    }
+    applicationProvider.addItem(app);
+    return Collections.singletonMap("status", "success");
+  }
+
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ServiceAccountsController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ServiceAccountsController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.controllers;
+
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.providers.ResourceProvider;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping(path = "/serviceAccounts")
+public class ServiceAccountsController {
+  private final ResourceProvider<ServiceAccount> serviceAccountResourceProvider;
+
+  public ServiceAccountsController(ResourceProvider<ServiceAccount> serviceAccountResourceProvider) {
+    this.serviceAccountResourceProvider = serviceAccountResourceProvider;
+  }
+  @RequestMapping(value = "/{serviceAccountName:.+}", method = RequestMethod.PUT)
+  public Map<String, String> updateApplication(@PathVariable String serviceAccountName, @RequestBody @NonNull List<String> memberOf, HttpServletResponse response) {
+    ServiceAccount serviceAccount = new ServiceAccount();
+    serviceAccount.setName(serviceAccountName);
+    serviceAccount.setMemberOf(memberOf);
+    log.info("Updating serviceAccount {}", serviceAccountName);
+
+    serviceAccountResourceProvider.addItem(serviceAccount);
+    return Collections.singletonMap("status", "success");
+  }
+}


### PR DESCRIPTION
This endpoint enables front50 to tell fiat about permission updates.
Without this, new permissions might not be available to the user after
creation.


This is a more generic way of solving https://github.com/spinnaker/fiat/pull/299 and adds service account management as well