### PR TITLE
fix(serviceAccounts): limit the number of service accounts to expand

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -47,6 +47,8 @@ public class FiatServerConfigurationProperties {
 
   private WriteMode writeMode = new WriteMode();
 
+  private int maxExpandedServiceAccounts = 25;
+
   @NestedConfigurationProperty
   private ChaosMonkeyConfigurationProperties chaosMonkey = new ChaosMonkeyConfigurationProperties();
 

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.fiat.model.resources.*;
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
 import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
@@ -138,6 +139,13 @@ public class AuthorizeController {
     Set<ServiceAccount.View> serviceAccounts = getUserPermissionView(userId).getServiceAccounts();
     if (!expand) {
       return serviceAccounts;
+    }
+
+    if (serviceAccounts.size() > configProps.getMaxExpandedServiceAccounts()) {
+      throw new InvalidRequestException(
+          String.format(
+              "Unable to expand service accounts for user %s. User has %s service accounts. Maximum expandable service accounts is %s.",
+              userId, serviceAccounts.size(), configProps.getMaxExpandedServiceAccounts()));
     }
 
     return serviceAccounts.stream()


### PR DESCRIPTION
This is primarily a guard against a user with the admin flag (who has access to all service accounts) in a Spinnaker instance with hundreds of service accounts. This endpoint can quickly get up past the point where the request from gate will time out (and fall back to just asking for the unexpanded list).