### PR TITLE
fix(build): support nested composite builds

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,15 +23,19 @@ if (spinnakerGradleVersion.endsWith('-SNAPSHOT')) {
   }
 }
 
-['kork'].each { prj ->
-  String propName = "${prj}Composite"
-  String projectPath = "../$prj"
-  if (settings.ext.has(propName) && Boolean.parseBoolean(settings.ext.get(propName) as String)) {
-    includeBuild projectPath
+rootProject.name = "fiat"
+
+if (!settings.ext.has("${rootProject.name}Composite") ||
+     !Boolean.parseBoolean(settings.ext.get("${rootProject.name}Composite") as String)) {
+
+  ['kork'].each { prj ->
+    String propName = "${prj}Composite"
+    String projectPath = "../$prj"
+    if (settings.ext.has(propName) && Boolean.parseBoolean(settings.ext.get(propName) as String)) {
+      includeBuild projectPath
+    }
   }
 }
-
-rootProject.name="fiat"
 
 include 'fiat-api',
         'fiat-bom',


### PR DESCRIPTION
Following the composte build flags convention, this change
prevents including builds in this project if a flag exists
that would indicate this project is being included in a
composite build already.

If `<projectName>Composite` exists and is set to `true`,
then this project won't include any builds. The project
that has imported this project is responsible for build
inclusion.