### PR TITLE
feat(fiat): Add support for Redis SSL

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
@@ -61,13 +61,15 @@ public class RedisConfig {
       password = redisConnection.getUserInfo().split(":", 2)[1];
     }
 
+    boolean isSSL = redisConnection.getScheme().equals("rediss");
+
     if (redisPoolConfig == null) {
       redisPoolConfig = new GenericObjectPoolConfig();
     }
 
     return new InstrumentedJedisPool(
         registry,
-        new JedisPool(redisPoolConfig, host, port, timeout, password, database, null),
+        new JedisPool(redisPoolConfig, host, port, timeout, password, database, null, isSSL),
         "fiat");
   }
 }


### PR DESCRIPTION
Follow Kork's existing pattern and check for presence of `rediss` in
the URI Scheme.

Follow Kork's existing usage of JedisPool() and supply optional
parameter designating if SSL is enabled or disabled.

Related to: https://github.com/spinnaker/spinnaker/issues/5470

Tested with default in cluster redis (no auth or TLS) and `fiat.yml` 
snippet below and mounting in Redis auth token via env var:
```
services:
  redis:
    baseUrl: rediss://:${REDIS_TOKEN}@master.<snip>.cache.amazonaws.com:6379
    enabled: true
  redisRo:
    baseUrl: rediss://:${REDIS_TOKEN}@replica.<snip>.cache.amazonaws.com:6379
    enabled: true
```


