### PR TITLE
fix(java11): fix Stream#count() use under Java 11

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent;
 import com.netflix.spinnaker.kork.lock.LockManager;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -256,10 +257,9 @@ public class UserRolesSyncer implements ApplicationListener<RemoteStatusChangedE
       return 0;
     }
 
-    long count =
-        permissionsResolver.resolve(extUsers).values().stream()
-            .map(permission -> permissionsRepository.put(permission))
-            .count();
+    Collection<UserPermission> values = permissionsResolver.resolve(extUsers).values();
+    values.forEach(permissionsRepository::put);
+    long count = values.size();
     log.info("Synced {} non-anonymous user roles.", count);
     return count;
   }


### PR DESCRIPTION
Cherry-picking part of #630 to `release-1.19.x`

`UserRoleSyncer` was using `stream.map().count()` to run an operation on each element and then return the number of elements in the stream. But this doesn't work in Java 11 because "An implementation may choose to not execute the stream pipeline (either sequentially or in parallel) if it is capable of computing the count directly from the stream source." The Java 11 docs (unlike the Java 8 docs) [include an explicit example of this exact thing we're doing and why it doesn't work.](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#count())

Fixes spinnaker/spinanker#5466
Fixes spinnaker/spinnaker#5687