### PR TITLE
feat(perf): cache the unrestricted users permissions

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -17,6 +17,7 @@
 dependencies {
   implementation project(":fiat-core")
 
+  implementation "com.github.ben-manes.caffeine:caffeine"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.squareup.okhttp:okhttp"


### PR DESCRIPTION
The unrestricted user is loaded from redis each time a lookup for a user happens, and
this user may end up with a lot of data associated with it if there are a large number
of secured entities set up for anonymous read access.

This saves the step of fetching and deserializing that data if there is a copy cached.

Adds a new last modified key to track (via redis server time) the last time the
unrestricted user was written to redis, and uses that to ensure a reload happens when
the permissions are rebuilt.