### PR TITLE
fix(tests): test state leakage fix

### DIFF
--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -53,6 +53,7 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
 
   def cleanup() {
     MDC.clear()
+    SecurityContextHolder.clearContext()
   }
 
   @Unroll


### PR DESCRIPTION
Need to clear the SecurityContext in between test runs to isolate
test behavior. (Discovered in experimenting with some changes in
kork to support custom Authentication tokens)