### PR TITLE
fix(ci): remove 'javadoc' from PR build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew build 


### PR DESCRIPTION
The equivalent Travis CI build wasn't running it.
