### PR TITLE
fix(api): remove spring-boot-properties-migrator from fiat-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,6 @@ subprojects {
       testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
 
-      implementation "org.springframework.boot:spring-boot-properties-migrator"
-
       testImplementation "org.springframework.boot:spring-boot-starter-test"
       testImplementation "org.spockframework:spock-core"
       testImplementation "org.spockframework:spock-spring"

--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
+  implementation "org.springframework:spring-core"
 
   testImplementation "org.springframework.boot:spring-boot"
   testImplementation "com.fasterxml.jackson.core:jackson-databind"

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.okhttp:okhttp-apache"
 
+  implementation "org.springframework.boot:spring-boot-properties-migrator"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "com.netflix.spinnaker.kork:kork-core"


### PR DESCRIPTION
If we actually want this dependency, it only needs to live on the web application itself, it inspects config at runtime. This was ending up as a dependency of fiat-api and landing on all the places we autobump fiat-api to.