### PR TITLE
feat(admin): Implement isAdmin check in FiatPermissionEvaluator.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -350,6 +350,15 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     return true; // TODO(ttomsu): Chosen by fair dice roll. Guaranteed to be random.
   }
 
+
+  public boolean isAdmin(Authentication authentication) {
+    if (!fiatStatus.isEnabled()) {
+      return true;
+    }
+
+    return getPermission(getUsername(authentication)).isAdmin();
+  }
+
   public class AuthorizationFailure {
     private final Authorization authorization;
     private final ResourceType resourceType;

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -251,6 +251,26 @@ class FiatPermissionEvaluatorSpec extends Specification {
     resourceType << ResourceType.values()*.toString()
   }
 
+  def "should support isAdmin check for a user"() {
+    when:
+    1 * fiatService.getUserPermission("testUser") >> {
+      return new UserPermission.View()
+          .setApplications(Collections.emptySet())
+          .setAdmin(true)
+    }
+    then:
+    evaluator.isAdmin(authentication)
+
+    when:
+    1 * fiatService.getUserPermission("testUser") >> {
+      return new UserPermission.View()
+          .setApplications(Collections.emptySet())
+          .setAdmin(false)
+    }
+    then:
+    !evaluator.isAdmin(authentication)
+  }
+
   private static FiatClientConfigurationProperties buildConfigurationProperties() {
     FiatClientConfigurationProperties configurationProperties = new FiatClientConfigurationProperties();
     configurationProperties.enabled = true


### PR DESCRIPTION
The previous implementation is used in some Front50 batch APIs so we can't get rid of it just yet!