### PR TITLE
fix(redis): fix accidental change of default redis key prefix

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionRepositoryConfigProps.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionRepositoryConfigProps.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @ConfigurationProperties("fiat.redis")
 public class RedisPermissionRepositoryConfigProps {
 
-  private String prefix = "fiat";
+  private String prefix = "spinnaker:fiat";
 
   @NestedConfigurationProperty private Repository repository = new Repository();
 


### PR DESCRIPTION
In moving a Value annotation to config properties, the default was changed from spinnaker:fiat to fiat
This switches the default back to its original value