### PR TITLE
feat(roles): Support for more flexible control over service account access

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -120,7 +120,7 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
         }
 
         if (!roles.isEmpty()) {
-          permission.addResources(provider.getAllRestricted(roles, permission.isAdmin()));
+          permission.addResources(provider.getAllRestricted(userId, roles, permission.isAdmin()));
         }
       } catch (ProviderException pe) {
         throw new PermissionResolutionException(
@@ -192,24 +192,24 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
     return userToRoles.entrySet().stream()
         .map(
             entry -> {
-              String username = entry.getKey();
+              String userId = entry.getKey();
               Set<Role> userRoles = new HashSet<>(entry.getValue());
 
               return new UserPermission()
-                  .setId(username)
+                  .setId(userId)
                   .setRoles(userRoles)
                   .setAdmin(resolveAdminRole(userRoles))
-                  .addResources(getResources(userRoles, resolveAdminRole(userRoles)));
+                  .addResources(getResources(userId, userRoles, resolveAdminRole(userRoles)));
             })
         .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
   }
 
-  private Set<Resource> getResources(Set<Role> roles, boolean isAdmin) {
+  private Set<Resource> getResources(String userId, Set<Role> userRoles, boolean isAdmin) {
     return resourceProviders.stream()
         .flatMap(
             provider -> {
               try {
-                return provider.getAllRestricted(roles, isAdmin).stream();
+                return provider.getAllRestricted(userId, userRoles, isAdmin).stream();
               } catch (ProviderException pe) {
                 throw new PermissionResolutionException(
                     String.format(

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
@@ -41,14 +41,15 @@ public abstract class BaseResourceProvider<R extends Resource> implements Resour
 
   @Override
   @SuppressWarnings("unchecked")
-  public Set<R> getAllRestricted(@NonNull Set<Role> roles, boolean isAdmin)
+  public Set<R> getAllRestricted(
+      @NonNull String userId, @NonNull Set<Role> userRoles, boolean isAdmin)
       throws ProviderException {
     return (Set<R>)
         getAll().stream()
             .filter(resource -> resource instanceof Resource.AccessControlled)
             .map(resource -> (Resource.AccessControlled) resource)
             .filter(resource -> resource.getPermissions().isRestricted())
-            .filter(resource -> resource.getPermissions().isAuthorized(roles) || isAdmin)
+            .filter(resource -> resource.getPermissions().isAuthorized(userRoles) || isAdmin)
             .collect(Collectors.toSet());
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseServiceAccountResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseServiceAccountResourceProvider.java
@@ -1,43 +1,35 @@
 package com.netflix.spinnaker.fiat.providers;
 
-import com.netflix.spinnaker.fiat.config.FiatRoleConfig;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 
 public abstract class BaseServiceAccountResourceProvider
     extends BaseResourceProvider<ServiceAccount> {
-  private final FiatRoleConfig fiatRoleConfig;
+  private final Collection<ServiceAccountPredicateProvider> serviceAccountPredicateProviders;
 
-  public BaseServiceAccountResourceProvider(FiatRoleConfig fiatRoleConfig) {
-    this.fiatRoleConfig = fiatRoleConfig;
+  public BaseServiceAccountResourceProvider(
+      Collection<ServiceAccountPredicateProvider> serviceAccountPredicateProviders) {
+    this.serviceAccountPredicateProviders = serviceAccountPredicateProviders;
   }
 
   @Override
-  public Set<ServiceAccount> getAllRestricted(@NonNull Set<Role> roles, boolean isAdmin)
+  public Set<ServiceAccount> getAllRestricted(
+      @NonNull String userId, @NonNull Set<Role> userRoles, boolean isAdmin)
       throws ProviderException {
-    List<String> roleNames = roles.stream().map(Role::getName).collect(Collectors.toList());
+    List<String> userRoleNames = userRoles.stream().map(Role::getName).collect(Collectors.toList());
     return getAll().stream()
         .filter(svcAcct -> !svcAcct.getMemberOf().isEmpty())
-        .filter(getServiceAccountPredicate(isAdmin, roleNames))
+        .filter(
+            svcAcct ->
+                serviceAccountPredicateProviders.stream()
+                    .anyMatch(p -> p.get(userId, userRoleNames, isAdmin).test(svcAcct)))
         .collect(Collectors.toSet());
-  }
-
-  private Predicate<ServiceAccount> getServiceAccountPredicate(
-      boolean isAdmin, List<String> roleNames) {
-    if (isAdmin) {
-      return svcAcct -> true;
-    }
-    if (fiatRoleConfig.isOrMode()) {
-      return svcAcct -> svcAcct.getMemberOf().stream().anyMatch(roleNames::contains);
-    } else {
-      return svcAcct -> roleNames.containsAll(svcAcct.getMemberOf());
-    }
   }
 
   @Override

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -58,14 +58,14 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   }
 
   @Override
-  public Set<Application> getAllRestricted(Set<Role> roles, boolean isAdmin)
+  public Set<Application> getAllRestricted(String userId, Set<Role> userRoles, boolean isAdmin)
       throws ProviderException {
-    return getAllApplications(roles, isAdmin, true);
+    return getAllApplications(userId, userRoles, isAdmin, true);
   }
 
   @Override
   public Set<Application> getAllUnrestricted() throws ProviderException {
-    return getAllApplications(Collections.emptySet(), false, false);
+    return getAllApplications(null, Collections.emptySet(), false, false);
   }
 
   @Override
@@ -115,7 +115,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   }
 
   private Set<Application> getAllApplications(
-      Set<Role> roles, boolean isAdmin, boolean isRestricted) {
+      String userId, Set<Role> userRoles, boolean isAdmin, boolean isRestricted) {
     if (allowAccessToUnknownApplications) {
       /*
        * By default, the `BaseProvider` parent methods will filter out any applications that the authenticated user does
@@ -130,6 +130,8 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
       return getAll();
     }
 
-    return isRestricted ? super.getAllRestricted(roles, isAdmin) : super.getAllUnrestricted();
+    return isRestricted
+        ? super.getAllRestricted(userId, userRoles, isAdmin)
+        : super.getAllUnrestricted();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountPredicateProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountPredicateProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.config.FiatRoleConfig;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Allows access to a service account if the authenticated is an administrator or has overlapping
+ * membership in the roles required by the service account.
+ */
+public class DefaultServiceAccountPredicateProvider implements ServiceAccountPredicateProvider {
+  private final FiatRoleConfig fiatRoleConfig;
+
+  public DefaultServiceAccountPredicateProvider(FiatRoleConfig fiatRoleConfig) {
+    this.fiatRoleConfig = fiatRoleConfig;
+  }
+
+  @Override
+  public Predicate<ServiceAccount> get(String userId, List<String> userRoles, boolean isAdmin) {
+    if (isAdmin) {
+      return svcAcct -> true;
+    }
+
+    if (fiatRoleConfig.isOrMode()) {
+      return svcAcct -> svcAcct.getMemberOf().stream().anyMatch(userRoles::contains);
+    } else {
+      return svcAcct -> userRoles.containsAll(svcAcct.getMemberOf());
+    }
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-import com.netflix.spinnaker.fiat.config.FiatRoleConfig;
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -29,8 +29,9 @@ public class DefaultServiceAccountResourceProvider extends BaseServiceAccountRes
   private final Front50Service front50Service;
 
   public DefaultServiceAccountResourceProvider(
-      Front50Service front50Service, FiatRoleConfig fiatRoleConfig) {
-    super(fiatRoleConfig);
+      Front50Service front50Service,
+      Collection<ServiceAccountPredicateProvider> serviceAccountPredicateProviders) {
+    super(serviceAccountPredicateProviders);
     this.front50Service = front50Service;
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourceProvider.java
@@ -24,7 +24,8 @@ public interface ResourceProvider<R extends Resource> {
 
   Set<R> getAll() throws ProviderException;
 
-  Set<R> getAllRestricted(Set<Role> roles, boolean isAdmin) throws ProviderException;
+  Set<R> getAllRestricted(String userId, Set<Role> userRoles, boolean isAdmin)
+      throws ProviderException;
 
   Set<R> getAllUnrestricted() throws ProviderException;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountPredicateProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ServiceAccountPredicateProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import java.util.List;
+import java.util.function.Predicate;
+
+/** Builds a predicate that determines whether a given service account is accessible. */
+public interface ServiceAccountPredicateProvider {
+  /**
+   * @param userId Identifier for the currently authenticated user
+   * @param userRoles Roles for the currently authenticated user
+   * @param isAdmin Whether the currently authenticated user is an administrator
+   * @return true if access to service account should be granted, otherwise false
+   */
+  Predicate<ServiceAccount> get(String userId, List<String> userRoles, boolean isAdmin);
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.fiat.providers.AccessControlledResourcePermissionSource
 import com.netflix.spinnaker.fiat.providers.AggregatingResourcePermissionProvider
 import com.netflix.spinnaker.fiat.providers.DefaultAccountResourceProvider
+import com.netflix.spinnaker.fiat.providers.DefaultServiceAccountPredicateProvider
 import com.netflix.spinnaker.fiat.providers.DefaultServiceAccountResourceProvider
 import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider
 import com.netflix.spinnaker.fiat.providers.ResourceProvider
@@ -87,7 +88,9 @@ class DefaultPermissionsResolverSpec extends Specification {
   }
 
   @Shared
-  DefaultServiceAccountResourceProvider serviceAccountProvider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
+  DefaultServiceAccountResourceProvider serviceAccountProvider = new DefaultServiceAccountResourceProvider(
+          front50Service, [new DefaultServiceAccountPredicateProvider(fiatRoleConfig) ]
+  )
 
   @Shared
   ResourceProvider<Application> applicationProvider = Mock(ResourceProvider) {

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
@@ -76,14 +76,14 @@ class BaseResourceProviderSpec extends Specification {
 
     when:
     provider.all = [noReqGroups]
-    def result = provider.getAllRestricted([new Role("group1")] as Set, false)
+    def result = provider.getAllRestricted("userId", [new Role("group1")] as Set, false)
 
     then:
     result.isEmpty()
 
     when:
     provider.all = [reqGroup1]
-    result = provider.getAllRestricted([new Role("group1")] as Set, false)
+    result = provider.getAllRestricted("userId", [new Role("group1")] as Set, false)
 
     then:
     result.size() == 1
@@ -91,21 +91,21 @@ class BaseResourceProviderSpec extends Specification {
 
     when:
     provider.all = [reqGroup1and2]
-    result = provider.getAllRestricted([new Role("group1")] as Set, false)
+    result = provider.getAllRestricted("userId", [new Role("group1")] as Set, false)
 
     then:
     result.size() == 1
     result.first() == reqGroup1and2
 
     when: "use additional groups that grants additional authorizations."
-    result = provider.getAllRestricted([new Role("group1"), new Role("group2")] as Set, false)
+    result = provider.getAllRestricted("userId", [new Role("group1"), new Role("group2")] as Set, false)
 
     then:
     result.size() == 1
     result.first() == reqGroup1and2
 
     when:
-    provider.getAllRestricted(null, false)
+    provider.getAllRestricted(null, null, false)
 
     then:
     thrown IllegalArgumentException

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -65,7 +65,7 @@ class DefaultApplicationProviderSpec extends Specification {
     provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, defaultProvider, fallbackPermissionsResolver, allowAccessToUnknownApplications)
 
     when:
-    def restrictedResult = provider.getAllRestricted([new Role(role)] as Set<Role>, false)
+    def restrictedResult = provider.getAllRestricted("userId", [new Role(role)] as Set<Role>, false)
     List<String> restrictedApplicationNames = restrictedResult*.name
 
     def unrestrictedResult = provider.getAllUnrestricted()

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -47,16 +47,18 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> false
     }
-    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(
+            front50Service, [new DefaultServiceAccountPredicateProvider(fiatRoleConfig)]
+    )
 
     when:
-    def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)
+    def result = provider.getAllRestricted("userId", input.collect { new Role(it) } as Set, isAdmin)
 
     then:
     CollectionUtils.disjunction(result, expected).isEmpty()
 
     when:
-    provider.getAllRestricted(null, false)
+    provider.getAllRestricted(null, null, false)
 
     then:
     thrown IllegalArgumentException
@@ -79,16 +81,18 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> true
     }
-    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(
+            front50Service, [new DefaultServiceAccountPredicateProvider(fiatRoleConfig)]
+    )
 
     when:
-    def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)
+    def result = provider.getAllRestricted("userId", input.collect { new Role(it) } as Set, isAdmin)
 
     then:
     CollectionUtils.disjunction(result, expected).isEmpty()
 
     when:
-    provider.getAllRestricted(null, false)
+    provider.getAllRestricted(null, null, false)
 
     then:
     thrown IllegalArgumentException

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -10,8 +10,10 @@ import com.netflix.spinnaker.fiat.permissions.DefaultFallbackPermissionsResolver
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
 import com.netflix.spinnaker.fiat.permissions.FallbackPermissionsResolver;
 import com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider;
+import com.netflix.spinnaker.fiat.providers.DefaultServiceAccountPredicateProvider;
 import com.netflix.spinnaker.fiat.providers.DefaultServiceAccountResourceProvider;
 import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
+import com.netflix.spinnaker.fiat.providers.ServiceAccountPredicateProvider;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
@@ -95,8 +97,10 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
       value = "fiat.service-account-resource-provider.default.enabled",
       matchIfMissing = true)
   DefaultServiceAccountResourceProvider serviceAccountResourceProvider(
-      Front50Service front50Service, FiatRoleConfig fiatRoleConfig) {
-    return new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig);
+      Front50Service front50Service,
+      Collection<ServiceAccountPredicateProvider> serviceAccountPredicateProviders) {
+    return new DefaultServiceAccountResourceProvider(
+        front50Service, serviceAccountPredicateProviders);
   }
 
   @Bean
@@ -104,6 +108,12 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
       FiatServerConfigurationProperties properties) {
     return new DefaultFallbackPermissionsResolver(
         Authorization.EXECUTE, properties.getExecuteFallback());
+  }
+
+  @Bean
+  public DefaultServiceAccountPredicateProvider defaultServiceAccountPredicateProvider(
+      FiatRoleConfig fiatRoleConfig) {
+    return new DefaultServiceAccountPredicateProvider(fiatRoleConfig);
   }
 
   /**


### PR DESCRIPTION
The existing behavior has been maintained in `DefaultServiceAccountPredicateProvider`.

Alternative implementations can be provided should you have a need for more
granular or custom behavior.

Access to a service account will be granted _if_ any predicate allows it.