### PR TITLE
feat(chaos-monkey): Add ChaosMonkeyResourcePermissionSource and switch fiat to pulling list of applications vs. list of application permissions from front50

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -16,8 +16,11 @@
 
 package com.netflix.spinnaker.fiat.model.resources;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.fiat.model.Authorization;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,6 +33,13 @@ public class Application extends BaseAccessControlled implements Viewable {
 
   private String name;
   private Permissions permissions = Permissions.EMPTY;
+
+  private Map<String, Object> details = new HashMap<>();
+
+  @JsonAnySetter
+  public void setDetails(String name, Object value) {
+    this.details.put(name, value);
+  }
 
   @JsonIgnore
   public View getView(Set<Role> userRoles, boolean isAdmin) {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyApplicationResourcePermissionSource.java
@@ -20,33 +20,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-public class ChaosMonkeyResourcePermissionSource<T extends Resource.AccessControlled>
-    implements ResourcePermissionSource<T> {
+public class ChaosMonkeyApplicationResourcePermissionSource
+    implements ResourcePermissionSource<Application> {
 
   private final List<String> roles;
   private final ObjectMapper objectMapper;
 
-  public ChaosMonkeyResourcePermissionSource(List<String> roles, ObjectMapper objectMapper) {
+  public ChaosMonkeyApplicationResourcePermissionSource(
+      List<String> roles, ObjectMapper objectMapper) {
     this.roles = roles;
     this.objectMapper = objectMapper;
   }
 
   @Nonnull
   @Override
-  public Permissions getPermissions(@Nonnull T resource) {
+  public Permissions getPermissions(@Nonnull Application application) {
     Permissions.Builder builder = new Permissions.Builder();
-    Permissions permissions = resource.getPermissions();
+    Permissions permissions = application.getPermissions();
 
     if (permissions.isRestricted()) {
-      if (resource instanceof Application) {
-        Application application = (Application) resource;
-        if (isChaosMonkeyEnabled(application)) {
-          builder.add(Authorization.READ, roles).add(Authorization.WRITE, roles).build();
-        }
+      if (isChaosMonkeyEnabled(application)) {
+        builder.add(Authorization.READ, roles).add(Authorization.WRITE, roles).build();
       }
     }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyResourcePermissionSource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public class ChaosMonkeyResourcePermissionSource<T extends Resource.AccessControlled>
+    implements ResourcePermissionSource<T> {
+
+  private final List<String> roles;
+  private final ObjectMapper objectMapper;
+
+  public ChaosMonkeyResourcePermissionSource(List<String> roles, ObjectMapper objectMapper) {
+    this.roles = roles;
+    this.objectMapper = objectMapper;
+  }
+
+  @Nonnull
+  @Override
+  public Permissions getPermissions(@Nonnull T resource) {
+    Permissions.Builder builder = new Permissions.Builder();
+    Permissions permissions = resource.getPermissions();
+
+    if (permissions.isRestricted()) {
+      if (resource instanceof Application) {
+        Application application = (Application) resource;
+        if (isChaosMonkeyEnabled(application)) {
+          builder.add(Authorization.READ, roles).add(Authorization.WRITE, roles).build();
+        }
+      }
+    }
+
+    return builder.build();
+  }
+
+  protected boolean isChaosMonkeyEnabled(Application application) {
+    Object config = application.getDetails().get("chaosMonkey");
+    if (config == null) {
+      return false;
+    }
+    return objectMapper.convertValue(config, ChaosMonkeyConfig.class).enabled;
+  }
+
+  private static class ChaosMonkeyConfig {
+    public boolean enabled;
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -71,7 +71,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   @Override
   protected Set<Application> loadAll() throws ProviderException {
     try {
-      List<Application> front50Applications = front50Service.getAllApplicationPermissions();
+      List<Application> front50Applications = front50Service.getAllApplications();
       List<Application> clouddriverApplications = clouddriverService.getApplications();
 
       // Stream front50 first so that if there's a name collision, we'll keep that one instead of

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Api.java
@@ -25,6 +25,9 @@ public interface Front50Api {
   @GET("/permissions/applications")
   List<Application> getAllApplicationPermissions();
 
+  @GET("/v2/applications")
+  List<Application> getAllApplications();
+
   @GET("/serviceAccounts")
   List<ServiceAccount> getAllServiceAccounts();
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/Front50Service.java
@@ -52,12 +52,12 @@ public class Front50Service implements HealthTrackable, InitializingBean {
     refreshCache();
   }
 
-  public List<Application> getAllApplicationPermissions() {
+  public List<Application> getAllApplications() {
     return new SimpleJava8HystrixCommand<>(
             GROUP_KEY,
-            "getAllApplicationPermissions",
+            "getAllApplications",
             () -> {
-              applicationCache.set(allowAnonymous(front50Api::getAllApplicationPermissions));
+              applicationCache.set(allowAnonymous(front50Api::getAllApplications));
               healthTracker.success();
               return applicationCache.get();
             },
@@ -101,7 +101,7 @@ public class Front50Service implements HealthTrackable, InitializingBean {
   private void refreshCache() {
     try {
       // Initialize caches (also indicates service is healthy)
-      getAllApplicationPermissions();
+      getAllApplications();
       getAllServiceAccounts();
     } catch (Exception e) {
       log.warn("Cache prime failed: ", e);

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -97,7 +97,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.hgetAll("unittests:permissions:testUser:accounts") ==
         ['account': /{"name":"account","permissions":$EMPTY_PERM_JSON}/.toString()]
     jedis.hgetAll("unittests:permissions:testUser:applications") ==
-        ['app': /{"name":"app","permissions":$EMPTY_PERM_JSON}/.toString()]
+        ['app': /{"name":"app","permissions":$EMPTY_PERM_JSON,"details":{}}/.toString()]
     jedis.hgetAll("unittests:permissions:testUser:service_accounts") ==
         ['serviceAccount': '{"name":"serviceAccount","memberOf":["role1"]}']
     jedis.hgetAll("unittests:permissions:testUser:roles") ==

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -49,7 +49,7 @@ class DefaultApplicationProviderSpec extends Specification {
   def "should #action applications with empty permissions when allowAccessToUnknownApplications = #allowAccessToUnknownApplications"() {
     setup:
     Front50Service front50Service = Mock(Front50Service) {
-      getAllApplicationPermissions() >> [
+      getAllApplications() >> [
           new Application().setName("onlyKnownToFront50"),
           new Application().setName("app1")
                            .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
@@ -99,7 +99,7 @@ class DefaultApplicationProviderSpec extends Specification {
     def resultApps = provider.getAll()
 
     then:
-    1 * front50Service.getAllApplicationPermissions() >> [app]
+    1 * front50Service.getAllApplications() >> [app]
     1 * clouddriverService.getApplications() >> []
 
     resultApps.size() == 1
@@ -125,7 +125,7 @@ class DefaultApplicationProviderSpec extends Specification {
     def resultApps = provider.getAll()
 
     then:
-    1 * front50Service.getAllApplicationPermissions() >> [app]
+    1 * front50Service.getAllApplications() >> [app]
     1 * clouddriverService.getApplications() >> []
 
     resultApps.size() == 1

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -98,7 +98,7 @@ class DefaultResourcePermissionConfig {
   @ConditionalOnProperty(value = "auth.permissions.source.application.chaos-monkey.enabled")
   public ResourcePermissionSource<Application> chaosMonkeyApplicationResourcePermissionSource(
       ObjectMapper objectMapper, FiatServerConfigurationProperties configurationProperties) {
-    return new ChaosMonkeyResourcePermissionSource<>(
+    return new ChaosMonkeyApplicationResourcePermissionSource(
         configurationProperties.getChaosMonkey().getRoles(), objectMapper);
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.BuildService;
@@ -91,5 +92,13 @@ class DefaultResourcePermissionConfig {
   @ConfigurationProperties("auth.permissions.source.application.prefix")
   ResourcePermissionSource<Application> applicationPrefixResourcePermissionSource() {
     return new ResourcePrefixPermissionSource<Application>();
+  }
+
+  @Bean
+  @ConditionalOnProperty(value = "auth.permissions.source.application.chaos-monkey.enabled")
+  public ResourcePermissionSource<Application> chaosMonkeyApplicationResourcePermissionSource(
+      ObjectMapper objectMapper, FiatServerConfigurationProperties configurationProperties) {
+    return new ChaosMonkeyResourcePermissionSource<>(
+        configurationProperties.getChaosMonkey().getRoles(), objectMapper);
   }
 }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -17,8 +17,11 @@
 package com.netflix.spinnaker.fiat.config;
 
 import com.netflix.spinnaker.fiat.model.Authorization;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @Data
 @ConfigurationProperties("fiat")
@@ -36,6 +39,14 @@ public class FiatServerConfigurationProperties {
   private boolean restrictApplicationCreation = false;
 
   private WriteMode writeMode = new WriteMode();
+
+  @NestedConfigurationProperty
+  private ChaosMonkeyConfigurationProperties chaosMonkey = new ChaosMonkeyConfigurationProperties();
+
+  @Data
+  static class ChaosMonkeyConfigurationProperties {
+    private List<String> roles = new ArrayList<>();
+  }
 
   @Data
   static class WriteMode {

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -71,7 +71,7 @@ class RolesControllerSpec extends Specification {
   def "should put user in the repo"() {
     setup:
     stubFront50Service.getAllServiceAccounts() >> []
-    stubFront50Service.getAllApplicationPermissions() >> [unrestrictedApp, restrictedApp]
+    stubFront50Service.getAllApplications() >> [unrestrictedApp, restrictedApp]
     stubClouddriverService.getAccounts() >> [unrestrictedAccount, restrictedAccount]
     stubIgorService.allBuildServices >> []
 
@@ -120,7 +120,7 @@ class RolesControllerSpec extends Specification {
     mockMvc.perform(put("/roles/expectedError").content('["batman"]')).andExpect(status().is5xxServerError())
 
     then:
-    stubFront50Service.getAllApplicationPermissions() >> {
+    stubFront50Service.getAllApplications() >> {
       throw RetrofitError.networkError("test1", new IOException("test2"))
     }
 


### PR DESCRIPTION
This is riffing off an idea @cfieber had regarding using Fiat as a source of permission policies.

Listing all Applications from front50 (as opposed to listing all application permissions) allows us to use application configuration to apply a permissions policy.  In this case, add the chaos monkey roles to READ and WRITE authorizations if the application config has chaos monkey enabled.  

Logically, this is far simpler than what currently exists in Front50 (see https://github.com/spinnaker/front50/tree/master/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners) as, since the role is not stored in the application configs permissions in front50, there is far less logic that needs to be applied to determine when to add/remove the role so as not to lock people out of their applications.