### PR TITLE
fix(redis): only remove a key if it wouldn't be overwritten

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -130,12 +130,13 @@ public class RedisPermissionsRepository implements PermissionsRepository {
 
             for (ResourceType r : ResourceType.values()) {
               String userResourceKey = userKey(userId, r);
-
-              pipeline.del(userResourceKey);
-
               Map<String, String> redisValue = resourceTypeToRedisValue.get(r);
+              String tempKey = UUID.randomUUID().toString();
               if (redisValue != null && !redisValue.isEmpty()) {
-                pipeline.hmset(userResourceKey, redisValue);
+                pipeline.hmset(tempKey, redisValue);
+                pipeline.rename(tempKey, userResourceKey);
+              } else {
+                pipeline.del(userResourceKey);
               }
             }
             pipeline.sync();


### PR DESCRIPTION
Fixes a potential race condition persisting user permissions where previously we would
remove the entire set of permissions for a resource, then write the current set. This
changes to only remove the permissions if the updated UserPermission is empty for that
resource type, so that an API request to load that UserPermission that overlaps with
a refresh of the UserPermission in redis doesn't get less data than it should