### PR TITLE
fix(redis): stream read from Redis

### DIFF
--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -453,7 +453,6 @@ class RedisPermissionsRepositorySpec extends Specification {
                "user3"       : user3.merge(unrestricted),
                "user4"       : user4.merge(unrestricted),
                "user5"       : user5.merge(unrestricted),
-               "USER5"       : user5.merge(unrestricted),
                (UNRESTRICTED): unrestricted]
 
     when:


### PR DESCRIPTION
This change makes the role sync process stream and process the data from Redis incrementally. Previously it would cache the entire data set before processing which would cause `fiat` to consume a large amount of heap on some data sets.

May fix spinnaker/spinnaker#6328 and fix spinnaker/spinnaker#6319
