### PR TITLE
Add missing user role provider "SAML Groups"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently supported user role providers are:
 * GitHub Teams
 * LDAP
 * File based role provider
+* SAML Groups
 
 ---
 


### PR DESCRIPTION
## What

While SAML groups are documented in [Authorization (RBAC)](https://spinnaker.io/setup/security/authorization/#authorization-rbac), it is missing in the README.md.