### PR TITLE
fix(apps): Clear resource provider caches to ensure up-to-date data

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -91,6 +91,13 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
     return getUserPermission(user.getId(), combo);
   }
 
+  @Override
+  public void clearCache() {
+    for (ResourceProvider provider : resourceProviders) {
+      provider.clearCache();
+    }
+  }
+
   private boolean resolveAdminRole(Set<Role> roles) {
     List<String> adminRoles = fiatAdminConfig.getAdmin().getRoles();
     return roles.stream().map(Role::getName).anyMatch(adminRoles::contains);

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -36,4 +36,7 @@ public interface PermissionsResolver {
   /** Resolves multiple user's permissions. Returned map is keyed by userId. */
   Map<String, UserPermission> resolve(Collection<ExternalUser> users)
       throws PermissionResolutionException;
+
+  /** Clears resource cache: apps, service accounts,... */
+  void clearCache();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseProvider.java
@@ -86,5 +86,9 @@ public abstract class BaseProvider<R extends Resource> implements ResourceProvid
         .build();
   }
 
+  public void clearCache() {
+    cache.invalidate(CACHE_KEY);
+  }
+
   protected abstract Set<R> loadAll() throws ProviderException;
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -27,4 +27,6 @@ public interface ResourceProvider<R extends Resource> {
   Set<R> getAllRestricted(Set<Role> roles, boolean isAdmin) throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
+
+  void clearCache();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -157,6 +157,9 @@ public class UserRolesSyncer implements ApplicationListener<RemoteStatusChangedE
               + "resolution may not complete until this server becomes healthy again.");
     }
 
+    // Ensure we're going to reload app and service account definitions
+    permissionsResolver.clearCache();
+
     while (true) {
       try {
         Map<String, UserPermission> combo = new HashMap<>();


### PR DESCRIPTION
When syncing roles, Fiat recomputes unrestricted roles for all the apps. Apps are cached for 20s (by default). This causes issues when creating an app (which will also do a sync) within 20s of another sync: the new app will not be reflected in the unrestricted role and result in 403s.

This fix clears the cache of the various providers to ensure they're refetched from Front50/Clouddriver.

This should address https://github.com/spinnaker/spinnaker/issues/4421