### PR TITLE
fix(serviceAccount): Filter non-valid roles when converting to UserPermission

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -22,6 +22,7 @@ import javax.annotation.Nonnull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Data
 @EqualsAndHashCode(of = "name")
@@ -46,7 +47,7 @@ public class Role implements Resource, Viewable {
   }
 
   public Role setName(@Nonnull String name) {
-    if (name.isEmpty()) {
+    if (!StringUtils.hasText(name)) {
       throw new IllegalArgumentException("name cannot be empty");
     }
     this.name = name.toLowerCase();

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
@@ -26,6 +26,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import org.springframework.util.StringUtils;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -38,6 +39,7 @@ public class ServiceAccount implements Resource, Viewable {
   public UserPermission toUserPermission() {
     val roles =
         memberOf.stream()
+            .filter(StringUtils::hasText)
             .map(membership -> new Role(membership).setSource(Role.Source.EXTERNAL))
             .collect(Collectors.toSet());
     return new UserPermission().setId(name).setRoles(roles);

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ServiceAccountSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/ServiceAccountSpec.groovy
@@ -20,10 +20,10 @@ import spock.lang.Specification
 
 class ServiceAccountSpec extends Specification {
 
-  def 'should convert to UserPermission'() {
+  def 'should convert to UserPermission, filtering non-text strings'() {
     setup:
     ServiceAccount acct = new ServiceAccount().setName("my-svc-acct")
-                                              .setMemberOf(["foo", "bar"])
+                                              .setMemberOf(["foo", "bar", "", "   "])
 
     when:
     def result = acct.toUserPermission()


### PR DESCRIPTION
Roles can't be empty. This leads to unexpected behaviour. However, we
were allowing creating empty roles like "" or "   " on the pipeline
triggers (via API), which made service users to contain invalid roles
and thus failing on every sync request that tries to map roles to accounts.
This rendered FIAT unusable to get permissions and subsequently not
allowing any authorization operation.

This patch sanitizes the input on ServiceAccounts so we make sure
that the roles considered are valid.