### PR TITLE
Revert "fix(front50): Update Front50 cache periodically and serve live calls from cache. (#351)"

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,13 +50,7 @@ public class Front50Service implements HealthTrackable, InitializingBean {
 
   @Override
   public void afterPropertiesSet() throws Exception {
-    try {
-      // Initialize caches (also indicates service is healthy)
-      getAllApplicationPermissions();
-      getAllServiceAccounts();
-    } catch (Exception e) {
-      log.warn("Cache prime failed: ", e);
-    }
+    refreshCache();
   }
 
   public List<Application> getAllApplicationPermissions() {
@@ -99,5 +94,16 @@ public class Front50Service implements HealthTrackable, InitializingBean {
   private static void logFallback(String resource, Throwable cause) {
     String message = cause != null ? "Cause: " + cause.getMessage() : "";
     log.info("Falling back to {} cache. {}", resource, message);
+  }
+
+  @Scheduled(fixedDelayString = "${fiat.front50RefreshMs:30000}")
+  private void refreshCache() {
+    try {
+      // Initialize caches (also indicates service is healthy)
+      getAllApplicationPermissions();
+      getAllServiceAccounts();
+    } catch (Exception e) {
+      log.warn("Cache prime failed: ", e);
+    }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -25,13 +25,14 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 public class Front50Service implements HealthTrackable, InitializingBean {
+
+  private static final String GROUP_KEY = "front50Service";
 
   private final Front50Api front50Api;
 
@@ -50,40 +51,53 @@ public class Front50Service implements HealthTrackable, InitializingBean {
   public void afterPropertiesSet() throws Exception {
     try {
       // Initialize caches (also indicates service is healthy)
-      refreshApplications();
-      refreshServiceAccounts();
+      getAllApplicationPermissions();
+      getAllServiceAccounts();
     } catch (Exception e) {
       log.warn("Cache prime failed: ", e);
     }
   }
 
   public List<Application> getAllApplicationPermissions() {
-    return applicationCache.get();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getAllApplicationPermissions",
+        () -> {
+          applicationCache.set(front50Api.getAllApplicationPermissions());
+          healthTracker.success();
+          return applicationCache.get();
+        },
+        (Throwable cause) -> {
+          logFallback("application", cause);
+          List<Application> applications = applicationCache.get();
+          if (applications == null) {
+            throw new HystrixBadRequestException("Front50 is unavailable", cause);
+          }
+          return applications;
+        }).execute();
   }
 
   public List<ServiceAccount> getAllServiceAccounts() {
-    return serviceAccountCache.get();
+    return new SimpleJava8HystrixCommand<>(
+        GROUP_KEY,
+        "getAccounts",
+        () -> {
+          serviceAccountCache.set(front50Api.getAllServiceAccounts());
+          healthTracker.success();
+          return serviceAccountCache.get();
+        },
+        (Throwable cause) -> {
+          logFallback("service account", cause);
+          List<ServiceAccount> serviceAccounts = serviceAccountCache.get();
+          if (serviceAccounts == null) {
+            throw new HystrixBadRequestException("Front50 is unavailable", cause);
+          }
+          return serviceAccounts;
+        }).execute();
   }
 
   private static void logFallback(String resource, Throwable cause) {
     String message = cause != null ? "Cause: " + cause.getMessage() : "";
     log.info("Falling back to {} cache. {}", resource, message);
-  }
-
-
-  @Scheduled(fixedDelayString = "${fiat.front50RefreshMs:30000}")
-  public void refreshApplications() {
-    applicationCache.set(
-            front50Api.getAllApplicationPermissions()
-    );
-    healthTracker.success();
-  }
-
-  @Scheduled(fixedDelayString = "${fiat.front50RefreshMs:30000}")
-  public void refreshServiceAccounts() {
-    serviceAccountCache.set(
-            front50Api.getAllServiceAccounts()
-    );
-    healthTracker.success();
   }
 }


### PR DESCRIPTION
This reverts commit 4ea2d71a717b2366acae34170823596ccf43dcc4.

Having this cache along with the cache in `BaseProvider` was causing a lot of user role syncs to use stale data from Front50. This should alleviate the problems in 1.13 e.g. https://github.com/spinnaker/spinnaker/issues/4276

Ideally, I think we should try to refresh the `BaseProvider` cache with live data before a role sync starts but I'll make that a follow up PR.