### PR TITLE
refactor(fallback): Add FallbackPermissionsResolver and default implementation

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.fiat.permissions;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+public class DefaultFallbackPermissionsResolver implements FallbackPermissionsResolver {
+
+  private final Authorization fallbackFrom;
+  private final Authorization fallbackTo;
+
+  public DefaultFallbackPermissionsResolver(Authorization fallbackFrom, Authorization fallbackTo) {
+    this.fallbackFrom = fallbackFrom;
+    this.fallbackTo = fallbackTo;
+  }
+
+  @Override
+  public boolean shouldResolve(@Nonnull Permissions permissions) {
+    return permissions.isRestricted() && unpackPermissions(permissions).get(fallbackFrom).isEmpty();
+  }
+
+  @Override
+  public Permissions resolve(@Nonnull Permissions permissions) {
+    Map<Authorization, List<String>> authorizations = unpackPermissions(permissions);
+    authorizations.put(fallbackFrom, authorizations.get(fallbackTo));
+    return Permissions.Builder.factory(authorizations).build();
+  }
+
+  private Map<Authorization, List<String>> unpackPermissions(Permissions permissions) {
+    return Arrays.stream(Authorization.values()).collect(toMap(identity(), permissions::get));
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/FallbackPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/FallbackPermissionsResolver.java
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.fiat.permissions;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import javax.annotation.Nonnull;
+
+/**
+ * Resolve permissions. This is useful if you do not have a way to configure a particular permission
+ * and so want to apply one permission group type to another.
+ */
+public interface FallbackPermissionsResolver {
+
+  /**
+   * Determine if resolving fallback permissions is necessary - typically checking if permissions
+   * are restricted.
+   *
+   * @param permissions
+   * @return boolean
+   */
+  boolean shouldResolve(@Nonnull Permissions permissions);
+
+  /**
+   * Resolve fallback permissions.
+   *
+   * @param permissions
+   * @return The resolved Permissions
+   */
+  Permissions resolve(@Nonnull Permissions permissions);
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 
 /**
  * AggregatingResourcePermissionProvider additively combines permissions from all
- * ResourcePermissionSources to build a resulting Permission object.
+ * ResourcePermissionSources to build a resulting Permissions object.
  *
  * @param <T> the type of Resource for this AggregatingResourcePermissionProvider
  */

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
@@ -30,12 +30,6 @@ import javax.annotation.Nonnull;
 public final class ApplicationResourcePermissionSource
     implements ResourcePermissionSource<Application> {
 
-  private final Authorization executeFallback;
-
-  public ApplicationResourcePermissionSource(Authorization executeFallback) {
-    this.executeFallback = executeFallback;
-  }
-
   @Override
   @Nonnull
   public Permissions getPermissions(@Nonnull Application resource) {
@@ -46,12 +40,6 @@ public final class ApplicationResourcePermissionSource
 
     Map<Authorization, List<String>> authorizations =
         Arrays.stream(Authorization.values()).collect(toMap(identity(), storedPermissions::get));
-
-    // If the execute permission wasn't set, copy the permissions from whatever is specified in the
-    // config's executeFallback flag
-    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
-      authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
-    }
 
     // CREATE permissions are not allowed on the resource level.
     authorizations.remove(Authorization.CREATE);

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolverSpec.groovy
@@ -1,0 +1,36 @@
+package com.netflix.spinnaker.fiat.permissions
+
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.resources.Permissions
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultFallbackPermissionsResolverSpec extends Specification {
+    private static final Authorization R = Authorization.READ
+    private static final Authorization W = Authorization.WRITE
+    private static final Authorization E = Authorization.EXECUTE
+    private static final Authorization C = Authorization.CREATE
+
+    def makePerms(Map<Authorization, List<String>> auths) {
+        return Permissions.Builder.factory(auths).build()
+    }
+
+    @Unroll
+    def "should add fallback permissions based on fallbackTo value" () {
+        setup:
+        FallbackPermissionsResolver fallbackResolver = new DefaultFallbackPermissionsResolver(fallbackFrom, fallbackTo)
+
+        when:
+        def result = fallbackResolver.resolve(makePerms(givenPermissions))
+
+        then:
+        makePerms(expectedPermissions) == result
+
+        where:
+        fallbackFrom  ||  fallbackTo  || givenPermissions         || expectedPermissions
+        E             ||  R           || [:]                      || [:]
+        E             ||  R           || [(R): ['r']]             || [(R): ['r'], (E): ['r']]
+        E             ||  W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
+        C             ||  W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (C): ['w']]
+    }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -53,10 +53,8 @@ class DefaultResourcePermissionConfig {
       value = "auth.permissions.source.application.resource.enabled",
       matchIfMissing = true)
   @Order
-  ResourcePermissionSource<Application> applicationResourcePermissionSource(
-      FiatServerConfigurationProperties fiatServerConfigurationProperties) {
-    return new ApplicationResourcePermissionSource(
-        fiatServerConfigurationProperties.getExecuteFallback());
+  ResourcePermissionSource<Application> applicationResourcePermissionSource() {
+    return new ApplicationResourcePermissionSource();
   }
 
   @Bean

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -2,9 +2,12 @@ package com.netflix.spinnaker.fiat.config;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.permissions.DefaultFallbackPermissionsResolver;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
+import com.netflix.spinnaker.fiat.permissions.FallbackPermissionsResolver;
 import com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider;
 import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
@@ -74,12 +77,21 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
       Front50Service front50Service,
       ClouddriverService clouddriverService,
       ResourcePermissionProvider<Application> permissionProvider,
+      FallbackPermissionsResolver executeFallbackPermissionsResolver,
       FiatServerConfigurationProperties properties) {
     return new DefaultApplicationResourceProvider(
         front50Service,
         clouddriverService,
         permissionProvider,
+        executeFallbackPermissionsResolver,
         properties.isAllowAccessToUnknownApplications());
+  }
+
+  @Bean
+  DefaultFallbackPermissionsResolver executeFallbackPermissionsResolver(
+      FiatServerConfigurationProperties properties) {
+    return new DefaultFallbackPermissionsResolver(
+        Authorization.EXECUTE, properties.getExecuteFallback());
   }
 
   /**


### PR DESCRIPTION
I misread the logic for the aggregate permissions resolver - we will need to resolve fallback permissions after everything has been built up.  I tried to do this in a way that would allow us to configure other fallback resolvers if need be.