### PR TITLE
fix(roles): Allow anonymous calls from Fiat to other Spinnaker modules

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-dynomite"
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
   implementation "com.netflix.spinnaker.kork:kork-jedis"
+  implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "redis.clients:jedis"
   implementation "com.google.api-client:google-api-client"
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import static com.netflix.spinnaker.security.AuthenticatedRequest.allowAnonymous;
+
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.providers.HealthTrackable;
@@ -66,13 +68,13 @@ public class ClouddriverService implements HealthTrackable, InitializingBean {
 
   @Scheduled(fixedDelayString = "${fiat.clouddriver-refresh-ms:30000}")
   public void refreshAccounts() {
-    accountCache.set(clouddriverApi.getAccounts());
+    accountCache.set(allowAnonymous(clouddriverApi::getAccounts));
     healthTracker.success();
   }
 
   @Scheduled(fixedDelayString = "${fiat.clouddriver-refresh-ms:30000}")
   public void refreshApplications() {
-    applicationCache.set(clouddriverApi.getApplications());
+    applicationCache.set(allowAnonymous(clouddriverApi::getApplications));
     healthTracker.success();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import static com.netflix.spinnaker.security.AuthenticatedRequest.*;
+
 import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
@@ -55,7 +57,7 @@ public class Front50Service implements HealthTrackable, InitializingBean {
             GROUP_KEY,
             "getAllApplicationPermissions",
             () -> {
-              applicationCache.set(front50Api.getAllApplicationPermissions());
+              applicationCache.set(allowAnonymous(front50Api::getAllApplicationPermissions));
               healthTracker.success();
               return applicationCache.get();
             },
@@ -75,7 +77,7 @@ public class Front50Service implements HealthTrackable, InitializingBean {
             GROUP_KEY,
             "getAccounts",
             () -> {
-              serviceAccountCache.set(front50Api.getAllServiceAccounts());
+              serviceAccountCache.set(allowAnonymous(front50Api::getAllServiceAccounts));
               healthTracker.success();
               return serviceAccountCache.get();
             },

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/IgorService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/IgorService.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import static com.netflix.spinnaker.security.AuthenticatedRequest.allowAnonymous;
+
 import com.netflix.spinnaker.fiat.model.resources.BuildService;
 import com.netflix.spinnaker.fiat.providers.HealthTrackable;
 import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
@@ -60,7 +62,7 @@ public class IgorService implements HealthTrackable, InitializingBean {
   @Scheduled(fixedDelayString = "${fiat.igor-refresh-ms:30000}")
   public void refreshBuildServices() {
     if (igorEnabled) {
-      buildServicesCache.set(igorApi.getBuildMasters());
+      buildServicesCache.set(allowAnonymous(igorApi::getBuildMasters));
     }
     healthTracker.success();
   }


### PR DESCRIPTION
Will suppress all the `Request GET:http://<service>/<endpoint> is missing [X-SPINNAKER-USER, X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous` messages that is currently spamming the Fiat log.