### PR TITLE
chore(syncroles): Improve partial sync of roles

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -31,8 +31,6 @@ import com.netflix.spinnaker.fiat.providers.ProviderException;
 import com.netflix.spinnaker.fiat.providers.ResourceProvider;
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
 import com.netflix.spinnaker.kork.lock.LockManager;
-
-import java.util.*;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +44,11 @@ import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -31,6 +31,8 @@ import com.netflix.spinnaker.fiat.providers.ProviderException;
 import com.netflix.spinnaker.fiat.providers.ResourceProvider;
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
 import com.netflix.spinnaker.kork.lock.LockManager;
+
+import java.util.*;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,10 +46,6 @@ import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -117,10 +115,10 @@ public class UserRolesSyncer implements ApplicationListener<RemoteStatusChangedE
         .withSuccessInterval(Duration.ofMillis(syncDelayMs))
         .withFailureInterval(Duration.ofMillis(syncFailureDelayMs));
 
-    lockManager.acquireLock(lockOptions, this::syncAndReturn);
+    lockManager.acquireLock(lockOptions, () -> this.syncAndReturn(new ArrayList<>()));
   }
 
-  public long syncAndReturn() {
+  public long syncAndReturn(List<String> roles) {
     FixedBackOff backoff = new FixedBackOff();
     backoff.setInterval(retryIntervalMs);
     backoff.setMaxAttempts(Math.floorDiv(syncDelayTimeoutMs, retryIntervalMs) + 1);
@@ -140,10 +138,10 @@ public class UserRolesSyncer implements ApplicationListener<RemoteStatusChangedE
         //force a refresh of the unrestricted user in case the backing repository is empty:
         combo.put(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME, new UserPermission());
         Map<String, UserPermission> temp;
-        if (!(temp = getUserPermissions()).isEmpty()) {
+        if (!(temp = getUserPermissions(roles)).isEmpty()) {
           combo.putAll(temp);
         }
-        if (!(temp = getServiceAccountsAsMap()).isEmpty()) {
+        if (!(temp = getServiceAccountsAsMap(roles)).isEmpty()) {
           combo.putAll(temp);
         }
 
@@ -183,16 +181,33 @@ public class UserRolesSyncer implements ApplicationListener<RemoteStatusChangedE
     return healthIndicator.health().getStatus() == Status.UP;
   }
 
-  private Map<String, UserPermission> getServiceAccountsAsMap() {
-    return serviceAccountProvider
+  private Map<String, UserPermission> getServiceAccountsAsMap(List<String> roles) {
+    List<UserPermission> allServiceAccounts = serviceAccountProvider
         .getAll()
         .stream()
         .map(ServiceAccount::toUserPermission)
-        .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+        .collect(Collectors.toList());
+    if (roles == null || roles.isEmpty()) {
+      return allServiceAccounts
+              .stream()
+              .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+    } else {
+      return allServiceAccounts
+              .stream()
+              .filter(p -> p.getRoles()
+                      .stream()
+                      .map(Role::getName)
+                      .anyMatch(roles::contains))
+              .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+    }
   }
 
-  private Map<String, UserPermission> getUserPermissions() {
-    return permissionsRepository.getAllById();
+  private Map<String, UserPermission> getUserPermissions(List<String> roles) {
+    if (roles == null || roles.isEmpty()) {
+      return permissionsRepository.getAllById();
+    } else {
+      return permissionsRepository.getAllByRoles(roles);
+    }
   }
 
   public long updateUserPermissions(Map<String, UserPermission> permissionsById) {

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -41,7 +41,6 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import javax.annotation.Nonnull
 import java.util.concurrent.Callable
 
 class UserRolesSyncerSpec extends Specification {
@@ -79,33 +78,47 @@ class UserRolesSyncerSpec extends Specification {
     jedis.flushDB()
   }
 
+  @Unroll
   def "should update user roles & add service accounts"() {
     setup:
-    def extRole = new Role("extRole").setSource(Role.Source.EXTERNAL)
+    def extRoleA = new Role("extRoleA").setSource(Role.Source.EXTERNAL)
+    def extRoleB = new Role("extRoleB").setSource(Role.Source.EXTERNAL)
+    def extRoleC = new Role("extRoleC").setSource(Role.Source.EXTERNAL)
     def user1 = new UserPermission()
         .setId("user1")
         .setAccounts([new Account().setName("account1")] as Set)
-        .setRoles([extRole] as Set)
+        .setRoles([extRoleA] as Set)
     def user2 = new UserPermission()
         .setId("user2")
         .setAccounts([new Account().setName("account2")] as Set)
+        .setRoles([extRoleB] as Set)
+    def user3 = new UserPermission()
+        .setId("user3")
+        .setAccounts([new Account().setName("account3")] as Set)
+        .setRoles([extRoleC] as Set)
     def unrestrictedUser = new UserPermission()
         .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
         .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
 
-    def abcServiceAcct = new UserPermission().setId("abc")
+    def abcServiceAcct = new UserPermission().setId("abc").setRoles([extRoleC] as Set)
     def xyzServiceAcct = new UserPermission().setId("xyz@domain.com")
 
     repo.put(user1)
     repo.put(user2)
+    repo.put(user3)
     repo.put(unrestrictedUser)
 
     def newUser2 = new UserPermission()
         .setId("user2")
-        .setAccounts([new Account().setName("account3")] as Set)
+        .setAccounts([new Account().setName("accountX")] as Set)
+        .setRoles([extRoleB] as Set)
+    def newUser3 = new UserPermission()
+        .setId("user3")
+        .setAccounts([new Account().setName("accountX")] as Set)
+        .setRoles([extRoleC] as Set)
 
     def serviceAccountProvider = Mock(ResourceProvider) {
-      getAll() >> [new ServiceAccount().setName("abc"),
+      getAll() >> [new ServiceAccount().setName("abc").setMemberOf(["extRoleC"]),
                    new ServiceAccount().setName("xyz@domain.com")]
     }
 
@@ -135,27 +148,55 @@ class UserRolesSyncerSpec extends Specification {
     repo.getAllById() == [
         "user1"       : user1.merge(unrestrictedUser),
         "user2"       : user2.merge(unrestrictedUser),
+        "user3"       : user3.merge(unrestrictedUser),
         (UNRESTRICTED): unrestrictedUser
     ]
 
     when:
-    syncer.syncAndReturn([])
+    syncer.syncAndReturn(syncRoles)
 
     then:
-    permissionsResolver.resolve(_ as List) >> ["user1"         : user1,
-                                               "user2"         : newUser2,
-                                               "abc"           : abcServiceAcct,
-                                               "xyz@domain.com": xyzServiceAcct]
+    permissionsResolver.resolve(_ as List) >> {
+      if (fullsync) {
+        ["user1"         : user1,
+         "user2"         : newUser2,
+         "user3"         : newUser3,
+         "abc"           : abcServiceAcct,
+         "xyz@domain.com": xyzServiceAcct]
+      } else {
+        ["user3"         : newUser3,
+         "abc"           : abcServiceAcct]
+      }
+    }
     permissionsResolver.resolveUnrestrictedUser() >> unrestrictedUser
 
     expect:
-    repo.getAllById() == [
-        "user1"         : user1.merge(unrestrictedUser),
-        "user2"         : newUser2.merge(unrestrictedUser),
-        "abc"           : abcServiceAcct.merge(unrestrictedUser),
-        "xyz@domain.com": xyzServiceAcct.merge(unrestrictedUser),
-        (UNRESTRICTED)  : unrestrictedUser
-    ]
+    def expectedResult
+    if (fullsync) {
+      expectedResult = [
+              "user1"         : user1.merge(unrestrictedUser),
+              "user2"         : newUser2.merge(unrestrictedUser),
+              "user3"         : newUser3.merge(unrestrictedUser),
+              "abc"           : abcServiceAcct.merge(unrestrictedUser),
+              "xyz@domain.com": xyzServiceAcct.merge(unrestrictedUser),
+              (UNRESTRICTED)  : unrestrictedUser
+      ]
+    } else {
+      expectedResult = [
+              "user1"         : user1.merge(unrestrictedUser),
+              "user2"         : user2.merge(unrestrictedUser),
+              "user3"         : newUser3.merge(unrestrictedUser),
+              "abc"           : abcServiceAcct.merge(unrestrictedUser),
+              (UNRESTRICTED)  : unrestrictedUser
+      ]
+    }
+    repo.getAllById() == expectedResult
+
+    where:
+    syncRoles    | fullsync
+    null         | true
+    []           | true
+    ["extrolec"] | false
   }
 
   @Unroll

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -139,7 +139,7 @@ class UserRolesSyncerSpec extends Specification {
     ]
 
     when:
-    syncer.syncAndReturn()
+    syncer.syncAndReturn([])
 
     then:
     permissionsResolver.resolve(_ as List) >> ["user1"         : user1,

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -108,22 +108,13 @@ public class RolesController {
   @RequestMapping(value = "/sync", method = RequestMethod.POST)
   public long sync(HttpServletResponse response,
                    @RequestBody(required = false) List<String> specificRoles) throws IOException {
-    if (specificRoles == null || specificRoles.isEmpty()) {
-      log.info("Full role sync invoked by web request.");
-      long count = syncer.syncAndReturn();
-      if (count == 0) {
-        response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-                           "Error occurred syncing permissions. See Fiat Logs.");
-      }
-      return count;
-    }
-
-    log.info("Web request role sync of roles: " + String.join(",", specificRoles));
-    Map<String, UserPermission> affectedUsers = permissionsRepository.getAllByRoles(specificRoles);
-    if (affectedUsers.size() == 0) {
+    log.info("Role sync invoked by web request for roles: {}", specificRoles);
+    long count = syncer.syncAndReturn(specificRoles);
+    if (count == 0) {
       log.info("No users found with specified roles");
-      return 0;
+      response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+        "Error occurred syncing permissions. See Fiat Logs.");
     }
-    return syncer.updateUserPermissions(affectedUsers);
+    return count;
   }
 }


### PR DESCRIPTION
Doing a full sync of all roles takes a linear amount of time with respect to the number
of users. This patch only updates the users that are affected by a role change. If no roles
are specified, then a full sync is done as we were doing before.