### PR TITLE
fix(permissions): update order annotation on sources

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ProviderCacheConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.fiat.config;
 
+import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -24,6 +25,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ProviderCacheConfig {
 
   private int expiresAfterWriteSeconds = 20;
+
+  private Duration refreshInterval = Duration.ofSeconds(15);
 
   private long maximumStalenessTimeMs = Long.MAX_VALUE;
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
@@ -18,7 +18,7 @@ public class DefaultFallbackPermissionsResolver implements FallbackPermissionsRe
 
   @Override
   public boolean shouldResolve(@Nonnull Permissions permissions) {
-    return permissions.isRestricted() && permissions.unpack().get(fallbackFrom).isEmpty();
+    return permissions.isRestricted() && permissions.get(fallbackFrom).isEmpty();
   }
 
   @Override

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 
 @Slf4j
 public abstract class BaseResourceProvider<R extends Resource> implements ResourceProvider<R> {
@@ -84,6 +85,12 @@ public abstract class BaseResourceProvider<R extends Resource> implements Resour
         .expireAfterWrite(expireAfterWrite, TimeUnit.SECONDS)
         .maximumSize(1) // Using this cache loader just for the ability to refresh every X seconds.
         .build();
+  }
+
+  @Scheduled(fixedRateString = "${fiat.cache.refresh-interval:PT15S}")
+  public void reloadCache() {
+    Set<R> data = loadAll();
+    cache.put(CACHE_KEY, data);
   }
 
   public void clearCache() {

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
 @Configuration
@@ -34,7 +35,7 @@ class DefaultResourcePermissionConfig {
   @ConditionalOnProperty(
       value = "auth.permissions.source.account.resource.enabled",
       matchIfMissing = true)
-  @Order
+  @Order(Ordered.HIGHEST_PRECEDENCE + 100)
   ResourcePermissionSource<Account> accountResourcePermissionSource() {
     return new AccessControlledResourcePermissionSource<>();
   }
@@ -53,7 +54,7 @@ class DefaultResourcePermissionConfig {
   @ConditionalOnProperty(
       value = "auth.permissions.source.application.resource.enabled",
       matchIfMissing = true)
-  @Order
+  @Order(Ordered.HIGHEST_PRECEDENCE + 100)
   ResourcePermissionSource<Application> applicationResourcePermissionSource() {
     return new ApplicationResourcePermissionSource();
   }
@@ -72,7 +73,7 @@ class DefaultResourcePermissionConfig {
   @ConditionalOnProperty(
       value = "auth.permissions.source.build-service.resource.enabled",
       matchIfMissing = true)
-  @Order
+  @Order(Ordered.HIGHEST_PRECEDENCE + 100)
   ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource() {
     return new AccessControlledResourcePermissionSource<>();
   }
@@ -96,6 +97,7 @@ class DefaultResourcePermissionConfig {
 
   @Bean
   @ConditionalOnProperty(value = "auth.permissions.source.application.chaos-monkey.enabled")
+  @Order(Ordered.LOWEST_PRECEDENCE - 100)
   public ResourcePermissionSource<Application> chaosMonkeyApplicationResourcePermissionSource(
       ObjectMapper objectMapper, FiatServerConfigurationProperties configurationProperties) {
     return new ChaosMonkeyApplicationResourcePermissionSource(


### PR DESCRIPTION
ensure we read the base resource permission first so other permission sources that augment Permissions
are processed afterword

also adds a scheduled refresh to the BaseResourceProvider cache to ensure a user request doesn't hit
a cache expiration and have to wait for the cache reload