### PR TITLE
fix(core): add back isEnabled check to hasPermission method to preven…

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -196,6 +196,9 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
       Serializable resourceName,
       String resourceType,
       Object authorization) {
+    if (!fiatStatus.isEnabled()) {
+      return true;
+    }
     return hasPermission(getUsername(authentication), resourceName, resourceType, authorization);
   }
 


### PR DESCRIPTION
…t NPEs

- Prior to [this PR](https://github.com/spinnaker/fiat/pull/358), `fiatStatus.isEnabled` was called prior to trying to read anything off the (possibly null) auth object. Do this check immediately in order to prevent NPEs.
