### PR TITLE
fix(plugins): add an option for strict plugin loading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Mon Mar 02 19:29:33 UTC 2020
 enablePublishing=false
 spinnakerGradleVersion=7.1.1
-korkVersion=7.25.1
+korkVersion=7.25.13
 org.gradle.parallel=true
 includeProviders=file,github,google-groups,ldap


### PR DESCRIPTION
This PR is part of a series of PRs for allowing relaxed plugin loading by adding a config option to turn strict plugin loading on or off. See https://docs.google.com/document/d/1yFDrpkCCV7Vp0wN0gDc9GTbTOBoIzNo-tGj1-vVjq04/edit?usp=sharing for more info