### PR TITLE
fix(redis): New a JedisPoolConfig instead of GenericObjectPoolConfig

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
@@ -26,7 +26,7 @@ public class RedisConfig {
   @Bean
   @ConfigurationProperties("redis")
   public GenericObjectPoolConfig redisPoolConfig() {
-    GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+    GenericObjectPoolConfig config = new JedisPoolConfig();
     config.setMaxTotal(20);
     config.setMaxIdle(20);
     config.setMinIdle(5);


### PR DESCRIPTION
JedisPoolConfig also sets minEvictableIdleTimeMillis for this pool. Leaving it to 0 means infinite, not a good practice.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
