### PR TITLE
fix(redis): mitigate JedisPool depletion

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes redis interactions in RedisPermissionRepository that can result in
depleting the redis pool.

Specifically:
* converts smembers calls to sscan calls, and gets/returns an object
  from the pool to do so.
* removes nested calls to redisClientDelegate that were holding on
  to pool objects
* partitions lookup of users into smaller batches
* partitions role lookup

Additionally, uses InstrumentedJedisPool to enable metrics collection
on redis interactions.