### PR TITLE
fix(bom): Fix generated pom.xml to omit invalid lombok declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ buildscript {
     classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:$spinnakerGradleVersion"
     if (Boolean.valueOf(enablePublishing)) {
       classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion"
+// TODO: nebula-publishing-plugin version override should be removed as soon as spinnaker-gradle-project is updated
+// this override is needed to omit compileOnly dependencies from generated pom.xml
+      classpath "com.netflix.nebula:nebula-publishing-plugin:12.0.1"
     }
   }
 }

--- a/fiat-bom/fiat-bom.gradle
+++ b/fiat-bom/fiat-bom.gradle
@@ -17,11 +17,6 @@
 apply plugin: "java-platform"
 apply plugin: "maven-publish"
 
-// without this building the pom fails when using the Nebula publishing plugin
-configurations {
-  create("compileOnly")
-}
-
 javaPlatform {
   allowDependencies()
 }


### PR DESCRIPTION
compileOnly dependency should not be added to generated pom.xml,
see discussion: https://discuss.gradle.org/t/publishing-plugin-should-respect-compileonly-configuration/22903/2
see related commit: nebula-plugins/nebula-publishing-plugin@a5432aa