### PR TITLE
chore(bumpdeps): increase the pause before running bumpdeps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
            draft: false
            prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
       - name: Pause before dependency bump
-        run: sleep 90
+        run: sleep 300
       - name: Trigger dependency bump workflow
         uses: peter-evans/repository-dispatch@v1
         with:


### PR DESCRIPTION
90 seconds isn't long enough; often the artifacts don't show up in bintray yet. I had made this change previously, but I think it got accidentally overwritten in the migration to the new plugin.