### PR TITLE
chore(java11): Target Java 11.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Java 8 for cross-compilation support. Setting it up before
-      # Java 11 means it comes later in $PATH (because of how setup-java works)
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -31,4 +26,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build
-        run: ./gradlew -PenableCrossCompilerPlugin=true build --stacktrace
+        run: ./gradlew build --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # Install Java 8 for cross-compilation support. Setting it up before
-    # Java 11 means it comes later in $PATH (because of how setup-java works)
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
     - uses: actions/setup-java@v1
       with:
         java-version: 11
@@ -25,4 +20,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Build
-      run: ./gradlew -PenableCrossCompilerPlugin=true build
+      run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      # Install Java 8 for cross-compilation support. Setting it up before
-      # Java 11 means it comes later in $PATH (because of how setup-java works)
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -45,7 +40,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           RELEASE_VERSION: ${{ steps.release_info.outputs.RELEASE_VERSION }}
         run: |
-          ./gradlew -PenableCrossCompilerPlugin=true --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
+          ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,11 +1,8 @@
 FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y \
-    openjdk-8-jdk \
     openjdk-11-jdk \
  && rm -rf /var/lib/apt/lists/*
 LABEL maintainer="sig-platform@spinnaker.io"
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx4g
-CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true fiat-web:installDist -x test
+CMD ./gradlew --no-daemon fiat-web:installDist -x test

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -46,7 +46,7 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    List<String> pathVarsToTag = ImmutableList.of("accountName", "applicationName", "resourceName");
+    var pathVarsToTag = ImmutableList.of("accountName", "applicationName", "resourceName");
     List<String> exclude = ImmutableList.of("BasicErrorController");
     MetricsInterceptor interceptor =
         new MetricsInterceptor(this.registry, "controller.invocations", pathVarsToTag, exclude);

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ includeProviders=file,github,google-groups,ldap
 korkVersion=7.63.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.1
+targetJava11=true
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.
 #


### PR DESCRIPTION
After this commit, we can use Java 11 language features and APIs.

I added a single `var` declaration to make it more obvious if any of our various CI systems are misconfigured.
