### PR TITLE
chore(boot2): add order annotation, cannot have duplicate order now

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -35,6 +35,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -87,6 +88,7 @@ public class FiatAuthenticationConfig {
     return new FiatWebSecurityConfigurerAdapter(fiatStatus);
   }
 
+  @Order(110)
   private class FiatWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
     private final FiatStatus fiatStatus;
 


### PR DESCRIPTION
I'm the process of converting echo to boot 2. Turns out we can't have multiple beans with the same order. Currently `WebSecurityConfigurerAdapter` has an order of 100. Adding an order annotation with a number around there so that things don't conflict