### PR TITLE
chore(redis): use testcontainer for Redis tests

### DIFF
--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.fiat.model.resources
 
+import com.fasterxml.jackson.core.PrettyPrinter
+import com.fasterxml.jackson.core.util.DefaultIndenter
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.netflix.spinnaker.fiat.YamlFileApplicationContextInitializer
@@ -38,10 +41,15 @@ class PermissionsSpec extends Specification {
   @Autowired
   TestConfigProps testConfigProps
 
+  // Make line endings consistent regardless of OS
+  PrettyPrinter printer =
+          new DefaultPrettyPrinter()
+                  .withObjectIndenter(new DefaultIndenter().withLinefeed("\n"))
+
   ObjectMapper mapper =
-    new ObjectMapper()
-      .enable(SerializationFeature.INDENT_OUTPUT)
-      .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+          new ObjectMapper()
+                  .enable(SerializationFeature.INDENT_OUTPUT)
+                  .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
 
   String permissionJson = '''\
     {
@@ -80,7 +88,7 @@ class PermissionsSpec extends Specification {
     b.set([(R): ["foo"], (W): ["bar"]])
 
     then:
-    permissionSerialized ==  mapper.writeValueAsString(b.build())
+    permissionSerialized ==  mapper.writer(printer).writeValueAsString(b.build())
   }
 
   def "can deserialize to builder from serialized Permissions"() {

--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -36,6 +36,6 @@ dependencies {
   implementation "redis.clients:jedis"
   implementation "com.google.api-client:google-api-client"
 
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
   testImplementation "org.apache.commons:commons-collections4:4.1"
+  testImplementation "org.testcontainers:testcontainers"
 }

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -44,7 +44,7 @@ dependencies {
   }
 
   testImplementation "com.netflix.spinnaker.kork:kork-jedis"
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+  testImplementation "org.testcontainers:testcontainers"
 }
 
 applicationName = 'fiat'


### PR DESCRIPTION
Update integration tests to use testcontainer to managed Redis instances. This allows for development to be done on Windows machines.