### PR TITLE
fix(redis): New a JedisPoolConfig instead of GenericObjectPoolConfig

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
@@ -26,7 +26,7 @@ public class RedisConfig {
   @Bean
   @ConfigurationProperties("redis")
   public GenericObjectPoolConfig redisPoolConfig() {
-    GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+    GenericObjectPoolConfig config = new JedisPoolConfig();
     config.setMaxTotal(20);
     config.setMaxIdle(20);
     config.setMinIdle(5);


### PR DESCRIPTION
JedisPoolConfig also sets minEvictableIdleTimeMillis to 60 seconds for this pool. Leaving it to `public static final long DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS = 1000L * 60L * 30L` is too long. 

The idle connection will be kept on client side, but may be closed by server timeout configuration. One of our customers just met this issue, raise this pull request for his benefit.

We construct the object of GenericObjectPoolConfig in Jedis-related code on rare occasions.