### PR TITLE
fix(ldap): Disable LDAP health indicator

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/Main.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/Main.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.config.ErrorConfiguration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -36,7 +37,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
   "com.netflix.spinnaker.config",
 })
 @Import(ErrorConfiguration.class)
-@EnableAutoConfiguration(exclude = {GsonAutoConfiguration.class})
+@EnableAutoConfiguration(
+    exclude = {
+      GsonAutoConfiguration.class,
+      // Disable LDAP health check until we pull in the fix to
+      // https://github.com/spring-projects/spring-ldap/issues/473
+      LdapHealthIndicatorAutoConfiguration.class
+    })
 public class Main extends SpringBootServletInitializer {
 
   private static final Map<String, Object> DEFAULT_PROPS = buildDefaults();


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4346.  When we discussed a couple of weeks ago, I didn't realize there was a way to turn of the health indicator from the code (rather than from config).  Given it's possible to do that, it's probably easier to do this and then revert it once we pull in the upstream fix.

There is currently an NPE in the LDAP health indicator that has been fixed but not yet released which is causing fiat to never appear healthy. Until we can pull in the upstream fix, disable the LDAP health indicator.