### PR TITLE
fix(unrestricted): load permissions for unrestricted roles

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -117,7 +117,9 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
       try {
         if (UnrestrictedResourceConfig.UNRESTRICTED_USERNAME.equalsIgnoreCase(userId)) {
           permission.addResources(provider.getAllUnrestricted());
-        } else if (!roles.isEmpty()) {
+        }
+
+        if (!roles.isEmpty()) {
           permission.addResources(provider.getAllRestricted(roles, permission.isAdmin()));
         }
       } catch (ProviderException pe) {


### PR DESCRIPTION
The unrestricted user can have associated roles via
`UserRolesProvider.loadUnrestrictedRoles`, however this would
always short-circuit evaluation of permissions for those roles.

This resulted in the case where on the first authorization
(`POST /roles/:userId`) the user would not have access to any
resources that were granted solely via the unrestricted role.
However in a subsequent authentication - the users permissions
would get merged with an existing user entry and the unrestricted
roles would show up as if they were directly granted to the user
(due to thge way the `UserPermissions.merge` happens in the
`RedisPermissionRepository`) and eventually the resources protected
by unrestricted roles would show up.