### PR TITLE
 fix(fiat): Fiat Doesn't Support Structured Logging #4409

### DIFF
--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -3,7 +3,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
-
+  implementation "net.logstash.logback:logstash-logback-encoder"
   testImplementation "org.springframework.boot:spring-boot"
   testImplementation "com.fasterxml.jackson.core:jackson-databind"
 }


### PR DESCRIPTION
Fiat Doesn't Support Structured Logging #4409:

I have added logstashEncoder in fiat-core.gradle and made the log file initialised in lcass path.Able to check the logs.