### PR TITLE
fix(fiat-api): revert breaking change to Permissions.

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -61,6 +61,17 @@ public class Permissions {
     return permissions.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
   }
 
+  /**
+   * Determines whether this Permissions has any Authorizations with associated roles.
+   *
+   * @return whether this Permissions has any Authorizations with associated roles
+   * @deprecated check {@code !isRestricted()} instead
+   */
+  @Deprecated
+  public boolean isEmpty() {
+    return !isRestricted();
+  }
+
   public boolean isRestricted() {
     return this.permissions.values().stream().anyMatch(groups -> !groups.isEmpty());
   }


### PR DESCRIPTION
Deprecates instead of removes isEmpty() on Permissions, and delegates it to check isRestricted
rather than the Map content.