### PR TITLE
Revert "perf(auth/ldap): Limit search object size"

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
@@ -58,7 +58,6 @@ public class LdapConfig {
     String groupSearchFilter = "(uniqueMember={0})";
     String groupRoleAttributes = "cn";
     String groupUserAttributes = "";
-    String groupUserAttributesDelimiter = " ";
 
     int thresholdToUseGroupMembership = 100;
   }

--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -29,7 +29,6 @@ import javax.naming.Name;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
-import javax.naming.directory.SearchControls;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -136,10 +135,6 @@ public class LdapUserRolesProvider implements UserRolesProvider {
                   configProps.getGroupSearchFilter(),
                   "*",
                   "*"), // Passing two wildcard params like loadRoles
-              SearchControls.OBJECT_SCOPE, // Limit the scope to single object
-              configProps
-                  .getGroupUserAttributes()
-                  .split(configProps.getGroupUserAttributesDelimiter()),
               new UserGroupMapper())
           .stream()
           .flatMap(List::stream)


### PR DESCRIPTION
Reverts #747.

This is done since I'm starting to see issues with this change in one environment that was not caught during the regular testing of the change.
