### PR TITLE
refactor(fiat-roles): add a ResourcePermissionProvider interface

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -27,8 +27,8 @@ import lombok.val;
 
 /**
  * Representation of authorization configuration for a resource. This object is immutable, which
- * makes it challenging when working with Jackson's {{ObjectMapper}} and Spring's
- * {{\@ConfigurationProperties}}. The {@link Builder} is a helper class for the latter use case.
+ * makes it challenging when working with Jackson's {@code ObjectMapper} and Spring's
+ * {@code @ConfigurationProperties}. The {@link Builder} is a helper class for the latter use case.
  */
 @ToString
 @EqualsAndHashCode
@@ -90,7 +90,7 @@ public class Permissions {
   }
 
   public List<String> get(Authorization a) {
-    return permissions.get(a);
+    return permissions.getOrDefault(a, Collections.emptyList());
   }
 
   /**

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ClouddriverAccountResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ClouddriverAccountResourcePermissionProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+
+public final class ClouddriverAccountResourcePermissionProvider
+    implements ResourcePermissionProvider<Account> {
+
+  @Override
+  public Permissions getPermissions(Account resource) {
+    return resource.getPermissions();
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultAccountProvider.java
@@ -16,9 +16,10 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -28,18 +29,24 @@ public class DefaultAccountProvider extends BaseProvider<Account>
     implements ResourceProvider<Account> {
 
   private final ClouddriverService clouddriverService;
+  private final ResourcePermissionProvider<Account> permissionProvider;
 
   @Autowired
-  public DefaultAccountProvider(ClouddriverService clouddriverService) {
-    super();
+  public DefaultAccountProvider(
+      ClouddriverService clouddriverService,
+      ResourcePermissionProvider<Account> permissionProvider) {
     this.clouddriverService = clouddriverService;
+    this.permissionProvider = permissionProvider;
   }
 
   @Override
   protected Set<Account> loadAll() throws ProviderException {
     try {
-      return new HashSet<>(clouddriverService.getAccounts());
-    } catch (Exception e) {
+      List<Account> accounts = clouddriverService.getAccounts();
+      accounts.forEach(
+          account -> account.setPermissions(permissionProvider.getPermissions(account)));
+      return ImmutableSet.copyOf(accounts);
+    } catch (RuntimeException e) {
       throw new ProviderException(this.getClass(), e.getCause());
     }
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationProvider.java
@@ -22,13 +22,11 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -133,10 +131,7 @@ public class DefaultApplicationProvider extends BaseProvider<Application>
 
     Map<Authorization, List<String>> authorizations =
         Arrays.stream(Authorization.values())
-            .collect(
-                Collectors.toMap(
-                    Function.identity(),
-                    a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())));
+            .collect(Collectors.toMap(Function.identity(), permissions::get));
 
     if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
       authorizations.put(Authorization.EXECUTE, authorizations.get(this.executeFallback));

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public final class Front50ApplicationResourcePermissionProvider
+    implements ResourcePermissionProvider<Application> {
+
+  private final Authorization executeFallback;
+
+  public Front50ApplicationResourcePermissionProvider(Authorization executeFallback) {
+    this.executeFallback = executeFallback;
+  }
+
+  @Override
+  public Permissions getPermissions(Application resource) {
+    Permissions storedPermissions = resource.getPermissions();
+    if (storedPermissions == null || !storedPermissions.isRestricted()) {
+      return Permissions.EMPTY;
+    }
+
+    Map<Authorization, List<String>> authorizations =
+        Arrays.stream(Authorization.values()).collect(toMap(identity(), storedPermissions::get));
+
+    // If the execute permission wasn't set, copy the permissions from whatever is specified in the
+    // config's executeFallback flag
+    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
+      authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
+    }
+
+    return Permissions.Builder.factory(authorizations).build();
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+
+public interface ResourcePermissionProvider<T extends Resource> {
+
+  Permissions getPermissions(T resource);
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -85,11 +85,8 @@ class DefaultPermissionsResolverSpec extends Specification {
 
   def "should resolve the anonymous user permission, when enabled"() {
     setup:
-    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
-        .setResourceProviders(resourceProviders)
-        .setMapper(new ObjectMapper())
-        .setFiatAdminConfig(new FiatAdminConfig())
-        .setUserRolesProvider(userRolesProvider)
+    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver(
+            userRolesProvider, serviceAccountProvider, resourceProviders, new FiatAdminConfig(), new ObjectMapper())
 
     when:
     def result = resolver.resolveUnrestrictedUser()
@@ -107,10 +104,8 @@ class DefaultPermissionsResolverSpec extends Specification {
     setup:
     def testUserId = "testUserId"
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
-    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
-        .setUserRolesProvider(userRolesProvider)
-        .setResourceProviders(resourceProviders)
-        .setFiatAdminConfig(new FiatAdminConfig())
+    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver(
+            userRolesProvider, serviceAccountProvider, resourceProviders, new FiatAdminConfig(), new ObjectMapper())
 
     def role1 = new Role("group1")
     def role2 = new Role("gRoUP2") // to test case insensitivity.
@@ -167,10 +162,8 @@ class DefaultPermissionsResolverSpec extends Specification {
     def testUserId = "testUserId"
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
 
-    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
-            .setUserRolesProvider(userRolesProvider)
-            .setResourceProviders(resourceProviders)
-            .setFiatAdminConfig(fiatAdminConfig)
+    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver(
+            userRolesProvider, serviceAccountProvider, resourceProviders, fiatAdminConfig, new ObjectMapper())
 
     def role1 = new Role("delivery-team")
     def testUser = new ExternalUser().setId(testUserId).setExternalRoles([role1])
@@ -191,12 +184,8 @@ class DefaultPermissionsResolverSpec extends Specification {
   def "should resolve all user's permissions"() {
     setup:
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
-    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
-        .setUserRolesProvider(userRolesProvider)
-        .setResourceProviders(resourceProviders)
-        .setMapper(new ObjectMapper())
-        .setFiatAdminConfig(new FiatAdminConfig())
-        .setServiceAccountProvider(serviceAccountProvider)
+    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver(
+            userRolesProvider, serviceAccountProvider, resourceProviders, new FiatAdminConfig(), new ObjectMapper())
 
     def role1 = new Role("group1")
     def role2 = new Role("group2")
@@ -249,12 +238,8 @@ class DefaultPermissionsResolverSpec extends Specification {
   def "should resolve service account permissions"() {
     setup:
     UserRolesProvider userRolesProvider = Mock(UserRolesProvider)
-    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver()
-            .setUserRolesProvider(userRolesProvider)
-            .setResourceProviders(resourceProviders)
-            .setMapper(new ObjectMapper())
-            .setFiatAdminConfig(new FiatAdminConfig())
-            .setServiceAccountProvider(serviceAccountProvider)
+    @Subject DefaultPermissionsResolver resolver = new DefaultPermissionsResolver(
+            userRolesProvider, serviceAccountProvider, resourceProviders, new FiatAdminConfig(), new ObjectMapper())
 
     def role1 = new Role(group1SvcAcct.memberOf[0])
     def svc1 = new ExternalUser().setId(group1SvcAcct.name).setExternalRoles([role1])

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionSource.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionSource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.providers.ClouddriverAccountResourcePermissionProvider;
+import com.netflix.spinnaker.fiat.providers.Front50ApplicationResourcePermissionProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(
+    value = "auth.permissions-source",
+    havingValue = "default",
+    matchIfMissing = true)
+class DefaultResourcePermissionSource {
+
+  @Bean
+  public ResourcePermissionProvider<Account> getAccountPermissionProvider() {
+    return new ClouddriverAccountResourcePermissionProvider();
+  }
+
+  @Bean
+  public ResourcePermissionProvider<Application> getApplicationPermissionProvider(
+      FiatServerConfigurationProperties properties) {
+    return new Front50ApplicationResourcePermissionProvider(properties.getExecuteFallback());
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -2,9 +2,11 @@ package com.netflix.spinnaker.fiat.config;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
 import com.netflix.spinnaker.fiat.providers.DefaultApplicationProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
@@ -71,12 +73,13 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
   DefaultApplicationProvider applicationProvider(
       Front50Service front50Service,
       ClouddriverService clouddriverService,
+      ResourcePermissionProvider<Application> permissionProvider,
       FiatServerConfigurationProperties properties) {
     return new DefaultApplicationProvider(
         front50Service,
         clouddriverService,
-        properties.isAllowAccessToUnknownApplications(),
-        properties.getExecuteFallback());
+        permissionProvider,
+        properties.isAllowAccessToUnknownApplications());
   }
 
   /**


### PR DESCRIPTION
refactor(fiat-roles): add a `ResourcePermissionProvider` interface

There are two of these that are required to be provided for Fiat to
startup correctly: one for Accounts and one for Applications. There is
a default `@Configuration` that maintains the status quo by providing
default implementations that simply read the permissions directly off of
the objects, but alternate configurations can be provided that retrieve
permissions in other ways.

Curious what you think about this. The tests are almost certainly broken and more tests need to be added, etc., but it should work.

I prefer this because it allows you to define any number of policies, and those policies can define strict rules about where the permissions come from without worrying about interference from other unrelated policies. The interface is also more strict, just a mapping from `Resource` to `Permissions`, as opposed to `ResourceInterceptor` which lets implementations do any modifications they want to the `Resources`.