### PR TITLE
feat(roles): Add execute authz when its missing.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -326,7 +326,6 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
           // allow access to any applications w/o explicit permissions
           return true;
         }
-
         return permission.isLegacyFallback() || containsAuth.apply(permission.getApplications());
       case SERVICE_ACCOUNT:
         return permission.getServiceAccounts()

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -122,17 +122,22 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
    */
   private void ensureExecutePermission(@NonNull Application application) {
     Permissions permissions = application.getPermissions();
-    if(permissions == null || !permissions.isRestricted()) {
+    
+    if (permissions == null || !permissions.isRestricted()) {
       return;
     }
+    
     Map<Authorization, List<String>> authorizations = Arrays
         .stream(Authorization.values())
-        .collect(Collectors.toMap(Function.identity(),
-            a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())));
+        .collect(Collectors.toMap(
+          Function.identity(),
+          a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())
+        ));
 
     if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
       authorizations.put(Authorization.EXECUTE, authorizations.get(this.executeFallback));
     }
+    
     application.setPermissions(Permissions.Builder.factory(authorizations).build());
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -91,6 +91,7 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
 
       // Fallback authorization for legacy applications that are missing EXECUTE permissions
       appByName.values().forEach(this::ensureExecutePermission);
+      
       return new HashSet<>(appByName.values());
     } catch (Exception e) {
       throw new ProviderException(this.getClass(), e);

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -16,14 +16,21 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
+import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
+import lombok.NonNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -34,15 +41,18 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
   private final ClouddriverService clouddriverService;
 
   private final boolean allowAccessToUnknownApplications;
+  private final Authorization executeFallback;
 
   public DefaultApplicationProvider(Front50Service front50Service,
                                     ClouddriverService clouddriverService,
-                                    boolean allowAccessToUnknownApplications) {
+                                    boolean allowAccessToUnknownApplications,
+                                    Authorization executeFallback) {
     super();
 
     this.front50Service = front50Service;
     this.clouddriverService = clouddriverService;
     this.allowAccessToUnknownApplications = allowAccessToUnknownApplications;
+    this.executeFallback = executeFallback;
   }
 
   @Override
@@ -79,9 +89,11 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
             .collect(Collectors.toSet());
       }
 
+      // Fallback authorization for legacy applications that are missing EXECUTE permissions
+      appByName.values().forEach(this::ensureExecutePermission);
       return new HashSet<>(appByName.values());
     } catch (Exception e) {
-      throw new ProviderException(this.getClass(), e.getCause());
+      throw new ProviderException(this.getClass(), e);
     }
   }
 
@@ -101,5 +113,26 @@ public class DefaultApplicationProvider extends BaseProvider<Application> implem
     }
 
     return isRestricted ? super.getAllRestricted(roles, isAdmin) : super.getAllUnrestricted();
+  }
+
+  /**
+   * Set EXECUTE authorization(s) for the application. For applications that already have EXECUTE set,
+   * this will be a no-op. For the remaining applications, we'll add EXECUTE based on the value of the
+   * `executeFallback` flag.
+   */
+  private void ensureExecutePermission(@NonNull Application application) {
+    Permissions permissions = application.getPermissions();
+    if(permissions == null || !permissions.isRestricted()) {
+      return;
+    }
+    Map<Authorization, List<String>> authorizations = Arrays
+        .stream(Authorization.values())
+        .collect(Collectors.toMap(Function.identity(),
+            a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())));
+
+    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
+      authorizations.put(Authorization.EXECUTE, authorizations.get(this.executeFallback));
+    }
+    application.setPermissions(Permissions.Builder.factory(authorizations).build());
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 class DefaultApplicationProviderSpec extends Specification {
-  private static final Authorization R= Authorization.READ
+  private static final Authorization R = Authorization.READ
   private static final Authorization W = Authorization.WRITE
   private static final Authorization E = Authorization.EXECUTE
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -28,8 +28,18 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 class DefaultApplicationProviderSpec extends Specification {
+  private static final Authorization R= Authorization.READ
+  private static final Authorization W = Authorization.WRITE
+  private static final Authorization E = Authorization.EXECUTE
+
+  ClouddriverService clouddriverService = Mock(ClouddriverService)
+  Front50Service front50Service = Mock(Front50Service)
 
   @Subject DefaultApplicationProvider provider
+
+  def makePerms(Map<Authorization, List<String>> auths) {
+    return Permissions.Builder.factory(auths).build()
+  }
 
   @Unroll
   def "should #action applications with empty permissions when allowAccessToUnknownApplications = #allowAccessToUnknownApplications"() {
@@ -49,7 +59,7 @@ class DefaultApplicationProviderSpec extends Specification {
       ]
     }
 
-    provider = new DefaultApplicationProvider(front50Service, clouddriverService, allowAccessToUnknownApplications)
+    provider = new DefaultApplicationProvider(front50Service, clouddriverService, allowAccessToUnknownApplications, Authorization.READ)
 
     when:
     def restrictedResult = provider.getAllRestricted([new Role(role)] as Set<Role>, false)
@@ -72,5 +82,52 @@ class DefaultApplicationProviderSpec extends Specification {
     true                             | "bad_role" || ["app1"]
 
     action = allowAccessToUnknownApplications ? "exclude" : "include"
+  }
+
+  @Unroll
+  def "should add fallback execute permissions only to applications where it is not already set"() {
+    setup:
+    def app = new Application().setName("app")
+
+    when:
+    app.setPermissions(makePerms(givenPermissions))
+    provider = new DefaultApplicationProvider(front50Service, clouddriverService, false, Authorization.READ)
+    def resultApps = provider.getAll()
+
+    then:
+    1 * front50Service.getAllApplicationPermissions() >> [app]
+    1 * clouddriverService.getApplications() >> []
+
+    resultApps.size() == 1
+    makePerms(expectedPermissions) == resultApps.permissions[0]
+
+    where:
+    givenPermissions                ||  expectedPermissions
+    [:]                             ||  [:]
+    [(R): ['r']]                    ||  [(R): ['r'], (W): [], (E): ['r']]
+    [(R): ['r'], (E): ['foo']]      ||  [(R): ['r'], (W): [], (E): ['foo']]
+  }
+
+  @Unroll
+  def "should add fallback execute permissions based on executeFallback value" () {
+    setup:
+    def app = new Application().setName("app")
+
+    when:
+    app.setPermissions(makePerms(givenPermissions))
+    provider = new DefaultApplicationProvider(front50Service, clouddriverService, false, fallback)
+    def resultApps = provider.getAll()
+
+    then:
+    1 * front50Service.getAllApplicationPermissions() >> [app]
+    1 * clouddriverService.getApplications() >> []
+
+    resultApps.size() == 1
+    makePerms(expectedPermissions) == resultApps.permissions[0]
+
+    where:
+    fallback    || givenPermissions         || expectedPermissions
+    R           || [(R): ['r']]             || [(R): ['r'], (W): [], (E): ['r']]
+    W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -78,7 +78,8 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
     return new DefaultApplicationProvider(
         front50Service,
         clouddriverService,
-        properties.isAllowAccessToUnknownApplications()
+        properties.isAllowAccessToUnknownApplications(),
+        properties.getExecuteFallback()
     );
   }
 

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.config;
 
+import com.netflix.spinnaker.fiat.model.Authorization;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -31,6 +32,8 @@ public class FiatServerConfigurationProperties {
   private boolean defaultToUnrestrictedUser = false;
 
   private boolean allowAccessToUnknownApplications = false;
+
+  private Authorization executeFallback = Authorization.READ;
 
   private WriteMode writeMode = new WriteMode();
 


### PR DESCRIPTION
When an application does not explicity specify which groups have
`EXECUTE` permission, add `EXECUTE` permissions to groups that have
`READ` or `WRITE` based on the value of `fiat.executeFallback`. For
backwards compatibility, `fiat.executeFallback` defaults to `READ`
i.e. groups that have `READ` on an application will now have `EXECUTE`
as well.

Part of spinnaker/spinnaker#3554