### PR TITLE
feat(api): allow fiat clients to check if there is a user permission cached

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -190,6 +190,19 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     }
   }
 
+  /**
+   * @param username the username to check
+   * @return whether a permission is currently cached for the username
+   */
+  @SuppressWarnings("unused")
+  public boolean hasCachedPermission(String username) {
+    if (!fiatStatus.isEnabled()) {
+      return true;
+    }
+
+    return permissionsCache.getIfPresent(username) != null;
+  }
+
   public boolean hasPermission(
       String username, Serializable resourceName, String resourceType, Object authorization) {
     if (!fiatStatus.isEnabled()) {
@@ -253,6 +266,12 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
     return hasPermission(getUsername(authentication), resourceName, resourceType, authorization);
   }
 
+  /**
+   * Invalidates the cached permissions for a user.
+   *
+   * @param username the username of the user to invalidate from the local cache.
+   */
+  @SuppressWarnings("unused")
   public void invalidatePermission(String username) {
     permissionsCache.invalidate(username);
   }


### PR DESCRIPTION
For sessionless auth such as X509 in gate, there is a debounce option to prevent having to post a login to fiat for each request,
however part of that is determining whether the user is already populated in the hosts permission cache.

This check 404s if the user has not logged in, but in doing so triggers retries with backoffs before a login is posted.

This introduces a new method just to examine the cache without calling through to the loading behaviour on a miss