### PR TITLE
feat(api): Allow access to unknown applications when legacyFallback=true

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -232,7 +232,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                             .map(a -> new Account().setName(a))
                             .collect(Collectors.toSet())
                     )
-            ).setLegacyFallback(true);
+            ).setLegacyFallback(true).setAllowAccessToUnknownApplications(true);
           }
         }).call();
       });
@@ -253,10 +253,6 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
               exception
       );
       id = id.withTag("legacyFallback", legacyFallback.get());
-    }
-
-    if (legacyFallback.get()) {
-      permissionsCache.invalidate(username);
     }
 
     registry.counter(id).increment();


### PR DESCRIPTION
Recent testing of our legacy fallback support did not actually work
correctly when `fiat` was unavailable.

The original intention of `legacyFallback: true` was to support a
fallback to the authorization model that existed pre-fiat.

This model only supported WRITE restricted accounts and expected that
the authorization context was propagated between services with the
`X-SPINNAKER-*` headers.

This PR is an attempt to do a better job for manually triggered pipelines
(which should have some accounts specified) as well as read operations
performed via the UI.
