### PR TITLE
fix(authorization): canCreate should not return void

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -58,8 +58,8 @@ public interface FiatService {
    * @param resourceType The type of the resource
    * @param resource The resource to check
    */
-  @POST("/authorize/{userId}/{resourceType}")
-  void canCreate(
+  @POST("/authorize/canCreate/{userId}/{resourceType}")
+  Response canCreate(
       @Path("userId") String userId,
       @Path("resourceType") String resourceType,
       @Body Object resource);

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -58,7 +58,7 @@ public interface FiatService {
    * @param resourceType The type of the resource
    * @param resource The resource to check
    */
-  @POST("/authorize/canCreate/{userId}/{resourceType}")
+  @POST("/authorize/{userId}/{resourceType}/create")
   Response canCreate(
       @Path("userId") String userId,
       @Path("resourceType") String resourceType,

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -188,7 +188,7 @@ public class AuthorizeController {
     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
   }
 
-  @RequestMapping(value = "canCreate/{userId:.+}/{resourceType:.+}", method = RequestMethod.POST)
+  @RequestMapping(value = "/{userId:.+}/{resourceType:.+}/create", method = RequestMethod.POST)
   public void canCreate(
       @PathVariable String userId,
       @PathVariable String resourceType,

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -188,7 +188,7 @@ public class AuthorizeController {
     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
   }
 
-  @RequestMapping(value = "/{userId:.+}/{resourceType:.+}", method = RequestMethod.POST)
+  @RequestMapping(value = "canCreate/{userId:.+}/{resourceType:.+}", method = RequestMethod.POST)
   public void canCreate(
       @PathVariable String userId,
       @PathVariable String resourceType,


### PR DESCRIPTION
Retrofit methods cannot have a `void` return type. We either need to provide a return type, or a callback. This fixes the following exception:
```
java.lang.IllegalArgumentException: FiatService.canCreate: Must have either a return type or Callback as last argument.
```

I also added `canCreate` to the path, because it makes more sense.