### PR TITLE
chore(*): Bump spinnaker-dev plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-dev-plugin:6.1.0'
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-dev-plugin:6.3.0'
     if (Boolean.valueOf(enablePublishing)) {
-      classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:6.1.0'
+      classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:6.3.0'
     }
   }
 }


### PR DESCRIPTION
We need the new plugin to set spring.config.additional-location instead of spring.config.location when running services.