### PR TITLE
feat(permissions): allow username string to be passed to hasPermissions

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -150,8 +150,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     return false;
   }
 
-  @Override
-  public boolean hasPermission(Authentication authentication,
+  public boolean hasPermission(String username,
                                Serializable resourceName,
                                String resourceType,
                                Object authorization) {
@@ -175,7 +174,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
       resourceName = resourceName.toString();
     }
 
-    UserPermission.View permission = getPermission(getUsername(authentication));
+    UserPermission.View permission = getPermission(username);
     boolean hasPermission = permissionContains(permission, resourceName.toString(), r, a);
 
     authorizationFailure.set(
@@ -183,6 +182,14 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     );
 
     return hasPermission;
+  }
+
+  @Override
+  public boolean hasPermission(Authentication authentication,
+                               Serializable resourceName,
+                               String resourceType,
+                               Object authorization) {
+    return hasPermission(getUsername(authentication), resourceName, resourceType, authorization);
   }
 
   public void invalidatePermission(String username) {


### PR DESCRIPTION
When using Fiat, I keep tripping up and fetching the authentication from within another thread via `SecurityContextHolder.getContext().getAuthentication()`, which gives me a null authentication object.

Kork provides a `AuthenticatedRequest.getSpinnakerUser()` mechanism to get the username, so I've been creating an anonymous overriding horrible Authentication object to pass to Fiat. But Fiat just cares about the username, so...how about a method that just takes that?