### PR TITLE
fix(applications): (2nd PR) Do not apply permissions when building the internal model of apps

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -71,7 +71,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   @Override
   protected Set<Application> loadAll() throws ProviderException {
     try {
-      List<Application> front50Applications = front50Service.getAllApplications(true);
+      List<Application> front50Applications = front50Service.getAllApplications(false);
       List<Application> clouddriverApplications = clouddriverService.getApplications();
 
       // Stream front50 first so that if there's a name collision, we'll keep that one instead of

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -49,7 +49,7 @@ class DefaultApplicationProviderSpec extends Specification {
   def "should #action applications with empty permissions when allowAccessToUnknownApplications = #allowAccessToUnknownApplications"() {
     setup:
     Front50Service front50Service = Mock(Front50Service) {
-      getAllApplications(true) >> [
+      getAllApplications(false) >> [
           new Application().setName("onlyKnownToFront50"),
           new Application().setName("app1")
                            .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
@@ -99,7 +99,7 @@ class DefaultApplicationProviderSpec extends Specification {
     def resultApps = provider.getAll()
 
     then:
-    1 * front50Service.getAllApplications(true) >> [app]
+    1 * front50Service.getAllApplications(false) >> [app]
     1 * clouddriverService.getApplications() >> []
 
     resultApps.size() == 1
@@ -125,7 +125,7 @@ class DefaultApplicationProviderSpec extends Specification {
     def resultApps = provider.getAll()
 
     then:
-    1 * front50Service.getAllApplications(true) >> [app]
+    1 * front50Service.getAllApplications(false) >> [app]
     1 * clouddriverService.getApplications() >> []
 
     resultApps.size() == 1

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -71,7 +71,7 @@ class RolesControllerSpec extends Specification {
   def "should put user in the repo"() {
     setup:
     stubFront50Service.getAllServiceAccounts() >> []
-    stubFront50Service.getAllApplications(true) >> [unrestrictedApp, restrictedApp]
+    stubFront50Service.getAllApplications(false) >> [unrestrictedApp, restrictedApp]
     stubClouddriverService.getAccounts() >> [unrestrictedAccount, restrictedAccount]
     stubIgorService.allBuildServices >> []
 
@@ -120,7 +120,7 @@ class RolesControllerSpec extends Specification {
     mockMvc.perform(put("/roles/expectedError").content('["batman"]')).andExpect(status().is5xxServerError())
 
     then:
-    stubFront50Service.getAllApplications(true) >> {
+    stubFront50Service.getAllApplications(false) >> {
       throw RetrofitError.networkError("test1", new IOException("test2"))
     }
 


### PR DESCRIPTION
This PR completes a small detail that was left over from PR https://github.com/spinnaker/fiat/pull/564 (it was actually merged, even tho shows as closed).

When FIAT requests "all applications" from front50, it actually wants them all - fiat will then apply any "filtering" due to restrictions. That's fiat's job, right? 😅 