### PR TITLE
fix(permission): Normalize user permission ID and ensure controllers normalize incoming user IDs

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -38,6 +38,20 @@ public class UserPermission {
   private Set<Resource> extensionResources = new LinkedHashSet<>();
   private boolean admin = false;
 
+  /**
+   * Custom setter to normalize the input. lombok.accessors.chain is enabled, so setters must return
+   * {@code this}.
+   */
+  public UserPermission setId(String id) {
+    this.id = id.toLowerCase();
+    return this;
+  }
+
+  /** Custom getter to normalize the output. */
+  public String getId() {
+    return this.id.toLowerCase();
+  }
+
   public void addResource(Resource resource) {
     addResources(Collections.singleton(resource));
   }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -230,34 +230,34 @@ class RedisPermissionsRepositorySpec extends Specification {
                  .setRoles([role1] as Set))
 
     then:
-    jedis.smembers("unittests:users") == ["testUser"] as Set
-    jedis.smembers("unittests:roles:role1") == ["testUser"] as Set
+    jedis.smembers("unittests:users") == ["testuser"] as Set
+    jedis.smembers("unittests:roles:role1") == ["testuser"] as Set
 
-    jedis.hgetAll("unittests:permissions:testUser:accounts") ==
+    jedis.hgetAll("unittests:permissions:testuser:accounts") ==
         ['account': /{"name":"account","permissions":$EMPTY_PERM_JSON}/.toString()]
-    jedis.hgetAll("unittests:permissions:testUser:applications") ==
+    jedis.hgetAll("unittests:permissions:testuser:applications") ==
         ['app': /{"name":"app","permissions":$EMPTY_PERM_JSON,"details":{}}/.toString()]
-    jedis.hgetAll("unittests:permissions:testUser:service_accounts") ==
+    jedis.hgetAll("unittests:permissions:testuser:service_accounts") ==
         ['serviceAccount': '{"name":"serviceAccount","memberOf":["role1"]}']
-    jedis.hgetAll("unittests:permissions:testUser:roles") ==
+    jedis.hgetAll("unittests:permissions:testuser:roles") ==
         ['role1': '{"name":"role1"}']
     !jedis.sismember ("unittests:permissions:admin","testUser")
   }
 
   def "should remove permission that has been revoked"() {
     setup:
-    jedis.sadd("unittests:users", "testUser")
-    jedis.sadd("unittests:roles:role1", "testUser")
-    jedis.hset("unittests:permissions:testUser:accounts",
+    jedis.sadd("unittests:users", "testuser")
+    jedis.sadd("unittests:roles:role1", "testuser")
+    jedis.hset("unittests:permissions:testuser:accounts",
                "account",
                '{"name":"account","permissions":{}}')
-    jedis.hset("unittests:permissions:testUser:applications",
+    jedis.hset("unittests:permissions:testuser:applications",
                "app",
                '{"name":"app","permissions":{}}')
-    jedis.hset("unittests:permissions:testUser:service_accounts",
+    jedis.hset("unittests:permissions:testuser:service_accounts",
                "serviceAccount",
                '{"name":"serviceAccount"}')
-    jedis.hset("unittests:permissions:testUser:roles",
+    jedis.hset("unittests:permissions:testuser:roles",
                "role1",
                '{"name":"role1"}')
 
@@ -270,28 +270,28 @@ class RedisPermissionsRepositorySpec extends Specification {
                  .setRoles([] as Set))
 
     then:
-    jedis.hgetAll("unittests:permissions:testUser:accounts") == [:]
-    jedis.hgetAll("unittests:permissions:testUser:applications") == [:]
-    jedis.hgetAll("unittests:permissions:testUser:service_accounts") == [:]
-    jedis.hgetAll("unittests:permissions:testUser:roles") == [:]
+    jedis.hgetAll("unittests:permissions:testuser:accounts") == [:]
+    jedis.hgetAll("unittests:permissions:testuser:applications") == [:]
+    jedis.hgetAll("unittests:permissions:testuser:service_accounts") == [:]
+    jedis.hgetAll("unittests:permissions:testuser:roles") == [:]
     jedis.smembers("unittests:roles:role1") == [] as Set
   }
 
   def "should get the permission out of redis"() {
     setup:
-    jedis.sadd("unittests:users", "testUser")
-    jedis.hset("unittests:permissions:testUser:accounts",
+    jedis.sadd("unittests:users", "testuser")
+    jedis.hset("unittests:permissions:testuser:accounts",
                "account",
                '{"name":"account","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testUser:applications",
+    jedis.hset("unittests:permissions:testuser:applications",
                "app",
                '{"name":"app","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testUser:service_accounts",
+    jedis.hset("unittests:permissions:testuser:service_accounts",
                "serviceAccount",
                '{"name":"serviceAccount"}')
 
     when:
-    def result = repo.get("testUser").get()
+    def result = repo.get("testuser").get()
 
     then:
     def abcRead = new Permissions.Builder().add(Authorization.READ, "abc").build()
@@ -307,7 +307,7 @@ class RedisPermissionsRepositorySpec extends Specification {
                "account",
                '{"name":"unrestrictedAccount","permissions":{}}')
     jedis.set("unittests:last_modified:__unrestricted_user__", "1")
-    result = repo.get("testUser").get()
+    result = repo.get("testuser").get()
 
     then:
     expected.addResource(new Account().setName("unrestrictedAccount"))
@@ -316,19 +316,19 @@ class RedisPermissionsRepositorySpec extends Specification {
 
   def "should get all users from redis"() {
     setup:
-    jedis.sadd("unittests:users", "testUser1", "testUser2", "testUser3")
+    jedis.sadd("unittests:users", "testuser1", "testuser2", "testuser3")
 
     and:
     Account account1 = new Account().setName("account1")
     Application app1 = new Application().setName("app1")
     ServiceAccount serviceAccount1 = new ServiceAccount().setName("serviceAccount1")
-    jedis.hset("unittests:permissions:testUser1:accounts",
+    jedis.hset("unittests:permissions:testuser1:accounts",
                "account1",
                '{"name":"account1","permissions":{}}')
-    jedis.hset("unittests:permissions:testUser1:applications",
+    jedis.hset("unittests:permissions:testuser1:applications",
                "app1",
                '{"name":"app1","permissions":{}}')
-    jedis.hset("unittests:permissions:testUser1:service_accounts",
+    jedis.hset("unittests:permissions:testuser1:service_accounts",
                "serviceAccount1",
                '{"name":"serviceAccount1"}')
 
@@ -337,17 +337,17 @@ class RedisPermissionsRepositorySpec extends Specification {
     Account account2 = new Account().setName("account2").setPermissions(abcRead)
     Application app2 = new Application().setName("app2").setPermissions(abcRead)
     ServiceAccount serviceAccount2 = new ServiceAccount().setName("serviceAccount2")
-    jedis.hset("unittests:permissions:testUser2:accounts",
+    jedis.hset("unittests:permissions:testuser2:accounts",
                "account2",
                '{"name":"account2","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testUser2:applications",
+    jedis.hset("unittests:permissions:testuser2:applications",
                "app2",
                '{"name":"app2","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testUser2:service_accounts",
+    jedis.hset("unittests:permissions:testuser2:service_accounts",
                "serviceAccount2",
                '{"name":"serviceAccount2"}')
     and:
-    jedis.sadd("unittests:permissions:admin", "testUser3")
+    jedis.sadd("unittests:permissions:admin", "testuser3")
 
     when:
     def result = repo.getAllById()
@@ -363,7 +363,7 @@ class RedisPermissionsRepositorySpec extends Specification {
                                         .setServiceAccounts([serviceAccount2] as Set)
     def testUser3 = new UserPermission().setId("testUser3")
                                         .setAdmin(true)
-    result == ["testUser1": testUser1, "testUser2": testUser2, "testUser3": testUser3]
+    result == ["testuser1": testUser1, "testuser2": testUser2, "testuser3": testUser3]
   }
 
   def "should delete the specified user"() {
@@ -384,10 +384,10 @@ class RedisPermissionsRepositorySpec extends Specification {
 
     then:
     jedis.keys("*").size() == 6 // users, accounts, applications, roles, and reverse-index roles.
-    jedis.sismember("unittests:permissions:admin", "testUser")
+    jedis.sismember("unittests:permissions:admin", "testuser")
 
     when:
-    repo.remove("testUser")
+    repo.remove("testuser")
 
     then:
     jedis.keys("*").size() == 0

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -292,7 +292,8 @@ public class AuthorizeController {
        * First, attempt to resolve via the permissionsResolver.
        */
       if (configProps.isAllowPermissionResolverFallback()) {
-        UserPermission resolvedUserPermission = permissionsResolver.resolve(authenticatedUserId);
+        UserPermission resolvedUserPermission =
+            permissionsResolver.resolve(ControllerSupport.convert(authenticatedUserId));
         if (resolvedUserPermission.getAllResources().stream().anyMatch(Objects::nonNull)) {
           log.debug("Resolved fallback permissions for user {}", authenticatedUserId);
           userPermission = resolvedUserPermission;

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ControllerSupport.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/ControllerSupport.java
@@ -28,6 +28,6 @@ public class ControllerSupport {
     if (ANONYMOUS_USER.equalsIgnoreCase(in)) {
       return UnrestrictedResourceConfig.UNRESTRICTED_USERNAME;
     }
-    return in;
+    return in.toLowerCase();
   }
 }

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/RolesControllerSpec.groovy
@@ -78,9 +78,9 @@ class RolesControllerSpec extends Specification {
     igorBuildServiceLoader.getData() >> []
 
     userRoleProvider.userToRoles = [
-        "noRolesUser@group.com"   : [],
-        "roleAUser@group.com"     : [roleA],
-        "roleAroleBUser@group.com": [roleA],  // roleB comes in "externally"
+        "norolesuser@group.com"   : [],
+        "roleauser@group.com"     : [roleA],
+        "rolearolebuser@group.com": [roleA],  // roleB comes in "externally"
     ]
 
     when:
@@ -88,7 +88,7 @@ class RolesControllerSpec extends Specification {
 
     then:
     def expected = new UserPermission().setId("noRolesUser@group.com")
-    permissionsRepository.get("noRolesUser@group.com").get() == expected
+    permissionsRepository.get(ControllerSupport.convert("noRolesUser@group.com")).get() == expected
 
     when:
     mockMvc.perform(post("/roles/roleAUser@group.com")).andExpect(status().isOk())
@@ -97,7 +97,7 @@ class RolesControllerSpec extends Specification {
                                    .setApplications([restrictedApp] as Set)
 
     then:
-    permissionsRepository.get("roleAUser@group.com").get() == expected
+    permissionsRepository.get(ControllerSupport.convert("roleAUser@group.com")).get() == expected
 
     when:
     mockMvc.perform(put("/roles/roleBUser@group.com").content('["roleB"]')).andExpect(status().isOk())
@@ -106,7 +106,7 @@ class RolesControllerSpec extends Specification {
                                    .setAccounts([restrictedAccount] as Set)
 
     then:
-    permissionsRepository.get("roleBUser@group.com").get() == expected
+    permissionsRepository.get(ControllerSupport.convert("roleBUser@group.com")).get() == expected
 
     when:
     mockMvc.perform(put("/roles/roleAroleBUser@group.com").content('["roleB"]')).andExpect(status().isOk())
@@ -116,7 +116,7 @@ class RolesControllerSpec extends Specification {
                                    .setAccounts([restrictedAccount] as Set)
 
     then:
-    permissionsRepository.get("roleAroleBUser@group.com").get() == expected
+    permissionsRepository.get(ControllerSupport.convert("roleAroleBUser@group.com")).get() == expected
 
     when:
     mockMvc.perform(put("/roles/expectedError").content('["batman"]')).andExpect(status().is5xxServerError())


### PR DESCRIPTION
Inputs and outputs normalized so that the user ID lookup is functionally case insensitive.