### PR TITLE
fix(applications): fix dedupe of front50 and clouddriver apps

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -79,7 +79,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
       // clouddriver version definitely won't)
       List<Application> applications =
           Streams.concat(front50Applications.stream(), clouddriverApplications.stream())
-              .filter(distinctByKey(Application::getName))
+              .filter(distinctByKey(a -> a.getName().toUpperCase()))
               // Collect to a list instead of set since we're about to modify the applications
               .collect(toImmutableList());
 


### PR DESCRIPTION
We were trying to dedupe on appname but each system presents them in a different case (front50 upper
clouddriver lower)