### PR TITLE
fix(api): Support `legacyFallback` for `BUILD_SERVICE`

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -329,7 +329,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
             .stream()
             .anyMatch(view -> view.getName().equalsIgnoreCase(resourceName));
       case BUILD_SERVICE:
-        return containsAuth.apply(permission.getBuildServices());
+        return permission.isLegacyFallback() || containsAuth.apply(permission.getBuildServices());
       default:
         return false;
     }


### PR DESCRIPTION
When `service.fiat.legacyFallback` is `true`, this will implicitly allow
access to all build services in the event that `fiat` is unavailable.
