### PR TITLE
chore(log): Log request method, URI, and exception in FiatAccessDeniedExceptionHandler

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandler.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandler.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.StringJoiner;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class FiatAccessDeniedExceptionHandler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes();
 
@@ -36,6 +39,13 @@ public class FiatAccessDeniedExceptionHandler {
       AccessDeniedException e, HttpServletResponse response, HttpServletRequest request)
       throws IOException {
     storeException(request, response, e);
+
+    log.error(
+        "Encountered exception while processing request {}:{}",
+        request.getMethod(),
+        request.getRequestURI(),
+        e);
+
     String errorMessage =
         FiatPermissionEvaluator.getAuthorizationFailure()
             .map(this::authorizationFailureMessage)


### PR DESCRIPTION
Because this is often the only AccessDeniedException handler registered in services, it can be difficult to know exactly what caused the exception.  This should help.
