### PR TITLE
fix(metrics-logs): Record permissionsCache caffeine metrics with CaffeineStatsCounter and add debug log when access denied to accounts

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "com.netflix.spinnaker.kork:kork-telemetry"
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"


### PR DESCRIPTION
Debugging an intermittent access denied error to accounts.  CaffeineStatsCounter pushes cache metrics to the registry and the debug log might give us a bit more insight.
