### PR TITLE
fix(authorize): fixes for authorize redis and fallback

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -183,11 +183,17 @@ public class RedisPermissionsRepository implements PermissionsRepository {
                 .map(Resource::getResourceType)
                 .forEach(
                     r -> {
-                      Response<Map<String, String>> resourceMap = p.hgetAll(userKey(id, r));
+                      String userKey = userKey(id, r);
+                      String unrestrictedUserKey = unrestrictedUserKey(r);
+                      Response<Map<String, String>> resourceMap = p.hgetAll(userKey);
                       userResponseMap.put(r, resourceMap);
-                      Response<Map<String, String>> unrestrictedMap =
-                          p.hgetAll(unrestrictedUserKey(r));
-                      unrestrictedResponseMap.put(r, unrestrictedMap);
+                      if (userKey.equals(unrestrictedUserKey)) {
+                        unrestrictedResponseMap.put(r, resourceMap);
+                      } else {
+                        Response<Map<String, String>> unrestrictedMap =
+                            p.hgetAll(unrestrictedUserKey);
+                        unrestrictedResponseMap.put(r, unrestrictedMap);
+                      }
                       log.info("Resource: {}; map size: {}", r, unrestrictedResponseMap.size());
                     });
             Response<Boolean> admin = p.sismember(adminKey(), id);


### PR DESCRIPTION
- does less work while holding a redis connection:
  - ensure when looking up the unrestricted user, that we don't read the
    same values twice from redis
  - close the redis connection before deserializing permission objects

- ensures that if we hit the fallback case for a user that was not resolved
  we include the unrestricted user's permissions in the resulting UserPermission