### PR TITLE
fix(redis): Fix leaked embedded redis from tests

### DIFF
--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/EmbeddedRedisConfig.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/EmbeddedRedisConfig.groovy
@@ -20,18 +20,15 @@ package com.netflix.spinnaker.config
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
-import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Scope
 import redis.clients.jedis.Jedis
 import redis.clients.util.Pool
 
 @Configuration
 class EmbeddedRedisConfig {
 
-  @Bean
-  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean(destroyMethod = "destroy")
   EmbeddedRedis redisServer() {
     def redis = EmbeddedRedis.embed()
     redis.jedis.withCloseable { Jedis jedis ->

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -28,13 +28,11 @@ import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
-import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
-import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -68,10 +66,6 @@ class AuthorizeControllerSpec extends Specification {
 
   @Autowired
   ObjectMapper objectMapper
-
-  @Autowired
-  @AutoCleanup("destroy")
-  EmbeddedRedis embeddedRedis
 
   @Delegate
   FiatSystemTestSupport fiatIntegrationTestSupport = new FiatSystemTestSupport()

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -23,13 +23,11 @@ import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
-import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import retrofit.RetrofitError
-import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
@@ -52,10 +50,6 @@ class RolesControllerSpec extends Specification {
 
   @Autowired
   TestUserRoleProvider userRoleProvider
-
-  @Autowired
-  @AutoCleanup("destroy")
-  EmbeddedRedis embeddedRedis
 
   @Delegate
   FiatSystemTestSupport fiatIntegrationTestSupport = new FiatSystemTestSupport()


### PR DESCRIPTION
Embedded redis is currently defined as a prototype bean in the test config; this means that a new embedded redis will be generated any time a redis is need in the auotwiring config. We're currently only destroying one of them (the one directly asked for in the test class). Instead, make this a singleton bean with a spring-managed destruction method, and use the same bean everywhere.