### PR TITLE
feature(authorization): Add creation access control

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -160,7 +160,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
       return AuthenticatedRequest.propagate(
               () -> {
                 return retryHandler.retry(
-                    "get whether " + username + " can create resource" + resource,
+                    "determine whether " + username + " can create resource" + resource,
                     () -> {
                       Response response = fiatService.canCreate(username, resourceType, resource);
                       if (response.getStatus() == HttpServletResponse.SC_OK) {

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -211,6 +211,12 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
 
     ResourceType r = ResourceType.parse(resourceType);
     Authorization a = null;
+
+    if (a == Authorization.CREATE) {
+      throw new IllegalArgumentException(
+          "This method should not be called for `CREATE`. Please call the other implementation");
+    }
+
     // Service accounts don't have read/write authorizations.
     if (r != ResourceType.SERVICE_ACCOUNT) {
       a = Authorization.valueOf(authorization.toString());

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.fiat.shared;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
-import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.Collection;
 import java.util.List;
 import retrofit.client.Response;
@@ -53,15 +52,15 @@ public interface FiatService {
 
   /**
    * @param userId The username of the user
-   * @param authorization The authorization in question (read, write, etc)
-   * @param resource The resource for which we want to get the authorization
-   * @return 200 if the user has access to the specified resource, 404 otherwise
+   * @param resourceType The type of the resource
+   * @param resource The resource to check
+   * @return 200 if the user can create the specified resource, 404 otherwise
    */
-  @POST("/authorize/{userId}/{authorization}")
-  Response hasAuthorization(
+  @POST("/authorize/{userId}/{resourceType}")
+  Response canCreate(
       @Path("userId") String userId,
-      @Path("authorization") String authorization,
-      @Body Resource resource);
+      @Path("resourceType") String resourceType,
+      @Body Object resource);
 
   /**
    * Use to update all users.

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -51,13 +51,15 @@ public interface FiatService {
       @Path("authorization") String authorization);
 
   /**
+   * Determine whether the user can create a resource. Returns 200 if the user can, throws 404
+   * otherwise
+   *
    * @param userId The username of the user
    * @param resourceType The type of the resource
    * @param resource The resource to check
-   * @return 200 if the user can create the specified resource, 404 otherwise
    */
   @POST("/authorize/{userId}/{resourceType}")
-  Response canCreate(
+  void canCreate(
       @Path("userId") String userId,
       @Path("resourceType") String resourceType,
       @Body Object resource);

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.shared;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.Collection;
 import java.util.List;
 import retrofit.client.Response;
@@ -49,6 +50,18 @@ public interface FiatService {
       @Path("resourceType") String resourceType,
       @Path("resourceName") String resourceName,
       @Path("authorization") String authorization);
+
+  /**
+   * @param userId The username of the user
+   * @param authorization The authorization in question (read, write, etc)
+   * @param resource The resource for which we want to get the authorization
+   * @return 200 if the user has access to the specified resource, 404 otherwise
+   */
+  @POST("/authorize/{userId}/{authorization}")
+  Response hasAuthorization(
+      @Path("userId") String userId,
+      @Path("authorization") String authorization,
+      @Body Resource resource);
 
   /**
    * Use to update all users.

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.slf4j.MDC
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
+import retrofit.RetrofitError
 import retrofit.client.Response
 import spock.lang.Shared
 import spock.lang.Subject
@@ -105,8 +106,10 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
     SecurityContextHolder.getContext().setAuthentication(authentication)
     Resource resourceCanCreate = new Application().setName("app1")
     Resource resourceCannotCreate = new Application().setName("app2")
-    fiatService.canCreate("testUser", 'APPLICATION', resourceCanCreate) >> new Response("", HttpServletResponse.SC_OK, "", [], null)
-    fiatService.canCreate("testUser", 'APPLICATION', resourceCannotCreate) >> new Response("", HttpServletResponse.SC_NOT_FOUND, "", [], null)
+    fiatService.canCreate("testUser", 'APPLICATION', resourceCanCreate) >> null // doesn't return anything in case of success
+    fiatService.canCreate("testUser", 'APPLICATION', resourceCannotCreate) >> {
+      throw RetrofitError.httpError("", new Response("", HttpServletResponse.SC_NOT_FOUND, "", [], null), null, null)
+    }
 
     expect:
     evaluator.hasPermission(authentication, resource, 'APPLICATION', 'READ')

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -106,7 +106,7 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
     Resource resourceCanCreate = new Application().setName("app1")
     Resource resourceCannotCreate = new Application().setName("app2")
     fiatService.canCreate("testUser", 'APPLICATION', resourceCanCreate) >> new Response("", HttpServletResponse.SC_OK, "", [], null)
-    fiatService.hasAuthorization("testUser", 'APPLICATION', resourceCannotCreate) >> new Response("", HttpServletResponse.SC_NOT_FOUND, "", [], null)
+    fiatService.canCreate("testUser", 'APPLICATION', resourceCannotCreate) >> new Response("", HttpServletResponse.SC_NOT_FOUND, "", [], null)
 
     expect:
     evaluator.hasPermission(authentication, resource, 'APPLICATION', 'READ')

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
@@ -23,7 +23,8 @@ import java.util.Set;
 public enum Authorization {
   READ,
   WRITE,
-  EXECUTE;
+  EXECUTE,
+  CREATE;
 
   public static final Set<Authorization> ALL =
       Collections.unmodifiableSet(EnumSet.allOf(Authorization.class));

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -33,6 +33,7 @@ class PermissionsSpec extends Specification {
   private static final Authorization R = Authorization.READ
   private static final Authorization W = Authorization.WRITE
   private static final Authorization E = Authorization.EXECUTE
+  private static final Authorization C = Authorization.CREATE
 
   @Autowired
   TestConfigProps testConfigProps
@@ -52,7 +53,8 @@ class PermissionsSpec extends Specification {
     {
       "READ" : [ "foo" ],
       "WRITE" : [ "bar" ],
-      "EXECUTE" : [ ]
+      "EXECUTE" : [ ],
+      "CREATE" : [ ]
     }'''.stripIndent()
 
   def "should deserialize"() {
@@ -162,7 +164,7 @@ class PermissionsSpec extends Specification {
     Permissions p = new Permissions.Builder().build()
 
     expect:
-    p.getAuthorizations([]) == [R, W, E] as Set
+    p.getAuthorizations([]) == [R, W, E, C] as Set
 
     when:
     p = Permissions.factory([(R): ["bar"], (W): ["bar"]])

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultResourcePermissionProvider.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
- * A ResourcePermissionProvider that delegates to a single ResourcePermissionProvider.
+ * A ResourcePermissionProvider that delegates to a single ResourcePermissionSource.
  *
  * @param <T> the type of Resource for this DefaultResourcePermissionProvider
  */

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
@@ -53,6 +53,9 @@ public final class Front50ApplicationResourcePermissionSource
       authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
     }
 
+    // CREATE permissions are not allowed on the resource level
+    authorizations.remove(Authorization.CREATE);
+
     return Permissions.Builder.factory(authorizations).build();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
@@ -53,7 +53,7 @@ public final class Front50ApplicationResourcePermissionSource
       authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
     }
 
-    // CREATE permissions are not allowed on the resource level
+    // CREATE permissions are not allowed on the resource level.
     authorizations.remove(Authorization.CREATE);
 
     return Permissions.Builder.factory(authorizations).build();

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -33,6 +33,8 @@ public class FiatServerConfigurationProperties {
 
   private Authorization executeFallback = Authorization.READ;
 
+  private boolean restrictApplicationCreation = false;
+
   private WriteMode writeMode = new WriteMode();
 
   @Data

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -127,22 +127,6 @@ public class AuthorizeController {
         .orElseThrow(NotFoundException::new);
   }
 
-  @RequestMapping(value = "/{userId:.+}/buildServices", method = RequestMethod.GET)
-  public Set<BuildService.View> getUserBuildServices(@PathVariable String userId) {
-    return new HashSet<>(getUserPermissionView(userId).getBuildServices());
-  }
-
-  @RequestMapping(
-      value = "/{userId:.+}/buildServices/{buildServiceName:.+}",
-      method = RequestMethod.GET)
-  public BuildService.View getUserBuildService(
-      @PathVariable String userId, @PathVariable String buildServiceName) {
-    return getUserPermissionView(userId).getBuildServices().stream()
-        .filter(buildService -> buildServiceName.equalsIgnoreCase(buildService.getName()))
-        .findFirst()
-        .orElseThrow(NotFoundException::new);
-  }
-
   @RequestMapping(value = "/{userId:.+}/serviceAccounts", method = RequestMethod.GET)
   public Set<ServiceAccount.View> getServiceAccounts(@PathVariable String userId) {
     return new HashSet<>(getUserPermissionView(userId).getServiceAccounts());

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -200,28 +200,25 @@ public class AuthorizeController {
     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
   }
 
-  @RequestMapping(
-      value = "/{userId:.+}/{resourceType:.+}/{authorization:.+}",
-      method = RequestMethod.POST)
-  public void hasPermission(
+  @RequestMapping(value = "/{userId:.+}/{authorization:.+}", method = RequestMethod.POST)
+  public void hasAuthorization(
       @PathVariable String userId,
-      @PathVariable String resourceType,
       @PathVariable String authorization,
       @RequestBody @Nonnull Resource resource,
       HttpServletResponse response)
       throws IOException {
     Authorization a = Authorization.valueOf(authorization.toUpperCase());
-    ResourceType rt = ResourceType.parse(resourceType);
+    ResourceType resourceType = resource.getResourceType();
     Set<Authorization> authorizations = new HashSet<>(0);
 
     if (a == Authorization.CREATE) {
       if (!configProps.isRestrictApplicationCreation()) {
         authorizations.add(Authorization.CREATE);
       } else {
-        if (rt != ResourceType.APPLICATION) {
+        if (resourceType != ResourceType.APPLICATION) {
           response.sendError(
               HttpServletResponse.SC_BAD_REQUEST,
-              "Resource type " + resourceType + "does not support creation");
+              "Resource type " + resourceType.toString() + "does not support creation");
           return;
         }
         List<String> userRoles =
@@ -233,7 +230,7 @@ public class AuthorizeController {
       }
     } else {
       try {
-        switch (rt) {
+        switch (resourceType) {
           case ACCOUNT:
             authorizations = getUserAccount(userId, resource.getName()).getAuthorizations();
             break;

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -199,7 +199,7 @@ public class AuthorizeController {
     if (rt != ResourceType.APPLICATION) {
       response.sendError(
           HttpServletResponse.SC_BAD_REQUEST,
-          "Resource type " + resourceType + "does not support creation");
+          "Resource type " + resourceType + " does not support creation");
       return;
     }
 

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -25,7 +25,9 @@ import com.netflix.spinnaker.config.TestUserRoleProviderConfig
 import com.netflix.spinnaker.fiat.config.FiatServerConfigurationProperties
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
+import com.netflix.spinnaker.fiat.model.resources.Application
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import org.slf4j.MDC
@@ -72,6 +74,9 @@ class AuthorizeControllerSpec extends Specification {
 
   @Autowired
   ObjectMapper objectMapper
+
+  @Autowired
+  ResourcePermissionProvider<Application> applicationResourcePermissionProvider;
 
   @Delegate
   FiatSystemTestSupport fiatIntegrationTestSupport = new FiatSystemTestSupport()
@@ -154,7 +159,7 @@ class AuthorizeControllerSpec extends Specification {
   def "should get user from repo"() {
     setup:
     PermissionsRepository repository = Mock(PermissionsRepository)
-    AuthorizeController controller = new AuthorizeController(registry, repository, fiatServerConfigurationProperties)
+    AuthorizeController controller = new AuthorizeController(registry, repository, fiatServerConfigurationProperties, applicationResourcePermissionProvider)
 
     def foo = new UserPermission().setId("foo@batman.com")
 
@@ -176,7 +181,7 @@ class AuthorizeControllerSpec extends Specification {
   def "should get user's accounts from repo"() {
     setup:
     PermissionsRepository repository = Mock(PermissionsRepository)
-    AuthorizeController controller = new AuthorizeController(registry, repository, fiatServerConfigurationProperties)
+    AuthorizeController controller = new AuthorizeController(registry, repository, fiatServerConfigurationProperties, applicationResourcePermissionProvider)
 
     def bar = new Account().setName("bar")
     def foo = new UserPermission().setId("foo").setAccounts([bar] as Set)
@@ -253,7 +258,8 @@ class AuthorizeControllerSpec extends Specification {
     def authorizeController = new AuthorizeController(
         registry,
         permissionsRepository,
-        new FiatServerConfigurationProperties(defaultToUnrestrictedUser: defaultToUnrestrictedUser)
+        new FiatServerConfigurationProperties(defaultToUnrestrictedUser: defaultToUnrestrictedUser),
+        applicationResourcePermissionProvider
     )
     permissionsRepository.put(unrestrictedUser)
 


### PR DESCRIPTION
**This implementation is still in draft state**. It achieves the following:
1. Add a configuration parameter called `restrictApplicationCreation`. If set to false (the default), this feature will be ignored.
2. Add a `CREATE` authorization.
3. Call the `ResourcePermissionProvider` immediately from `AuthorizeController`, because creation permissions are typically dynamic, and cannot be known before the application is submitted for creation. Thus, they cannot be held on the UserPermissions object.
4. Make `Front50ApplicationResourcePermission` source strip out any `CREATE` permissions provided on the source, because it doesn't make sense for users to add `CREATE` permissions on the resource they are creating, and it will basically work against any other authorization model we try to implement.
5.  Implementations of `ResourcePermissionProvider` and `ResourcePermissionSource` will be free to handle creation permissions the way they say fit.

Please let me know what you think. Let's try to release this in the Oct 28th release