### PR TITLE
chore(build): Break fiat bump dependencies out into separate workflow

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -1,0 +1,29 @@
+name: Bump Dependencies
+
+on:
+  repository_dispatch:
+    types: [bump-dependencies]
+
+jobs:
+  bump-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Bump dependencies
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          SPINNAKER_GITHUB_TOKEN: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
+          GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
+        run: |
+          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" -Pgithub.token="${SPINNAKER_GITHUB_TOKEN}" bumpDependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,10 @@ jobs:
             ${{ steps.release_info.outputs.CHANGELOG }}
            draft: false
            prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
-      - name: Bump dependencies
-        env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          SPINNAKER_GITHUB_TOKEN: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
-          GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: |
-          sleep 90
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" -Pgithub.token="${SPINNAKER_GITHUB_TOKEN}" bumpDependencies
+      - name: Pause before dependency bump
+        run: sleep 90
+      - name: Trigger dependency bump workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
+          event-type: bump-dependencies


### PR DESCRIPTION
Exact same as https://github.com/spinnaker/kork/pull/567