### PR TITLE
feat(serviceAccounts): enable loading full service account details for each users serviceAccount

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -132,8 +132,18 @@ public class AuthorizeController {
   }
 
   @RequestMapping(value = "/{userId:.+}/serviceAccounts", method = RequestMethod.GET)
-  public Set<ServiceAccount.View> getServiceAccounts(@PathVariable String userId) {
-    return new HashSet<>(getUserPermissionView(userId).getServiceAccounts());
+  public Set<? extends Viewable.BaseView> getServiceAccounts(
+      @PathVariable String userId,
+      @RequestParam(name = "expand", defaultValue = "false") boolean expand) {
+    Set<ServiceAccount.View> serviceAccounts = getUserPermissionView(userId).getServiceAccounts();
+    if (!expand) {
+      return serviceAccounts;
+    }
+
+    return serviceAccounts.stream()
+        .map(ServiceAccount.View::getName)
+        .map(this::getUserPermissionView)
+        .collect(Collectors.toSet());
   }
 
   @RequestMapping(


### PR DESCRIPTION
adds an expand query parameter to the /auth/:userId/serviceAccounts endpoint that returns each
serviceAccount as a userPermission to allow for contextual filtering

This will enable an endpoint in gate to filter user service accounts by application when populating
the run as user dropdown in the UI to only include service accounts relevant for the application
being configured