### PR TITLE
chore(java11): compile with Java 11 (but using -source 8 -target 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - run: git fetch --prune --unshallow
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:11
 MAINTAINER sig-platform@spinnaker.io
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx2048m


### PR DESCRIPTION
Verified (with `javap`) that generated `*.class` files use Java 8 bytecodes.