### PR TITLE
feat(roles): Add Execute as a type of Authorization

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
@@ -18,5 +18,6 @@ package com.netflix.spinnaker.fiat.model;
 
 public enum Authorization {
   READ,
-  WRITE
+  WRITE,
+  EXECUTE
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -49,7 +49,7 @@ public class Application extends BaseAccessControlled implements Viewable {
     public View(Application application, Set<Role> userRoles, boolean isAdmin) {
       this.name = application.name;
       if (isAdmin) {
-        this.authorizations = Sets.newHashSet(Authorization.READ, Authorization.WRITE);
+        this.authorizations = Sets.newHashSet(Authorization.READ, Authorization.WRITE, Authorization.EXECUTE);
       } else {
         this.authorizations = application.permissions.getAuthorizations(userRoles);
       }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -106,8 +106,7 @@ public class Permissions {
                .collect(Collectors.toSet());
   }
 
-  @VisibleForTesting
-  protected List<String> get(Authorization a) {
+  public List<String> get(Authorization a) {
     return permissions.get(a);
   }
 

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -32,6 +32,7 @@ class PermissionsSpec extends Specification {
 
   private static final Authorization R = Authorization.READ
   private static final Authorization W = Authorization.WRITE
+  private static final Authorization E = Authorization.EXECUTE
 
   @Autowired
   TestConfigProps testConfigProps
@@ -149,7 +150,7 @@ class PermissionsSpec extends Specification {
     Permissions p = new Permissions.Builder().build()
 
     expect:
-    p.getAuthorizations([]) == [R, W] as Set
+    p.getAuthorizations([]) == [R, W, E] as Set
 
     when:
     p = Permissions.factory([(R): ["bar"], (W): ["bar"]])


### PR DESCRIPTION
Only adds the new type. Follow up PRs will:
- Migrate existing applications by adding execute permissions to users who can currently execute pipelines (PR:https://github.com/spinnaker/front50/pull/516)
- Switch to using Execute for checks during a pipeline trigger.

Part of https://github.com/spinnaker/spinnaker/issues/3554