### PR TITLE
feat(api): Support overriding the connect/read timeouts for `FiatService`

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
-import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.Setter;
@@ -29,7 +28,6 @@ import lombok.val;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -42,9 +40,10 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import retrofit.Endpoints;
 import retrofit.RestAdapter;
-import retrofit.client.Client;
 import retrofit.client.OkClient;
 import retrofit.converter.JacksonConverter;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @EnableWebSecurity
@@ -70,6 +69,14 @@ public class FiatAuthenticationConfig {
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     OkHttpClient okHttpClient = okHttpClientConfiguration.create();
+
+    if (fiatConfigurationProperties.getConnectTimeoutMs() != null) {
+      okHttpClient.setConnectTimeout(fiatConfigurationProperties.getConnectTimeoutMs(), TimeUnit.MILLISECONDS);
+    }
+
+    if (fiatConfigurationProperties.getReadTimeoutMs() != null) {
+      okHttpClient.setConnectTimeout(fiatConfigurationProperties.getReadTimeoutMs(), TimeUnit.MILLISECONDS);
+    }
 
     return new RestAdapter.Builder()
         .setEndpoint(Endpoints.newFixedEndpoint(fiatConfigurationProperties.getBaseUrl()))

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -36,6 +36,10 @@ public class FiatClientConfigurationProperties {
 
   private boolean refreshable = true;
 
+  private Integer connectTimeoutMs;
+
+  private Integer readTimeoutMs;
+
   @NestedConfigurationProperty
   private PermissionsCache cache = new PermissionsCache();
 


### PR DESCRIPTION
Currently these timeouts are inherited from normal service <-> service
communication.

The preference would be that an individual call to `fiat` would timeout
before the overarching service rpc times out.

Shorter timeouts would allow the existing retry behavior in
`FiatPermissionEvaluator` to be more effective.
