### PR TITLE
fix(roles): file-based roles fail when the user is not provided in the file

### DIFF
--- a/fiat-file/src/main/java/com/netflix/spinnaker/fiat/roles/file/FileBasedUserRolesProvider.java
+++ b/fiat-file/src/main/java/com/netflix/spinnaker/fiat/roles/file/FileBasedUserRolesProvider.java
@@ -26,11 +26,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -59,7 +55,7 @@ public class FileBasedUserRolesProvider implements UserRolesProvider {
   @Override
   public List<Role> loadRoles(ExternalUser user) {
     try {
-      return new ArrayList<>(parse().get(user.getId()));
+      return Optional.ofNullable(parse().get(user.getId())).orElse(Collections.emptyList());
     } catch (IOException io) {
       log.error("Couldn't load roles for user " + user.getId() + " from file", io);
     }

--- a/fiat-file/src/test/groovy/com/netflix/spinnaker/fiat/roles/file/FileBasedUserRolesProviderSpec.groovy
+++ b/fiat-file/src/test/groovy/com/netflix/spinnaker/fiat/roles/file/FileBasedUserRolesProviderSpec.groovy
@@ -33,20 +33,24 @@ class FileBasedUserRolesProviderSpec extends Specification {
     when:
     def result1 = provider.loadRoles(externalUser("batman"))
     def result2 = provider.loadRoles(externalUser("foo"))
+    def result3 = provider.loadRoles(externalUser("spiderman"))
 
     then:
     result1.name.containsAll(["crimefighter", "jokerjailer"])
     result2.name.containsAll(["bar", "baz"])
+    result3 == []
 
     when:
-    def result3 = provider.multiLoadRoles([externalUser("batman")])
-    def result4 = provider.multiLoadRoles([externalUser("batman"), externalUser("foo")])
+    def result4 = provider.multiLoadRoles([externalUser("batman")])
+    def result5 = provider.multiLoadRoles([externalUser("batman"), externalUser("foo")])
+    def result6 = provider.multiLoadRoles([externalUser("spiderman")])
 
     then:
-    result3.containsKey("batman")
-    !result3.containsKey("foo")
+    result4.containsKey("batman")
+    !result4.containsKey("foo")
 
-    result4.keySet().containsAll("batman", "foo")
+    result5.keySet().containsAll("batman", "foo")
+    result6.keySet().size() == 0
   }
 
   private static ExternalUser externalUser(String id) {


### PR DESCRIPTION
When calling `loadRoles` of file-based roles. I am faced with a `NullPointerException` if the user is not defined in the file. I fixed this to return an empty list instead.

This is a valid use-case for implementations that use external roles (SAML for example), but want to provide specific roles for some users. 