### PR TITLE
fix(decode): Remove duplicate url decoder in ControllerSupport

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ControllerSupport.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ControllerSupport.java
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.fiat.controllers;
 
 import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -27,15 +25,9 @@ public class ControllerSupport {
   static final String ANONYMOUS_USER = "anonymous";
 
   static String convert(String in) {
-    try {
-      String decoded = URLDecoder.decode(in, "UTF-8");
-      if (ANONYMOUS_USER.equalsIgnoreCase(decoded)) {
-        return UnrestrictedResourceConfig.UNRESTRICTED_USERNAME;
-      }
-      return decoded;
-    } catch (UnsupportedEncodingException uee) {
-      log.error("Decoding exception for string " + in, uee);
+    if (ANONYMOUS_USER.equalsIgnoreCase(in)) {
+      return UnrestrictedResourceConfig.UNRESTRICTED_USERNAME;
     }
-    return null;
+    return in;
   }
 }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -175,14 +175,14 @@ class AuthorizeControllerSpec extends Specification {
     def foo = new UserPermission().setId("foo@batman.com")
 
     when:
-    controller.getUserPermission("foo%40batman.com")
+    controller.getUserPermission("foo@batman.com")
 
     then:
     1 * repository.get("foo@batman.com") >> Optional.empty()
     thrown NotFoundException
 
     when:
-    def result = controller.getUserPermission("foo%40batman.com")
+    def result = controller.getUserPermission("foo@batman.com")
 
     then:
     1 * repository.get("foo@batman.com") >> Optional.of(foo)


### PR DESCRIPTION
A call to decode the input is not necessary since Spring decodes the path variable input by default.  See Spring's RequestMappingHandlerMapping and UrlPathHelper.  For example, a call to
fiat `/authorize/some%2Buser%40example.com` is properly decoded as `some+user@example.com` by Spring, but then decoded again via `ControllerSupport` -- the result is `some user@example.com`.  This can, in certain scenarios, cause authorization lookups to return a 404.