### PR TITLE
fix(permissionSource): Set order (lowest precedence) on default permission sources

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
@@ -27,12 +27,12 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-public final class Front50ApplicationResourcePermissionSource
+public final class ApplicationResourcePermissionSource
     implements ResourcePermissionSource<Application> {
 
   private final Authorization executeFallback;
 
-  public Front50ApplicationResourcePermissionSource(Authorization executeFallback) {
+  public ApplicationResourcePermissionSource(Authorization executeFallback) {
     this.executeFallback = executeFallback;
   }
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -34,7 +34,7 @@ class DefaultApplicationProviderSpec extends Specification {
 
   ClouddriverService clouddriverService = Mock(ClouddriverService)
   Front50Service front50Service = Mock(Front50Service)
-  ResourcePermissionProvider<Application> defaultProvider = new AggregatingResourcePermissionProvider<>([new Front50ApplicationResourcePermissionSource(Authorization.READ)])
+  ResourcePermissionProvider<Application> defaultProvider = new AggregatingResourcePermissionProvider<>([new ApplicationResourcePermissionSource(Authorization.READ)])
 
   @Subject DefaultApplicationResourceProvider provider
 
@@ -114,7 +114,7 @@ class DefaultApplicationProviderSpec extends Specification {
   def "should add fallback execute permissions based on executeFallback value" () {
     setup:
     def app = new Application().setName("app")
-    def provider = new AggregatingResourcePermissionProvider([new Front50ApplicationResourcePermissionSource(fallback)])
+    def provider = new AggregatingResourcePermissionProvider([new ApplicationResourcePermissionSource(fallback)])
 
     when:
     app.setPermissions(makePerms(givenPermissions))

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/AggregateResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/AggregateResourcePermissionConfig.java
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.BuildService;
+import com.netflix.spinnaker.fiat.providers.AggregatingResourcePermissionProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionSource;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AggregateResourcePermissionConfig {
+
+  @Bean
+  @ConditionalOnProperty(value = "auth.permissions.provider.account", havingValue = "aggregate")
+  public ResourcePermissionProvider<Account> aggregateAccountPermissionProvider(
+      List<ResourcePermissionSource<Account>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = "auth.permissions.provider.application", havingValue = "aggregate")
+  public ResourcePermissionProvider<Application> aggregateApplicationPermissionProvider(
+      List<ResourcePermissionSource<Application>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.build-service",
+      havingValue = "aggregate")
+  public ResourcePermissionProvider<BuildService> aggregateBuildServicePermissionProvider(
+      List<ResourcePermissionSource<BuildService>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.BuildService;
 import com.netflix.spinnaker.fiat.providers.*;
-import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 @Configuration
 class DefaultResourcePermissionConfig {
@@ -33,6 +33,7 @@ class DefaultResourcePermissionConfig {
   @ConditionalOnProperty(
       value = "auth.permissions.source.account.resource.enabled",
       matchIfMissing = true)
+  @Order
   ResourcePermissionSource<Account> accountResourcePermissionSource() {
     return new AccessControlledResourcePermissionSource<>();
   }
@@ -48,26 +49,13 @@ class DefaultResourcePermissionConfig {
   }
 
   @Bean
-  @ConditionalOnProperty(value = "auth.permissions.provider.account", havingValue = "aggregate")
-  public ResourcePermissionProvider<Account> aggregateAccountPermissionProvider(
-      List<ResourcePermissionSource<Account>> sources) {
-    return new AggregatingResourcePermissionProvider<>(sources);
-  }
-
-  @Bean
-  @ConditionalOnProperty("auth.permissions.source.application.prefix.enabled")
-  @ConfigurationProperties("auth.permissions.source.application.prefix")
-  ResourcePermissionSource<Application> applicationPrefixResourcePermissionSource() {
-    return new ResourcePrefixPermissionSource<Application>();
-  }
-
-  @Bean
   @ConditionalOnProperty(
-      value = "auth.permissions.source.application.front50.enabled",
+      value = "auth.permissions.source.application.resource.enabled",
       matchIfMissing = true)
-  ResourcePermissionSource<Application> front50ResourcePermissionSource(
+  @Order
+  ResourcePermissionSource<Application> applicationResourcePermissionSource(
       FiatServerConfigurationProperties fiatServerConfigurationProperties) {
-    return new Front50ApplicationResourcePermissionSource(
+    return new ApplicationResourcePermissionSource(
         fiatServerConfigurationProperties.getExecuteFallback());
   }
 
@@ -77,21 +65,15 @@ class DefaultResourcePermissionConfig {
       havingValue = "default",
       matchIfMissing = true)
   public ResourcePermissionProvider<Application> defaultApplicationPermissionProvider(
-      ResourcePermissionSource<Application> front50ResourcePermissionSource) {
-    return new DefaultResourcePermissionProvider<>(front50ResourcePermissionSource);
-  }
-
-  @Bean
-  @ConditionalOnProperty(value = "auth.permissions.provider.application", havingValue = "aggregate")
-  public ResourcePermissionProvider<Application> aggregateApplicationPermissionProvider(
-      List<ResourcePermissionSource<Application>> sources) {
-    return new AggregatingResourcePermissionProvider<>(sources);
+      ResourcePermissionSource<Application> applicationResourcePermissionSource) {
+    return new DefaultResourcePermissionProvider<>(applicationResourcePermissionSource);
   }
 
   @Bean
   @ConditionalOnProperty(
       value = "auth.permissions.source.build-service.resource.enabled",
       matchIfMissing = true)
+  @Order
   ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource() {
     return new AccessControlledResourcePermissionSource<>();
   }
@@ -107,11 +89,9 @@ class DefaultResourcePermissionConfig {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      value = "auth.permissions.provider.build-service",
-      havingValue = "aggregate")
-  public ResourcePermissionProvider<BuildService> aggregateBuildServicePermissionProvider(
-      List<ResourcePermissionSource<BuildService>> sources) {
-    return new AggregatingResourcePermissionProvider<>(sources);
+  @ConditionalOnProperty("auth.permissions.source.application.prefix.enabled")
+  @ConfigurationProperties("auth.permissions.source.application.prefix")
+  ResourcePermissionSource<Application> applicationPrefixResourcePermissionSource() {
+    return new ResourcePrefixPermissionSource<Application>();
   }
 }


### PR DESCRIPTION
Additionally, rename Front50ApplicationResourcePermissionSource to ApplicationResourcePermissionSource and adjust config accordingly.

This way, if default permission source objects contain logic then they will operate after any logic contained in an aggregate permission source (if order is specified correctly).

Specifically, we want to process `EXECUTE` permissions last in the chain of aggregate permission sources since if a resource is missing `EXECUTE` permissions it falls back to the configured permission type (defaults to `READ`).
