### PR TITLE
WIP: feat(roles): Add fallback behavior for EXECUTE authz checks

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -34,6 +34,8 @@ public class FiatClientConfigurationProperties {
 
   private boolean legacyFallback = false;
 
+  private boolean executeFallbackToWrite = false;
+
   private boolean refreshable = true;
 
   private Integer connectTimeoutMs;


### PR DESCRIPTION
For backwards compatibility, fallback to the existing behavior i.e.
READ users have access to EXECUTE. The `services.fiat.executeFallbackToWrite`
flag allows changing this behavior to allow WRITE users instead.

Part of https://github.com/spinnaker/spinnaker/issues/3554