### PR TITLE
feat(aggregator): enables customization of permission aggregation as well as permission sources

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.fiat.model;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public enum Authorization {
@@ -26,6 +26,6 @@ public enum Authorization {
   WRITE,
   EXECUTE;
 
-  public static Set<Authorization> ALL =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(values())));
+  public static final Set<Authorization> ALL =
+      Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(values())));
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
@@ -16,9 +16,8 @@
 
 package com.netflix.spinnaker.fiat.model;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 public enum Authorization {
@@ -27,5 +26,5 @@ public enum Authorization {
   EXECUTE;
 
   public static final Set<Authorization> ALL =
-      Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(values())));
+      Collections.unmodifiableSet(EnumSet.allOf(Authorization.class));
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -27,8 +27,8 @@ import lombok.val;
 
 /**
  * Representation of authorization configuration for a resource. This object is immutable, which
- * makes it challenging when working with Jackson's {{ObjectMapper}} and Spring's
- * {{\@ConfigurationProperties}}. The {@link Builder} is a helper class for the latter use case.
+ * makes it challenging when working with Jackson's {@code ObjectMapper} and Spring's
+ * {@code @ConfigurationProperties}. The {@link Builder} is a helper class for the latter use case.
  */
 @ToString
 @EqualsAndHashCode
@@ -90,7 +90,7 @@ public class Permissions {
   }
 
   public List<String> get(Authorization a) {
-    return permissions.get(a);
+    return permissions.getOrDefault(a, Collections.emptyList());
   }
 
   /**

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -101,7 +101,7 @@ public class Permissions {
    */
   public static class Builder extends LinkedHashMap<Authorization, List<String>> {
 
-    static Permissions fromMap(Map<Authorization, List<String>> authConfig) {
+    private static Permissions fromMap(Map<Authorization, List<String>> authConfig) {
       final Map<Authorization, List<String>> perms = new EnumMap<>(Authorization.class);
       for (Authorization auth : Authorization.values()) {
         perms.put(

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -34,12 +34,12 @@ import lombok.val;
 @EqualsAndHashCode
 public class Permissions {
 
-  public static Permissions EMPTY = new Permissions.Builder().build();
+  public static final Permissions EMPTY = Builder.fromMap(Collections.emptyMap());
 
   private final Map<Authorization, List<String>> permissions;
 
   private Permissions(Map<Authorization, List<String>> p) {
-    this.permissions = p;
+    this.permissions = Collections.unmodifiableMap(p);
   }
 
   /**
@@ -67,10 +67,6 @@ public class Permissions {
 
   public boolean isAuthorized(Set<Role> userRoles) {
     return !getAuthorizations(userRoles).isEmpty();
-  }
-
-  public boolean isEmpty() {
-    return permissions.isEmpty();
   }
 
   public Set<Authorization> getAuthorizations(Set<Role> userRoles) {
@@ -105,6 +101,25 @@ public class Permissions {
    */
   public static class Builder extends LinkedHashMap<Authorization, List<String>> {
 
+    static Permissions fromMap(Map<Authorization, List<String>> authConfig) {
+      final Map<Authorization, List<String>> perms = new EnumMap<>(Authorization.class);
+      for (Authorization auth : Authorization.values()) {
+        perms.put(
+            auth,
+            Optional.ofNullable(authConfig.get(auth))
+                .map(
+                    groups ->
+                        groups.stream()
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .map(String::toLowerCase)
+                            .collect(Collectors.toList()))
+                .map(Collections::unmodifiableList)
+                .orElse(Collections.emptyList()));
+      }
+      return new Permissions(perms);
+    }
+
     @JsonCreator
     public static Builder factory(Map<Authorization, List<String>> data) {
       return new Builder().set(data);
@@ -127,19 +142,11 @@ public class Permissions {
     }
 
     public Permissions build() {
-      final Map<Authorization, List<String>> perms = new HashMap<>();
-      this.forEach(
-          (auth, groups) -> {
-            List<String> lowerGroups =
-                Collections.unmodifiableList(
-                    groups.stream()
-                        .map(String::trim)
-                        .filter(s -> !s.isEmpty())
-                        .map(String::toLowerCase)
-                        .collect(Collectors.toList()));
-            perms.put(auth, lowerGroups);
-          });
-      return new Permissions(Collections.unmodifiableMap(perms));
+      final Permissions result = fromMap(this);
+      if (!result.isRestricted()) {
+        return Permissions.EMPTY;
+      }
+      return result;
     }
   }
 }

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -42,10 +42,18 @@ class PermissionsSpec extends Specification {
       .enable(SerializationFeature.INDENT_OUTPUT)
       .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
 
-  String permissionJson = '''{
-  "READ" : [ "foo" ],
-  "WRITE" : [ "bar" ]
-}'''
+  String permissionJson = '''\
+    {
+      "READ" : [ "foo" ],
+      "WRITE" : [ "bar" ]
+    }'''.stripIndent()
+
+  String permissionSerialized = '''\
+    {
+      "READ" : [ "foo" ],
+      "WRITE" : [ "bar" ],
+      "EXECUTE" : [ ]
+    }'''.stripIndent()
 
   def "should deserialize"() {
     when:
@@ -54,6 +62,7 @@ class PermissionsSpec extends Specification {
     then:
     p.get(R) == ["foo"]
     p.get(W) == ["bar"]
+    p.get(E) == []
 
     when:
     Permissions.Builder b = mapper.readValue(permissionJson, Permissions.Builder)
@@ -62,6 +71,7 @@ class PermissionsSpec extends Specification {
     then:
     p.get(R) == ["foo"]
     p.get(W) == ["bar"]
+    p.get(E) == []
   }
 
   def "should serialize"() {
@@ -70,7 +80,7 @@ class PermissionsSpec extends Specification {
     b.set([(R): ["foo"], (W): ["bar"]])
 
     then:
-    permissionJson ==  mapper.writeValueAsString(b.build())
+    permissionSerialized ==  mapper.writeValueAsString(b.build())
   }
 
   def "can deserialize to builder from serialized Permissions"() {
@@ -85,7 +95,6 @@ class PermissionsSpec extends Specification {
 
     then:
     p1 == p2
-    b1 == b2
   }
 
   def "should trim and lower"() {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
@@ -19,13 +19,16 @@ package com.netflix.spinnaker.fiat.providers;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public final class AccessControlledResourcePermissionSource<T extends Resource.AccessControlled>
     implements ResourcePermissionSource<T> {
 
   @Override
-  public Permissions getPermissions(T resource) {
-    return Optional.ofNullable(resource.getPermissions())
+  @Nonnull
+  public Permissions getPermissions(@Nonnull T resource) {
+    return Optional.ofNullable(resource)
+        .map(Resource.AccessControlled::getPermissions)
         .filter(Permissions::isRestricted)
         .orElse(Permissions.EMPTY);
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.Optional;
+
+public final class AccessControlledResourcePermissionSource<T extends Resource.AccessControlled>
+    implements ResourcePermissionSource<T> {
+
+  @Override
+  public Permissions getPermissions(T resource) {
+    return Optional.ofNullable(resource.getPermissions())
+        .filter(Permissions::isRestricted)
+        .orElse(Permissions.EMPTY);
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.List;
+
+/**
+ * AggregatingResourcePermissionProvider additively combines permissions from all
+ * ResourcePermissionSources to build a resulting Permission object.
+ *
+ * @param <T> the type of Resource for this AggregatingResourcePermissionProvider
+ */
+public class AggregatingResourcePermissionProvider<T extends Resource>
+    implements ResourcePermissionProvider<T> {
+
+  private final List<ResourcePermissionSource<T>> resourcePermissionSources;
+
+  public AggregatingResourcePermissionProvider(
+      List<ResourcePermissionSource<T>> resourcePermissionSources) {
+    this.resourcePermissionSources = resourcePermissionSources;
+  }
+
+  @Override
+  public Permissions getPermissions(T resource) {
+    Permissions.Builder builder = new Permissions.Builder();
+    for (ResourcePermissionSource<T> source : resourcePermissionSources) {
+      Permissions permissions = source.getPermissions(resource);
+      if (permissions.isRestricted()) {
+        for (Authorization auth : Authorization.values()) {
+          List<String> roles = permissions.get(auth);
+          if (roles != null && !roles.isEmpty()) {
+            builder.add(auth, roles);
+          }
+        }
+      }
+    }
+
+    Permissions aggregate = builder.build();
+    if (aggregate.isEmpty()) {
+      return Permissions.EMPTY;
+    }
+
+    return aggregate;
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -44,10 +44,7 @@ public class AggregatingResourcePermissionProvider<T extends Resource>
       Permissions permissions = source.getPermissions(resource);
       if (permissions.isRestricted()) {
         for (Authorization auth : Authorization.values()) {
-          List<String> roles = permissions.get(auth);
-          if (roles != null && !roles.isEmpty()) {
-            builder.add(auth, roles);
-          }
+          builder.add(auth, permissions.get(auth));
         }
       }
     }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 /**
  * AggregatingResourcePermissionProvider additively combines permissions from all
@@ -38,7 +39,8 @@ public class AggregatingResourcePermissionProvider<T extends Resource>
   }
 
   @Override
-  public Permissions getPermissions(T resource) {
+  @Nonnull
+  public Permissions getPermissions(@Nonnull T resource) {
     Permissions.Builder builder = new Permissions.Builder();
     for (ResourcePermissionSource<T> source : resourcePermissionSources) {
       Permissions permissions = source.getPermissions(resource);

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -52,11 +52,6 @@ public class AggregatingResourcePermissionProvider<T extends Resource>
       }
     }
 
-    Permissions aggregate = builder.build();
-    if (aggregate.isEmpty()) {
-      return Permissions.EMPTY;
-    }
-
-    return aggregate;
+    return builder.build();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
-public abstract class BaseProvider<R extends Resource> implements ResourceProvider<R> {
+public abstract class BaseResourceProvider<R extends Resource> implements ResourceProvider<R> {
 
   private static final Integer CACHE_KEY = 0;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -86,7 +86,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
         // no need to include applications w/o explicit permissions if we're allowing access to
         // unknown applications by default
         return applications.stream()
-            .filter(a -> !a.getPermissions().isEmpty())
+            .filter(a -> a.getPermissions().isRestricted())
             .collect(toImmutableSet());
       } else {
         return ImmutableSet.copyOf(applications);

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -16,44 +16,40 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-import com.netflix.spinnaker.fiat.model.Authorization;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.netflix.spinnaker.fiat.model.resources.Application;
-import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import lombok.NonNull;
+import java.util.function.Predicate;
 
-public class DefaultApplicationProvider extends BaseProvider<Application>
+public class DefaultApplicationResourceProvider extends BaseResourceProvider<Application>
     implements ResourceProvider<Application> {
 
   private final Front50Service front50Service;
   private final ClouddriverService clouddriverService;
+  private final ResourcePermissionProvider<Application> permissionProvider;
 
   private final boolean allowAccessToUnknownApplications;
-  private final Authorization executeFallback;
 
-  public DefaultApplicationProvider(
+  public DefaultApplicationResourceProvider(
       Front50Service front50Service,
       ClouddriverService clouddriverService,
-      boolean allowAccessToUnknownApplications,
-      Authorization executeFallback) {
-    super();
-
+      ResourcePermissionProvider<Application> permissionProvider,
+      boolean allowAccessToUnknownApplications) {
     this.front50Service = front50Service;
     this.clouddriverService = clouddriverService;
+    this.permissionProvider = permissionProvider;
     this.allowAccessToUnknownApplications = allowAccessToUnknownApplications;
-    this.executeFallback = executeFallback;
   }
 
   @Override
@@ -70,34 +66,40 @@ public class DefaultApplicationProvider extends BaseProvider<Application>
   @Override
   protected Set<Application> loadAll() throws ProviderException {
     try {
-      Map<String, Application> appByName =
-          front50Service.getAllApplicationPermissions().stream()
-              .collect(Collectors.toMap(Application::getName, Function.identity()));
+      List<Application> front50Applications = front50Service.getAllApplicationPermissions();
+      List<Application> clouddriverApplications = clouddriverService.getApplications();
 
-      clouddriverService.getApplications().stream()
-          .filter(app -> !appByName.containsKey(app.getName()))
-          .forEach(app -> appByName.put(app.getName(), app));
+      // Stream front50 first so that if there's a name collision, we'll keep that one instead of
+      // the clouddriver application (since front50 might have permissions stored on it, but the
+      // clouddriver version definitely won't)
+      List<Application> applications =
+          Streams.concat(front50Applications.stream(), clouddriverApplications.stream())
+              .filter(distinctByKey(Application::getName))
+              // Collect to a list instead of set since we're about to modify the applications
+              .collect(toImmutableList());
 
-      Set<Application> applications;
+      applications.forEach(
+          application ->
+              application.setPermissions(permissionProvider.getPermissions(application)));
 
       if (allowAccessToUnknownApplications) {
         // no need to include applications w/o explicit permissions if we're allowing access to
         // unknown applications by default
-        applications =
-            appByName.values().stream()
-                .filter(a -> !a.getPermissions().isEmpty())
-                .collect(Collectors.toSet());
+        return applications.stream()
+            .filter(a -> !a.getPermissions().isEmpty())
+            .collect(toImmutableSet());
       } else {
-        applications = new HashSet<>(appByName.values());
+        return ImmutableSet.copyOf(applications);
       }
-
-      // Fallback authorization for legacy applications that are missing EXECUTE permissions
-      applications.forEach(this::ensureExecutePermission);
-
-      return applications;
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       throw new ProviderException(this.getClass(), e);
     }
+  }
+
+  // Keeps only the first object with the key
+  private static Predicate<Application> distinctByKey(Function<Application, String> keyExtractor) {
+    Set<String> seenKeys = new HashSet<>();
+    return t -> seenKeys.add(keyExtractor.apply(t));
   }
 
   private Set<Application> getAllApplications(
@@ -117,31 +119,5 @@ public class DefaultApplicationProvider extends BaseProvider<Application>
     }
 
     return isRestricted ? super.getAllRestricted(roles, isAdmin) : super.getAllUnrestricted();
-  }
-
-  /**
-   * Set EXECUTE authorization(s) for the application. For applications that already have EXECUTE
-   * set, this will be a no-op. For the remaining applications, we'll add EXECUTE based on the value
-   * of the `executeFallback` flag.
-   */
-  private void ensureExecutePermission(@NonNull Application application) {
-    Permissions permissions = application.getPermissions();
-
-    if (permissions == null || !permissions.isRestricted()) {
-      return;
-    }
-
-    Map<Authorization, List<String>> authorizations =
-        Arrays.stream(Authorization.values())
-            .collect(
-                Collectors.toMap(
-                    Function.identity(),
-                    a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())));
-
-    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
-      authorizations.put(Authorization.EXECUTE, authorizations.get(this.executeFallback));
-    }
-
-    application.setPermissions(Permissions.Builder.factory(authorizations).build());
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.fiat.providers;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 /**
  * A ResourcePermissionProvider that delegates to a single ResourcePermissionProvider.
@@ -35,7 +36,8 @@ public class DefaultResourcePermissionProvider<T extends Resource>
   }
 
   @Override
-  public Permissions getPermissions(T resource) {
+  @Nonnull
+  public Permissions getPermissions(@Nonnull T resource) {
     return resourcePermissionSource.getPermissions(resource);
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.Objects;
+
+/**
+ * A ResourcePermissionProvider that delegates to a single ResourcePermissionProvider.
+ *
+ * @param <T> the type of Resource for this DefaultResourcePermissionProvider
+ */
+public class DefaultResourcePermissionProvider<T extends Resource>
+    implements ResourcePermissionProvider<T> {
+
+  private final ResourcePermissionSource<T> resourcePermissionSource;
+
+  public DefaultResourcePermissionProvider(ResourcePermissionSource<T> resourcePermissionSource) {
+    this.resourcePermissionSource = Objects.requireNonNull(resourcePermissionSource);
+  }
+
+  @Override
+  public Permissions getPermissions(T resource) {
+    return resourcePermissionSource.getPermissions(resource);
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount>
+public class DefaultServiceAccountResourceProvider extends BaseResourceProvider<ServiceAccount>
     implements ResourceProvider<ServiceAccount> {
 
   private final Front50Service front50Service;
@@ -41,7 +41,7 @@ public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount>
   private final FiatRoleConfig fiatRoleConfig;
 
   @Autowired
-  public DefaultServiceAccountProvider(
+  public DefaultServiceAccountResourceProvider(
       Front50Service front50Service, FiatRoleConfig fiatRoleConfig) {
     super();
     this.front50Service = front50Service;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public final class Front50ApplicationResourcePermissionSource
     implements ResourcePermissionSource<Application> {
@@ -36,7 +37,8 @@ public final class Front50ApplicationResourcePermissionSource
   }
 
   @Override
-  public Permissions getPermissions(Application resource) {
+  @Nonnull
+  public Permissions getPermissions(@Nonnull Application resource) {
     Permissions storedPermissions = resource.getPermissions();
     if (storedPermissions == null || !storedPermissions.isRestricted()) {
       return Permissions.EMPTY;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public final class Front50ApplicationResourcePermissionSource
+    implements ResourcePermissionSource<Application> {
+
+  private final Authorization executeFallback;
+
+  public Front50ApplicationResourcePermissionSource(Authorization executeFallback) {
+    this.executeFallback = executeFallback;
+  }
+
+  @Override
+  public Permissions getPermissions(Application resource) {
+    Permissions storedPermissions = resource.getPermissions();
+    if (storedPermissions == null || !storedPermissions.isRestricted()) {
+      return Permissions.EMPTY;
+    }
+
+    Map<Authorization, List<String>> authorizations =
+        Arrays.stream(Authorization.values()).collect(toMap(identity(), storedPermissions::get));
+
+    // If the execute permission wasn't set, copy the permissions from whatever is specified in the
+    // config's executeFallback flag
+    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
+      authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
+    }
+
+    return Permissions.Builder.factory(authorizations).build();
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-public class ProviderException extends RuntimeException {
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+
+public class ProviderException extends IntegrationException {
 
   private Class provider;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
@@ -18,14 +18,28 @@ package com.netflix.spinnaker.fiat.providers;
 
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
+import javax.annotation.Nonnull;
 
 /**
  * A ResourcePermissionProvider is responsible for supplying the full set of Permissions for a
  * specific Resource.
  *
+ * <p>Note that while the API signature matches ResourcePermissionSource the intent of
+ * ResourcePermissionProvider is the interface for consumers interested in the actual Permissions of
+ * a resource, while ResourcePermissionSource models a single source of Permissions (for example
+ * CloudDriver as a source of Account permissions).
+ *
  * @param <T> the type of Resource for which this ResourcePermissionProvider supplies Permissions.
  */
 public interface ResourcePermissionProvider<T extends Resource> {
 
-  Permissions getPermissions(T resource);
+  /**
+   * Retrieves Permissions for the supplied resource.
+   *
+   * @param resource the resource for which to get permissions (never null)
+   * @return the Permissions for the resource (never null - use Permissions.EMPTY or apply some
+   *     restriction)
+   */
+  @Nonnull
+  Permissions getPermissions(@Nonnull T resource);
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+
+/**
+ * A ResourcePermissionProvider is responsible for supplying the full set of Permissions for a
+ * specific Resource.
+ *
+ * @param <T> the type of Resource for which this ResourcePermissionProvider supplies Permissions.
+ */
+public interface ResourcePermissionProvider<T extends Resource> {
+
+  Permissions getPermissions(T resource);
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.fiat.providers;
 
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
+import javax.annotation.Nonnull;
 
 /**
  * A ResourcePermissionSource is capable of resolving the Permissions for a specified Resource from
@@ -31,5 +32,14 @@ import com.netflix.spinnaker.fiat.model.resources.Resource;
  * @param <T> the type of Resource this ResourcePermissionSource will supply Permissions for
  */
 public interface ResourcePermissionSource<T extends Resource> {
-  Permissions getPermissions(T resource);
+
+  /**
+   * Retrieves Permissions for the supplied resource.
+   *
+   * @param resource the resource for which to get permissions (never null)
+   * @return the Permissions for the resource (never null - use Permissions.EMPTY or apply some
+   *     restriction)
+   */
+  @Nonnull
+  Permissions getPermissions(@Nonnull T resource);
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+
+/**
+ * A ResourcePermissionSource is capable of resolving the Permissions for a specified Resource from
+ * a specified single source.
+ *
+ * <p>Note that while the API signature matches ResourcePermissionProvider the intent of
+ * ResourcePermissionSource is to model a single source of Permissions (for example CloudDriver as a
+ * source of Account permissions), while ResourcePermissionProvider is responsible for supplying the
+ * computed Permission considering all available ResourcePermissionSources.
+ *
+ * @param <T> the type of Resource this ResourcePermissionSource will supply Permissions for
+ */
+public interface ResourcePermissionSource<T extends Resource> {
+  Permissions getPermissions(T resource);
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -19,9 +19,11 @@ package com.netflix.spinnaker.fiat.permissions
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig
+import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.model.resources.Application
+import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
@@ -34,6 +36,8 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class RedisPermissionsRepositorySpec extends Specification {
+
+  private static final String EMPTY_PERM_JSON = "{${Authorization.values().collect {/"$it":[]/}.join(',')}}"
 
   private static final String UNRESTRICTED = UnrestrictedResourceConfig.UNRESTRICTED_USERNAME
 
@@ -91,9 +95,9 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.smembers("unittests:roles:role1") == ["testUser"] as Set
 
     jedis.hgetAll("unittests:permissions:testUser:accounts") ==
-        ['account': '{"name":"account","permissions":{}}']
+        ['account': /{"name":"account","permissions":$EMPTY_PERM_JSON}/.toString()]
     jedis.hgetAll("unittests:permissions:testUser:applications") ==
-        ['app': '{"name":"app","permissions":{}}']
+        ['app': /{"name":"app","permissions":$EMPTY_PERM_JSON}/.toString()]
     jedis.hgetAll("unittests:permissions:testUser:service_accounts") ==
         ['serviceAccount': '{"name":"serviceAccount","memberOf":["role1"]}']
     jedis.hgetAll("unittests:permissions:testUser:roles") ==

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
@@ -27,7 +27,7 @@ import groovy.transform.builder.SimpleStrategy
 import spock.lang.Specification
 import spock.lang.Subject
 
-class BaseProviderSpec extends Specification {
+class BaseResourceProviderSpec extends Specification {
 
   private static Authorization R = Authorization.READ
   private static Authorization W = Authorization.WRITE
@@ -51,7 +51,7 @@ class BaseProviderSpec extends Specification {
 
   def "should get all unrestricted"() {
     setup:
-    @Subject provider = new TestResourceProvider()
+    @Subject provider = new TestResourceResourceProvider()
 
     when:
     provider.all = [noReqGroups]
@@ -72,7 +72,7 @@ class BaseProviderSpec extends Specification {
 
   def "should get restricted"() {
     setup:
-    @Subject provider = new TestResourceProvider()
+    @Subject provider = new TestResourceResourceProvider()
 
     when:
     provider.all = [noReqGroups]
@@ -111,7 +111,7 @@ class BaseProviderSpec extends Specification {
     thrown IllegalArgumentException
   }
 
-  class TestResourceProvider extends BaseProvider<TestResource> {
+  class TestResourceResourceProvider extends BaseResourceProvider<TestResource> {
     Set<TestResource> all = new HashSet<>()
 
     @Override

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -51,7 +51,6 @@ class DefaultApplicationProviderSpec extends Specification {
           new Application().setName("app1")
                            .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
       ]
-
     }
     ClouddriverService clouddriverService = Mock(ClouddriverService) {
       getApplications() >> [
@@ -130,8 +129,9 @@ class DefaultApplicationProviderSpec extends Specification {
     makePerms(expectedPermissions) == resultApps.permissions[0]
 
     where:
-    fallback    || givenPermissions         || expectedPermissions
-    R           || [(R): ['r']]             || [(R): ['r'], (E): ['r']]
-    W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
+    fallback    | givenPermissions         || expectedPermissions
+    R           | [:]                      || [:]
+    R           | [(R): ['r']]             || [(R): ['r'], (E): ['r']]
+    W           | [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -34,8 +34,9 @@ class DefaultApplicationProviderSpec extends Specification {
 
   ClouddriverService clouddriverService = Mock(ClouddriverService)
   Front50Service front50Service = Mock(Front50Service)
+  ResourcePermissionProvider<Application> defaultProvider = new AggregatingResourcePermissionProvider<>([new Front50ApplicationResourcePermissionSource(Authorization.READ)])
 
-  @Subject DefaultApplicationProvider provider
+  @Subject DefaultApplicationResourceProvider provider
 
   def makePerms(Map<Authorization, List<String>> auths) {
     return Permissions.Builder.factory(auths).build()
@@ -59,7 +60,7 @@ class DefaultApplicationProviderSpec extends Specification {
       ]
     }
 
-    provider = new DefaultApplicationProvider(front50Service, clouddriverService, allowAccessToUnknownApplications, Authorization.READ)
+    provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, defaultProvider, allowAccessToUnknownApplications)
 
     when:
     def restrictedResult = provider.getAllRestricted([new Role(role)] as Set<Role>, false)
@@ -91,9 +92,8 @@ class DefaultApplicationProviderSpec extends Specification {
 
     when:
     app.setPermissions(makePerms(givenPermissions))
-    provider = new DefaultApplicationProvider(
-        front50Service, clouddriverService, allowAccessToUnknownApplications, Authorization.READ
-    )
+    provider = new DefaultApplicationResourceProvider(
+        front50Service, clouddriverService, defaultProvider, allowAccessToUnknownApplications)
     def resultApps = provider.getAll()
 
     then:
@@ -106,19 +106,20 @@ class DefaultApplicationProviderSpec extends Specification {
     where:
     givenPermissions           | allowAccessToUnknownApplications || expectedPermissions
     [:]                        | false                            || [:]
-    [(R): ['r']]               | false                            || [(R): ['r'], (W): [], (E): ['r']]
-    [(R): ['r'], (E): ['foo']] | false                            || [(R): ['r'], (W): [], (E): ['foo']]
-    [(R): ['r']]               | true                             || [(R): ['r'], (W): [], (E): ['r']]
+    [(R): ['r']]               | false                            || [(R): ['r'], (E): ['r']]
+    [(R): ['r'], (E): ['foo']] | false                            || [(R): ['r'], (E): ['foo']]
+    [(R): ['r']]               | true                             || [(R): ['r'], (E): ['r']]
   }
 
   @Unroll
   def "should add fallback execute permissions based on executeFallback value" () {
     setup:
     def app = new Application().setName("app")
+    def provider = new AggregatingResourcePermissionProvider([new Front50ApplicationResourcePermissionSource(fallback)])
 
     when:
     app.setPermissions(makePerms(givenPermissions))
-    provider = new DefaultApplicationProvider(front50Service, clouddriverService, false, fallback)
+    provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, provider, false)
     def resultApps = provider.getAll()
 
     then:
@@ -130,7 +131,7 @@ class DefaultApplicationProviderSpec extends Specification {
 
     where:
     fallback    || givenPermissions         || expectedPermissions
-    R           || [(R): ['r']]             || [(R): ['r'], (W): [], (E): ['r']]
+    R           || [(R): ['r']]             || [(R): ['r'], (E): ['r']]
     W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import org.apache.commons.collections4.CollectionUtils
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Subject
 import spock.lang.Unroll
 
 class DefaultServiceAccountProviderSpec extends Specification {
@@ -48,7 +47,7 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> false
     }
-    DefaultServiceAccountProvider provider = new DefaultServiceAccountProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
 
     when:
     def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)
@@ -80,7 +79,7 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> true
     }
-    DefaultServiceAccountProvider provider = new DefaultServiceAccountProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
 
     when:
     def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -42,6 +42,13 @@ class DefaultResourcePermissionConfig {
       havingValue = "default",
       matchIfMissing = true)
   public ResourcePermissionProvider<Account> defaultAccountPermissionProvider(
+      ResourcePermissionSource<Account> accountResourcePermissionSource) {
+    return new DefaultResourcePermissionProvider<>(accountResourcePermissionSource);
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = "auth.permissions.provider.account", havingValue = "aggregate")
+  public ResourcePermissionProvider<Account> aggregateAccountPermissionProvider(
       List<ResourcePermissionSource<Account>> sources) {
     return new AggregatingResourcePermissionProvider<>(sources);
   }
@@ -62,6 +69,13 @@ class DefaultResourcePermissionConfig {
       havingValue = "default",
       matchIfMissing = true)
   public ResourcePermissionProvider<Application> defaultApplicationPermissionProvider(
+      ResourcePermissionSource<Application> front50ResourcePermissionSource) {
+    return new DefaultResourcePermissionProvider<>(front50ResourcePermissionSource);
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = "auth.permissions.provider.application", havingValue = "aggregate")
+  public ResourcePermissionProvider<Application> aggregateApplicationPermissionProvider(
       List<ResourcePermissionSource<Application>> sources) {
     return new AggregatingResourcePermissionProvider<>(sources);
   }
@@ -80,6 +94,15 @@ class DefaultResourcePermissionConfig {
       havingValue = "default",
       matchIfMissing = true)
   public ResourcePermissionProvider<BuildService> defaultBuildServicePermissionProvider(
+      ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource) {
+    return new DefaultResourcePermissionProvider<>(buildServiceResourcePermissionSource);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.build-service",
+      havingValue = "aggregate")
+  public ResourcePermissionProvider<BuildService> aggregateBuildServicePermissionProvider(
       List<ResourcePermissionSource<BuildService>> sources) {
     return new AggregatingResourcePermissionProvider<>(sources);
   }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.BuildService;
+import com.netflix.spinnaker.fiat.providers.*;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class DefaultResourcePermissionConfig {
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.account.resource.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<Account> accountResourcePermissionSource() {
+    return new AccessControlledResourcePermissionSource<>();
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.account",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<Account> defaultAccountPermissionProvider(
+      List<ResourcePermissionSource<Account>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.application.front50.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<Application> front50ResourcePermissionSource(
+      FiatServerConfigurationProperties fiatServerConfigurationProperties) {
+    return new Front50ApplicationResourcePermissionSource(
+        fiatServerConfigurationProperties.getExecuteFallback());
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.application",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<Application> defaultApplicationPermissionProvider(
+      List<ResourcePermissionSource<Application>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.account.resource.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource() {
+    return new AccessControlledResourcePermissionSource<>();
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.build-service",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<BuildService> defaultBuildServicePermissionProvider(
+      List<ResourcePermissionSource<BuildService>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -68,7 +68,7 @@ class DefaultResourcePermissionConfig {
 
   @Bean
   @ConditionalOnProperty(
-      value = "auth.permissions.source.account.resource.enabled",
+      value = "auth.permissions.source.build-service.resource.enabled",
       matchIfMissing = true)
   ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource() {
     return new AccessControlledResourcePermissionSource<>();

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -2,9 +2,11 @@ package com.netflix.spinnaker.fiat.config;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
-import com.netflix.spinnaker.fiat.providers.DefaultApplicationProvider;
+import com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
@@ -68,15 +70,16 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
   }
 
   @Bean
-  DefaultApplicationProvider applicationProvider(
+  DefaultApplicationResourceProvider applicationProvider(
       Front50Service front50Service,
       ClouddriverService clouddriverService,
+      ResourcePermissionProvider<Application> permissionProvider,
       FiatServerConfigurationProperties properties) {
-    return new DefaultApplicationProvider(
+    return new DefaultApplicationResourceProvider(
         front50Service,
         clouddriverService,
-        properties.isAllowAccessToUnknownApplications(),
-        properties.getExecuteFallback());
+        permissionProvider,
+        properties.isAllowAccessToUnknownApplications());
   }
 
   /**


### PR DESCRIPTION
Adds a ResourcePermissionSource - a place to get permissions from, and
ResourcePermissionProvider - the API for callers

The default ResourcePermissionProvider is an aggregator across all
ResourcePermissionSources

There is a `DefaultResourcePermissionConfiguration` that maintains the
status quo by providing default implementations that simply read the
permissions directly off of the objects, but allows opting out of some
or all of the default opinions if someone wants to customize, extend,
or override any of the default behaviour.

Additional improvements:

* refactor(fiat-roles):
    - make DefaultPermissionsResolver immutable
    - don't return null values from Permissions#get
    - clean up loadAll

closes #478 
closes #472 