### PR TITLE
fix(roles): ensure usernames are case-insensitively deduped in RedisPermissionsRepository.getAllByRoles()

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -356,7 +356,8 @@ public class RedisPermissionsRepository implements PermissionsRepository {
 
     final Set<String> dedupedUsernames = new HashSet<>();
     for (String role : new HashSet<>(anyRoles)) {
-      dedupedUsernames.addAll(scanSet(roleKey(role)));
+      dedupedUsernames.addAll(
+          scanSet(roleKey(role)).stream().map(String::toLowerCase).collect(Collectors.toSet()));
     }
     dedupedUsernames.add(UNRESTRICTED);
 

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -399,6 +399,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     def role2 = new Role("role2")
     def role3 = new Role("role3")
     def role4 = new Role("role4")
+    def role5 = new Role("role5")
 
     def acct1 = new Account().setName("acct1")
 
@@ -406,6 +407,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     def user2 = new UserPermission().setId("user2").setRoles([role1, role3] as Set)
     def user3 = new UserPermission().setId("user3") // no roles.
     def user4 = new UserPermission().setId("user4").setRoles([role4] as Set)
+    def user5 = new UserPermission().setId("user5").setRoles([role5] as Set)
     def unrestricted = new UserPermission().setId(UNRESTRICTED).setAccounts([acct1] as Set)
 
     jedis.hset("unittests:permissions:user1:roles", "role1", '{"name":"role1"}')
@@ -413,6 +415,8 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.hset("unittests:permissions:user2:roles", "role1", '{"name":"role1"}')
     jedis.hset("unittests:permissions:user2:roles", "role3", '{"name":"role3"}')
     jedis.hset("unittests:permissions:user4:roles", "role4", '{"name":"role4"}')
+    jedis.hset("unittests:permissions:user5:roles", "role5", '{"name":"role5"}')
+    jedis.hset("unittests:permissions:USER5:roles", "role5", '{"name":"role5"}')
 
     jedis.hset("unittests:permissions:__unrestricted_user__:accounts", "acct1", '{"name":"acct1"}')
 
@@ -420,8 +424,9 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.sadd("unittests:roles:role2", "user1")
     jedis.sadd("unittests:roles:role3", "user2")
     jedis.sadd("unittests:roles:role4", "user4")
+    jedis.sadd("unittests:roles:role5", "user5", "USER5")
 
-    jedis.sadd("unittests:users", "user1", "user2", "user3", "user4", "__unrestricted_user__")
+    jedis.sadd("unittests:users", "user1", "user2", "user3", "user4", "user5", "USER5", "__unrestricted_user__")
 
     when:
     def result = repo.getAllByRoles(["role1"])
@@ -447,6 +452,8 @@ class RedisPermissionsRepositorySpec extends Specification {
                "user2"       : user2.merge(unrestricted),
                "user3"       : user3.merge(unrestricted),
                "user4"       : user4.merge(unrestricted),
+               "user5"       : user5.merge(unrestricted),
+               "USER5"       : user5.merge(unrestricted),
                (UNRESTRICTED): unrestricted]
 
     when:
@@ -454,5 +461,12 @@ class RedisPermissionsRepositorySpec extends Specification {
 
     then:
     result == [(UNRESTRICTED): unrestricted]
+
+    when:
+    result = repo.getAllByRoles(["role5"])
+
+    then:
+    result == ["user5"       : user5.merge(unrestricted),
+               (UNRESTRICTED): unrestricted]
   }
 }


### PR DESCRIPTION
At the username dedupe stage, pre-emptively call `toLowerCase()` to ensure that the `dedupedUsernames` set has been case-insensitively deduped.

In our environment some users have mixed-case usernames, which would lead to a "deduped" username set containing (for example) both `jdoe` and `JDoe`.  In this situation, `RedisPermissionsRepository.getAllByRoles()` would crash with:

```
    java.lang.IllegalStateException: Duplicate key jdoe (attempted merging values UserPermission(id=jdoe, accounts=[Account(resourceType=account, name=someaccount, cloudProvider=null, permissions=Permissions(permissions={}))], applications=[], serviceAccounts=[], roles=[Role(resourceType=role, name=somerole, source=null)], buildServices=[], extensionResources=[], admin=false) and UserPermission(id=jdoe, accounts=[Account(resourceType=account, name=someaccount, cloudProvider=null, permissions=Permissions(permissions={}))], applications=[], serviceAccounts=[], roles=[Role(resourceType=role, name=somerole, source=null)], buildServices=[], extensionResources=[], admin=false))
```

This is because the username dedupe in `getAllByRoles()` was, prior to this commit, case-sensitive, but the keys for the subsequent `collect()` are converted to lowercase by way of `UserPermission::getId`, leading to key duplication.

By calling `toLowerCase()` to case-insensitively dedupe the username set, the resultant `Map` contains only one (lowercased) entry for each user, as expected.