### PR TITLE
feat(api): Support turning off dynamic refreshing of fiat status

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -30,6 +30,8 @@ public class FiatClientConfigurationProperties {
 
   private boolean legacyFallback = false;
 
+  private boolean refreshable = true;
+
   @NestedConfigurationProperty
   private PermissionsCache cache = new PermissionsCache();
 

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
@@ -43,12 +43,8 @@ public class FiatStatus {
     this.dynamicConfigService = dynamicConfigService;
     this.fiatClientConfigurationProperties = fiatClientConfigurationProperties;
 
-    this.enabled = new AtomicBoolean(
-        dynamicConfigService.isEnabled("fiat", fiatClientConfigurationProperties.isEnabled())
-    );
-    this.legacyFallbackEnabled = new AtomicBoolean(
-        dynamicConfigService.isEnabled("fiat.legacyFallback", fiatClientConfigurationProperties.isLegacyFallback())
-    );
+    this.enabled = new AtomicBoolean(fiatClientConfigurationProperties.isEnabled());
+    this.legacyFallbackEnabled = new AtomicBoolean(fiatClientConfigurationProperties.isLegacyFallback());
 
     registry.gauge("fiat.enabled", enabled, value -> enabled.get() ? 1 : 0);
     registry.gauge("fiat.legacyFallback.enabled", legacyFallbackEnabled, value -> legacyFallbackEnabled.get() ? 1 : 0);
@@ -65,6 +61,10 @@ public class FiatStatus {
   @Scheduled(fixedDelay = 30000L)
   void refreshStatus() {
     try {
+      if (!fiatClientConfigurationProperties.isRefreshable()) {
+        return;
+      }
+
       enabled.set(dynamicConfigService.isEnabled("fiat", fiatClientConfigurationProperties.isEnabled()));
       legacyFallbackEnabled.set(
           dynamicConfigService.isEnabled("fiat.legacyFallback", fiatClientConfigurationProperties.isLegacyFallback())


### PR DESCRIPTION
The ability to dynamically turn fiat off/on was convenient during initial
rollout but can be a security risk in a production environment.

Set `services.fiat.refreshable: false` to disable.
