### PR TITLE
config(core): Move redis connection default to base config

### DIFF
--- a/fiat-web/config/fiat.yml
+++ b/fiat-web/config/fiat.yml
@@ -2,7 +2,7 @@ server:
   port: 7003
 
 redis:
-  connection: ${services.redis.connection:redis://localhost:6379}
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
 
 okHttpClient:
   retries:

--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton fiat configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `fiat-web/config/fiat.yml`
+or set a default in the code reading the config property.

--- a/halconfig/fiat.yml
+++ b/halconfig/fiat.yml
@@ -4,5 +4,3 @@ server:
   port: ${services.fiat.port:7003}
   address: ${services.fiat.host:localhost}
 
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}


### PR DESCRIPTION
Currently Halyard is appending a default for the redis config to all configs it generates. Let's push this down to the base config so all users get the same defaults and we don't need to append this all the time.

Currently the base config uses 'services.redis.connection' as the default. This doesn't match what is used for other services, nor what is used for the redis connection in other microservices (which use services.redis.baseUrl).

This commit changes this to look at 'services.redis.baseUrl' for consistency. Users who have configured a 'services.redis.connection' property but not 'services.redis.baseUrl' (and who are depending on that rather than just setting redis.connection directly in their gate config) will need to update to account for this change.