### PR TITLE
Extension Resources

### DIFF
--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
@@ -53,7 +53,7 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
         String resource = "service"
         UserPermission.View upv = new UserPermission.View()
         upv.setApplications([new Application.View().setName(resource)
-                                     .setAuthorizations([userAuthroizationType] as Set)] as Set)
+                                     .setAuthorizations([userAuthorizationType] as Set)] as Set)
         fiatService.getUserPermission("testUser") >> upv
 
         when:
@@ -66,7 +66,7 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
         1 * response.sendError(403, "Access denied to application service - required authorization: " + authorizationTypeRequired)
 
         where:
-        userAuthroizationType | authorizationTypeRequired
+        userAuthorizationType | authorizationTypeRequired
         Authorization.READ    | "WRITE"
         Authorization.WRITE   | "READ"
     }

--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"
   implementation "org.springframework:spring-core"
+  implementation "org.springframework.boot:spring-boot-starter-web"
 
   testImplementation "org.springframework.boot:spring-boot"
   testImplementation "com.fasterxml.jackson.core:jackson-databind"

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -22,7 +22,9 @@ import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Account extends BaseAccessControlled<Account> implements Viewable {

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -25,7 +25,9 @@ import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Application extends BaseAccessControlled<Application> implements Viewable {

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BaseAccessControlled.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BaseAccessControlled.java
@@ -21,10 +21,10 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-abstract class BaseAccessControlled<R extends BaseAccessControlled>
+public abstract class BaseAccessControlled<R extends BaseAccessControlled>
     implements Resource.AccessControlled {
 
-  abstract R setPermissions(Permissions p);
+  public abstract R setPermissions(Permissions p);
 
   /**
    * Legacy holdover where setting `requiredGroupMembership` implied both read and write

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BuildService.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BuildService.java
@@ -22,7 +22,9 @@ import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class BuildService implements Resource.AccessControlled, Viewable {

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -22,8 +22,10 @@ import javax.annotation.Nonnull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Component
 @Data
 @EqualsAndHashCode(of = "name")
 @NoArgsConstructor

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ServiceAccount.java
@@ -26,8 +26,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Component
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class ServiceAccount implements Resource, Viewable {

--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp-apache"
 
   implementation "io.github.resilience4j:resilience4j-spring-boot2"
+  implementation "org.springframework:spring-core"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-aop"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.model.resources.Application
+import com.netflix.spinnaker.fiat.model.resources.BuildService
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
@@ -66,7 +67,8 @@ class RedisPermissionsRepositorySpec extends Specification {
     repo = new RedisPermissionsRepository(
         objectMapper,
         new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-        prefix
+        [new Application(), new Account(), new ServiceAccount(), new Role(), new BuildService()],
+        prefix,
     )
   }
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicator
 import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
+import com.netflix.spinnaker.fiat.model.resources.Application
+import com.netflix.spinnaker.fiat.model.resources.BuildService
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
@@ -75,6 +77,7 @@ class UserRolesSyncerSpec extends Specification {
     repo = new RedisPermissionsRepository(
         objectMapper,
         new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+        [new Application(), new Account(), new ServiceAccount(), new Role(), new BuildService()],
         "unittests"
     )
   }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.model.resources.Application
 import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.fiat.model.resources.Resource
 import com.netflix.spinnaker.fiat.permissions.PermissionsRepository
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider
@@ -77,6 +78,9 @@ class AuthorizeControllerSpec extends Specification {
 
   @Autowired
   ResourcePermissionProvider<Application> applicationResourcePermissionProvider;
+
+  @Autowired
+  List<Resource> resources;
 
   @Delegate
   FiatSystemTestSupport fiatIntegrationTestSupport = new FiatSystemTestSupport()
@@ -164,6 +168,7 @@ class AuthorizeControllerSpec extends Specification {
             permissionsResolver,
             fiatServerConfigurationProperties,
             applicationResourcePermissionProvider,
+            resources,
             objectMapper
     )
 
@@ -193,6 +198,7 @@ class AuthorizeControllerSpec extends Specification {
             permissionsResolver,
             fiatServerConfigurationProperties,
             applicationResourcePermissionProvider,
+            resources,
             objectMapper
     )
 
@@ -275,6 +281,7 @@ class AuthorizeControllerSpec extends Specification {
             resolver,
             new FiatServerConfigurationProperties(allowPermissionResolverFallback: allowPermissionResolverFallback),
             applicationResourcePermissionProvider,
+            resources,
             objectMapper
     )
     def account = new Account().setName("some-account")
@@ -313,6 +320,7 @@ class AuthorizeControllerSpec extends Specification {
         permissionsResolver,
         new FiatServerConfigurationProperties(defaultToUnrestrictedUser: defaultToUnrestrictedUser),
         applicationResourcePermissionProvider,
+        resources,
         objectMapper
     )
     permissionsRepository.put(unrestrictedUser)
@@ -347,6 +355,7 @@ class AuthorizeControllerSpec extends Specification {
             permissionsResolver,
             new FiatServerConfigurationProperties(restrictApplicationCreation: false),
             applicationResourcePermissionProvider,
+            resources,
             objectMapper
     )
     when:
@@ -375,6 +384,7 @@ class AuthorizeControllerSpec extends Specification {
             permissionsResolver,
             new FiatServerConfigurationProperties(restrictApplicationCreation: true),
             applicationResourcePermissionProvider,
+            resources,
             objectMapper
     )
     when:


### PR DESCRIPTION
This change allows Fiat to serve / evaluate permissions for arbitrary resources. I've added an example plugin here that demonstrates how it works: https://github.com/spinnaker-plugin-examples/fileResourceProvider. That example is Spring-based. Ideally I'd get this PR merged and then pull out `Resource` and `ResourceProvider` extension points.

The resulting map served from `/authorize/{user}` looks like this:

```
{
  ...
  "extensionResources": {
     "my_extension_resource": [{
         "name": ...
         "authorizations": ["READ", "WRITE"]
     }]
  },
  ...
}
```

There's a slight tweak in fiat client code to automatically evaluate authorizations on these resources.