### PR TITLE
fix(syncroles): Lock redis db when syncing

### DIFF
--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -162,6 +162,7 @@ class UserRolesSyncerSpec extends Specification {
   def "should only schedule sync when in-service"() {
     given:
     def lockManager = Mock(LockManager)
+    def lockManagerResponse = Mock(LockManager.AcquireLockResponse)
     def userRolesSyncer = new UserRolesSyncer(
         Optional.ofNullable(discoveryClient),
         lockManager,
@@ -176,11 +177,12 @@ class UserRolesSyncerSpec extends Specification {
     )
 
     when:
+    lockManagerResponse.getOnLockAcquiredCallbackResult() >> 42L
     userRolesSyncer.onApplicationEvent(null)
     userRolesSyncer.schedule()
 
     then:
-    (shouldAcquireLock ? 1 : 0) * lockManager.acquireLock(_, _)
+    (shouldAcquireLock ? 1 : 0) * lockManager.acquireLock(_, _) >> lockManagerResponse
 
     where:
     discoveryClient                                || shouldAcquireLock

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -110,7 +110,7 @@ public class RolesController {
                    @RequestBody(required = false) List<String> specificRoles) throws IOException {
     if (specificRoles == null || specificRoles.isEmpty()) {
       log.info("Full role sync invoked by web request.");
-      long count = syncer.syncAndReturn();
+      long count = syncer.lockedSyncAndReturn();
       if (count == 0) {
         response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
                            "Error occurred syncing permissions. See Fiat Logs.");


### PR DESCRIPTION
The sync endpoint is modifying the redis roles database. The problem is
that there may be a concurrent operation that also modifies the
database, making it prone to race conditions.

This patch just locks the redis database when modifying the roles from
the period operation as well as from the sync endpoint.