### PR TITLE
chore(compile): switch to the openjdk container

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,12 +1,5 @@
-FROM ubuntu:eoan
+FROM openjdk:8
 MAINTAINER sig-platform@spinnaker.io
-
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get install -y \
-        openjdk-8-jdk-headless \
-    && apt-get clean
-
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx2048m
 CMD ./gradlew --no-daemon fiat-web:installDist -x test


### PR DESCRIPTION
I missed this one apparently when I was switching them all in response
to a code review comment.