### PR TITLE
fix(redis): Performance improvements for RedisPermissionsRepository

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-aop"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.lz4:lz4-java:1.7.1"
 
   implementation "com.netflix.spinnaker.kork:kork-jedis"
   implementation "com.netflix.spinnaker.kork:kork-security"

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionRepositoryConfigProps.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionRepositoryConfigProps.java
@@ -30,6 +30,7 @@ public class RedisPermissionRepositoryConfigProps {
   public static class Repository {
     private Duration getPermissionTimeout = Duration.ofSeconds(1);
     private Duration checkLastModifiedTimeout = Duration.ofMillis(50);
+    private Duration getUserResourceTimeout = Duration.ofSeconds(1);
 
     public Duration getGetPermissionTimeout() {
       return getPermissionTimeout;
@@ -45,6 +46,14 @@ public class RedisPermissionRepositoryConfigProps {
 
     public void setCheckLastModifiedTimeout(Duration checkLastModifiedTimeout) {
       this.checkLastModifiedTimeout = checkLastModifiedTimeout;
+    }
+
+    public Duration getGetUserResourceTimeout() {
+      return getUserResourceTimeout;
+    }
+
+    public void setGetUserResourceTimeout(Duration getUserResourceTimeout) {
+      this.getUserResourceTimeout = getUserResourceTimeout;
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.fiat.permissions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.kork.exceptions.IntegrationException;
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import io.github.resilience4j.retry.RetryRegistry;
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -39,9 +40,8 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import redis.clients.jedis.Response;
-import redis.clients.jedis.ScanParams;
-import redis.clients.jedis.ScanResult;
+import net.jpountz.lz4.*;
+import redis.clients.jedis.*;
 import redis.clients.jedis.commands.BinaryJedisCommands;
 import redis.clients.jedis.util.SafeEncoder;
 
@@ -64,6 +64,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   private static final String REDIS_READ_RETRY = "permissionsRepositoryRedisRead";
 
   private static final String KEY_PERMISSIONS = "permissions";
+  private static final String KEY_PERMISSIONS_LZ4 = "permissions-lz4";
   private static final String KEY_ROLES = "roles";
   private static final String KEY_ALL_USERS = "users";
   private static final String KEY_ADMIN = "admin";
@@ -79,6 +80,8 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   private final RedisPermissionRepositoryConfigProps configProps;
   private final RetryRegistry retryRegistry;
   private final AtomicReference<String> fallbackLastModified = new AtomicReference<>(null);
+  private final LZ4CompressorWithLength lz4Compressor;
+  private final LZ4DecompressorWithLength lz4Decompressor;
 
   private final LoadingCache<String, UserPermission> unrestrictedPermission =
       Caffeine.newBuilder()
@@ -103,6 +106,10 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     this.prefix = configProps.getPrefix();
     this.resources = resources;
     this.retryRegistry = retryRegistry;
+
+    LZ4Factory factory = LZ4Factory.fastestInstance();
+    this.lz4Compressor = new LZ4CompressorWithLength(factory.fastCompressor());
+    this.lz4Decompressor = new LZ4DecompressorWithLength(factory.fastDecompressor());
 
     this.allUsersKey = SafeEncoder.encode(String.format("%s:%s", prefix, KEY_ALL_USERS));
     this.adminKey =
@@ -144,13 +151,12 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   private UserPermission getUnrestrictedUserPermission() {
     String serverLastModified = NO_LAST_MODIFIED;
     byte[] bServerLastModified =
-        (byte[])
-            redisRead(
-                new TimeoutContext(
-                    "checkLastModified",
-                    clock,
-                    configProps.getRepository().getCheckLastModifiedTimeout()),
-                c -> c.get(SafeEncoder.encode(unrestrictedLastModifiedKey())));
+        redisRead(
+            new TimeoutContext(
+                "checkLastModified",
+                clock,
+                configProps.getRepository().getCheckLastModifiedTimeout()),
+            c -> c.get(SafeEncoder.encode(unrestrictedLastModifiedKey())));
     if (bServerLastModified == null || bServerLastModified.length == 0) {
       log.debug(
           "no last modified time available in redis for user {} using default of {}",
@@ -189,78 +195,79 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     }
   }
 
+  private static class PutUpdateData {
+    public byte[] userResourceKey;
+    public byte[] compressedData;
+  }
+
   @Override
   public RedisPermissionsRepository put(@NonNull UserPermission permission) {
-    val resourceTypes =
+    String userId = permission.getId();
+    byte[] bUserId = SafeEncoder.encode(userId);
+    List<ResourceType> resourceTypes =
         resources.stream().map(Resource::getResourceType).collect(Collectors.toList());
-    Map<ResourceType, Map<byte[], byte[]>> resourceTypeToRedisValue =
+    Map<ResourceType, Map<String, Resource>> resourceTypeToRedisValue =
         new HashMap<>(resourceTypes.size());
 
     permission
         .getAllResources()
         .forEach(
             resource -> {
-              try {
-                resourceTypeToRedisValue
-                    .computeIfAbsent(resource.getResourceType(), key -> new HashMap<>())
-                    .put(
-                        SafeEncoder.encode(resource.getName()),
-                        objectMapper.writeValueAsBytes(resource));
-              } catch (JsonProcessingException jpe) {
-                log.error("Serialization exception writing {} entry.", permission.getId(), jpe);
-              }
+              resourceTypeToRedisValue
+                  .computeIfAbsent(resource.getResourceType(), key -> new HashMap<>())
+                  .put(resource.getName(), resource);
             });
 
     try {
-      Set<Role> existingRoles =
-          redisClientDelegate.withCommandsClient(
-              client -> {
-                return client
-                    .hgetAll(userKey(permission.getId(), ResourceType.ROLE))
-                    .values()
-                    .stream()
-                    .map(
-                        (ThrowingFunction<String, Role>)
-                            serialized -> objectMapper.readValue(serialized, Role.class))
-                    .collect(Collectors.toSet());
-              });
+      Set<Role> existingRoles = new HashSet<>(getUserRoleMapFromRedis(userId).values());
+
+      // These updates are pre-prepared to reduce work done during the multi-key pipeline
+      List<PutUpdateData> updateData = new ArrayList<>();
+      for (ResourceType rt : resourceTypes) {
+        Map<String, Resource> redisValue = resourceTypeToRedisValue.get(rt);
+        byte[] userResourceKey = userKey(userId, rt);
+        PutUpdateData pud = new PutUpdateData();
+        pud.userResourceKey = userResourceKey;
+
+        if (redisValue == null || redisValue.size() == 0) {
+          pud.compressedData = null;
+        } else {
+          pud.compressedData = lz4Compressor.compress(objectMapper.writeValueAsBytes(redisValue));
+        }
+
+        updateData.add(pud);
+      }
 
       AtomicReference<Response<List<String>>> serverTime = new AtomicReference<>();
       redisClientDelegate.withMultiKeyPipeline(
           pipeline -> {
-            String userId = permission.getId();
             if (permission.isAdmin()) {
-              pipeline.sadd(adminKey, SafeEncoder.encode(userId));
+              pipeline.sadd(adminKey, bUserId);
             } else {
-              pipeline.srem(adminKey, SafeEncoder.encode(userId));
+              pipeline.srem(adminKey, bUserId);
             }
 
-            permission.getRoles().forEach(role -> pipeline.sadd(roleKey(role), userId));
+            permission.getRoles().forEach(role -> pipeline.sadd(roleKey(role), bUserId));
             existingRoles.stream()
                 .filter(it -> !permission.getRoles().contains(it))
-                .forEach(role -> pipeline.srem(roleKey(role), userId));
+                .forEach(role -> pipeline.srem(roleKey(role), bUserId));
 
-            resources.stream()
-                .map(Resource::getResourceType)
-                .forEach(
-                    r -> {
-                      String userResourceKey = userKey(userId, r);
-                      Map<byte[], byte[]> redisValue = resourceTypeToRedisValue.get(r);
-                      String tempKey = UUID.randomUUID().toString();
-                      if (redisValue != null && !redisValue.isEmpty()) {
-                        pipeline.hmset(SafeEncoder.encode(tempKey), redisValue);
-                        pipeline.rename(tempKey, userResourceKey);
-                      } else {
-                        pipeline.del(userResourceKey);
-                      }
-                    });
+            for (PutUpdateData pud : updateData) {
+              if (pud.compressedData == null) {
+                pipeline.del(pud.userResourceKey);
+              } else {
+                byte[] tempKey = SafeEncoder.encode(UUID.randomUUID().toString());
+                pipeline.set(tempKey, pud.compressedData);
+                pipeline.rename(tempKey, pud.userResourceKey);
+              }
+            }
 
             serverTime.set(pipeline.time());
-            pipeline.sadd(allUsersKey, SafeEncoder.encode(userId));
+            pipeline.sadd(allUsersKey, bUserId);
 
             pipeline.sync();
           });
-      if (UNRESTRICTED.equals(permission.getId())) {
+      if (UNRESTRICTED.equals(userId)) {
         String lastModified = serverTime.get().get().get(0);
         redisClientDelegate.withCommandsClient(
             c -> {
@@ -269,7 +276,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
             });
       }
     } catch (Exception e) {
-      log.error("Storage exception writing {} entry.", permission.getId(), e);
+      log.error("Storage exception writing {} entry.", userId, e);
     }
     return this;
   }
@@ -280,6 +287,52 @@ public class RedisPermissionsRepository implements PermissionsRepository {
       return Optional.of(getUnrestrictedUserPermission());
     }
     return getFromRedis(id);
+  }
+
+  private byte[] getUserResourceBytesFromRedis(String id, ResourceType resourceType) {
+    TimeoutContext timeoutContext =
+        new TimeoutContext(
+            String.format("get user resource from redis: %s (%s)", id, resourceType),
+            clock,
+            configProps.getRepository().getGetUserResourceTimeout());
+    byte[] key = userKey(id, resourceType);
+
+    byte[] compressedData =
+        redisRead(timeoutContext, (ThrowingFunction<BinaryJedisCommands, byte[]>) c -> c.get(key));
+
+    if (compressedData == null || compressedData.length == 0) {
+      return null;
+    }
+
+    return lz4Decompressor.decompress(compressedData);
+  }
+
+  private Map<String, Resource> getUserResourceMapFromRedis(String id, ResourceType resourceType)
+      throws IOException {
+    byte[] redisData = getUserResourceBytesFromRedis(id, resourceType);
+
+    if (redisData == null) {
+      return new HashMap<>();
+    }
+
+    Class<? extends Resource> modelClazz =
+        resources.stream()
+            .filter(resource -> resource.getResourceType().equals(resourceType))
+            .findFirst()
+            .orElseThrow(IllegalArgumentException::new)
+            .getClass();
+
+    return objectMapper.readerForMapOf(modelClazz).readValue(redisData);
+  }
+
+  private Map<String, Role> getUserRoleMapFromRedis(String id) throws IOException {
+    byte[] redisData = getUserResourceBytesFromRedis(id, ResourceType.ROLE);
+
+    if (redisData == null) {
+      return new HashMap<>();
+    }
+
+    return objectMapper.readValue(redisData, new TypeReference<>() {});
   }
 
   private Optional<UserPermission> getFromRedis(@NonNull String id) {
@@ -297,13 +350,16 @@ public class RedisPermissionsRepository implements PermissionsRepository {
         return Optional.empty();
       }
       UserPermission userPermission = new UserPermission().setId(id);
-      resources.forEach(
-          r -> {
-            ResourceType resourceType = r.getResourceType();
-            String userKey = userKey(id, resourceType);
-            Map<byte[], byte[]> resourcePermissions = hgetall(timeoutContext, userKey);
-            userPermission.addResources(extractResources(resourceType, resourcePermissions));
-          });
+
+      for (Resource r : resources) {
+        ResourceType resourceType = r.getResourceType();
+        Map<String, Resource> resourcePermissions = getUserResourceMapFromRedis(id, resourceType);
+
+        if (resourcePermissions != null && !resourcePermissions.isEmpty()) {
+          userPermission.addResources(resourcePermissions.values());
+        }
+      }
+
       if (!UNRESTRICTED.equals(id)) {
         userPermission.setAdmin(
             redisRead(timeoutContext, c -> c.sismember(adminKey, SafeEncoder.encode(id))));
@@ -323,9 +379,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   @Override
   public Map<String, UserPermission> getAllById() {
     Set<String> allUsers =
-        scanSet(SafeEncoder.encode(allUsersKey)).stream()
-            .map(String::toLowerCase)
-            .collect(Collectors.toSet());
+        scanSet(allUsersKey).stream().map(String::toLowerCase).collect(Collectors.toSet());
 
     if (allUsers.isEmpty()) {
       return new HashMap<>(0);
@@ -369,21 +423,16 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   @Override
   public void remove(@NonNull String id) {
     try {
-      Map<String, String> userRolesById =
-          redisClientDelegate.withCommandsClient(
-              jedis -> {
-                return jedis.hgetAll(userKey(id, ResourceType.ROLE));
-              });
+      Map<String, Role> userRolesById = getUserRoleMapFromRedis(id);
+      byte[] bId = SafeEncoder.encode(id);
 
       redisClientDelegate.withMultiKeyPipeline(
           p -> {
-            p.srem(allUsersKey, SafeEncoder.encode(id));
-            for (String roleName : userRolesById.keySet()) {
-              p.srem(roleKey(roleName), id);
-            }
+            p.srem(allUsersKey, bId);
+            userRolesById.keySet().forEach(roleName -> p.srem(roleKey(roleName), bId));
 
             resources.stream().map(Resource::getResourceType).forEach(r -> p.del(userKey(id, r)));
-            p.srem(adminKey, SafeEncoder.encode(id));
+            p.srem(adminKey, bId);
             p.sync();
           });
     } catch (Exception e) {
@@ -391,35 +440,34 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     }
   }
 
-  private Set<String> scanSet(String key) {
+  private Set<String> scanSet(byte[] key) {
     final Set<String> results = new HashSet<>();
-    final AtomicReference<String> cursor = new AtomicReference<>(ScanParams.SCAN_POINTER_START);
+    final AtomicReference<byte[]> cursor =
+        new AtomicReference<>(ScanParams.SCAN_POINTER_START_BINARY);
     do {
-      final ScanResult<String> result =
-          redisClientDelegate.withCommandsClient(
+      final ScanResult<byte[]> result =
+          redisClientDelegate.withBinaryClient(
               jedis -> {
                 return jedis.sscan(key, cursor.get());
               });
-      results.addAll(result.getResult());
-      cursor.set(result.getCursor());
-    } while (!"0".equals(cursor.get()));
+      results.addAll(
+          result.getResult().stream().map(SafeEncoder::encode).collect(Collectors.toList()));
+      cursor.set(result.getCursorAsBytes());
+    } while (!Arrays.equals(cursor.get(), ScanParams.SCAN_POINTER_START_BINARY));
     return results;
   }
 
-  private Set<String> getAllAdmins() {
-    return scanSet(SafeEncoder.encode(adminKey));
+  private byte[] userKey(String userId, ResourceType r) {
+    return SafeEncoder.encode(
+        String.format("%s:%s:%s:%s", prefix, KEY_PERMISSIONS_LZ4, userId, r.keySuffix()));
   }
 
-  private String userKey(String userId, ResourceType r) {
-    return String.format("%s:%s:%s:%s", prefix, KEY_PERMISSIONS, userId, r.keySuffix());
-  }
-
-  private String roleKey(Role role) {
+  private byte[] roleKey(Role role) {
     return roleKey(role.getName());
   }
 
-  private String roleKey(String role) {
-    return String.format("%s:%s:%s", prefix, KEY_ROLES, role);
+  private byte[] roleKey(String role) {
+    return SafeEncoder.encode(String.format("%s:%s:%s", prefix, KEY_ROLES, role));
   }
 
   private String lastModifiedKey(String userId) {
@@ -428,20 +476,6 @@ public class RedisPermissionsRepository implements PermissionsRepository {
 
   private String unrestrictedLastModifiedKey() {
     return lastModifiedKey(UNRESTRICTED);
-  }
-
-  private Set<Resource> extractResources(ResourceType r, Map<byte[], byte[]> resourceMap) {
-    val modelClazz =
-        resources.stream()
-            .filter(resource -> resource.getResourceType().equals(r))
-            .findFirst()
-            .orElseThrow(IllegalArgumentException::new)
-            .getClass();
-    return resourceMap.values().stream()
-        .map(
-            (ThrowingFunction<byte[], ? extends Resource>)
-                serialized -> objectMapper.readValue(serialized, modelClazz))
-        .collect(Collectors.toSet());
   }
 
   /** Used to swallow checked exceptions from Jackson methods. */
@@ -509,18 +543,5 @@ public class RedisPermissionsRepository implements PermissionsRepository {
               }
               return redisClientDelegate.withBinaryClient(fn);
             });
-  }
-
-  private Map<byte[], byte[]> hgetall(TimeoutContext timeoutContext, String key) {
-    Map<byte[], byte[]> all = new HashMap<>();
-    byte[] cursor = ScanParams.SCAN_POINTER_START_BINARY;
-    do {
-      final byte[] thisCursor = cursor;
-      ScanResult<Map.Entry<byte[], byte[]>> result =
-          redisRead(timeoutContext, c -> c.hscan(SafeEncoder.encode(key), thisCursor));
-      result.getResult().forEach(e -> all.put(e.getKey(), e.getValue()));
-      cursor = result.getCursorAsBytes();
-    } while (!Arrays.equals(ScanParams.SCAN_POINTER_START_BINARY, cursor));
-    return all;
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -31,8 +31,12 @@ import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import io.github.resilience4j.retry.RetryRegistry
+import net.jpountz.lz4.LZ4CompressorWithLength
+import net.jpountz.lz4.LZ4DecompressorWithLength
+import net.jpountz.lz4.LZ4Factory
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
+import redis.clients.jedis.util.SafeEncoder
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -70,6 +74,12 @@ class RedisPermissionsRepositorySpec extends Specification {
   @Shared
   PausableRedisClientDelegate redisClientDelegate
 
+  @Shared
+  LZ4CompressorWithLength lz4compressor
+
+  @Shared
+  LZ4DecompressorWithLength lz4decompressor
+
   @Subject
   RedisPermissionsRepository repo
 
@@ -80,6 +90,9 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis = embeddedRedis.jedis
     jedis.flushDB()
     redisClientDelegate = new PausableRedisClientDelegate(new JedisClientDelegate(embeddedRedis.pool as JedisPool))
+    LZ4Factory factory = LZ4Factory.fastestInstance()
+    lz4compressor = new LZ4CompressorWithLength(factory.fastCompressor())
+    lz4decompressor = new LZ4DecompressorWithLength(factory.fastDecompressor())
   }
 
   private static class TestClock extends Clock {
@@ -171,6 +184,23 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.flushDB()
   }
 
+  def setCompressed(String key, String value) {
+    byte[] k = SafeEncoder.encode(key)
+    byte[] v = lz4compressor.compress(SafeEncoder.encode(value))
+    jedis.set(k, v)
+  }
+
+  String getCompressed(String key) {
+    byte[] k = SafeEncoder.encode(key)
+    def val = jedis.get(k)
+
+    if (val == null) {
+      return null
+    }
+
+    return SafeEncoder.encode(lz4decompressor.decompress(val))
+  }
+
   def "should fail if timeout is exceeded"() {
     given:
     repo.put(new UserPermission().setId("foo"))
@@ -233,14 +263,14 @@ class RedisPermissionsRepositorySpec extends Specification {
     jedis.smembers("unittests:users") == ["testuser"] as Set
     jedis.smembers("unittests:roles:role1") == ["testuser"] as Set
 
-    jedis.hgetAll("unittests:permissions:testuser:accounts") ==
-        ['account': /{"name":"account","permissions":$EMPTY_PERM_JSON}/.toString()]
-    jedis.hgetAll("unittests:permissions:testuser:applications") ==
-        ['app': /{"name":"app","permissions":$EMPTY_PERM_JSON,"details":{}}/.toString()]
-    jedis.hgetAll("unittests:permissions:testuser:service_accounts") ==
-        ['serviceAccount': '{"name":"serviceAccount","memberOf":["role1"]}']
-    jedis.hgetAll("unittests:permissions:testuser:roles") ==
-        ['role1': '{"name":"role1"}']
+    getCompressed("unittests:permissions-lz4:testuser:accounts") ==
+        '{"account":{"name":"account","permissions":{}}}'
+    getCompressed("unittests:permissions-lz4:testuser:applications") ==
+        '{"app":{"name":"app","permissions":{},"details":{}}}'
+    getCompressed("unittests:permissions-lz4:testuser:service_accounts") ==
+        '{"serviceAccount":{"name":"serviceAccount","memberOf":["role1"]}}'
+    getCompressed("unittests:permissions-lz4:testuser:roles") ==
+        '{"role1":{"name":"role1"}}'
     !jedis.sismember ("unittests:permissions:admin","testUser")
   }
 
@@ -248,18 +278,10 @@ class RedisPermissionsRepositorySpec extends Specification {
     setup:
     jedis.sadd("unittests:users", "testuser")
     jedis.sadd("unittests:roles:role1", "testuser")
-    jedis.hset("unittests:permissions:testuser:accounts",
-               "account",
-               '{"name":"account","permissions":{}}')
-    jedis.hset("unittests:permissions:testuser:applications",
-               "app",
-               '{"name":"app","permissions":{}}')
-    jedis.hset("unittests:permissions:testuser:service_accounts",
-               "serviceAccount",
-               '{"name":"serviceAccount"}')
-    jedis.hset("unittests:permissions:testuser:roles",
-               "role1",
-               '{"name":"role1"}')
+    setCompressed("unittests:permissions-lz4:testuser:accounts", '{"account":{"name":"account","permissions":{}}}')
+    setCompressed("unittests:permissions-lz4:testuser:applications", '{"app":{"name":"app","permissions":{}}}')
+    setCompressed("unittests:permissions-lz4:testuser:service_accounts", '{"serviceAccount":{"name":"serviceAccount"}}')
+    setCompressed("unittests:permissions-lz4:testuser:roles", '{"role1":{"name":"role1"}}')
 
     when:
     repo.put(new UserPermission()
@@ -270,25 +292,22 @@ class RedisPermissionsRepositorySpec extends Specification {
                  .setRoles([] as Set))
 
     then:
-    jedis.hgetAll("unittests:permissions:testuser:accounts") == [:]
-    jedis.hgetAll("unittests:permissions:testuser:applications") == [:]
-    jedis.hgetAll("unittests:permissions:testuser:service_accounts") == [:]
-    jedis.hgetAll("unittests:permissions:testuser:roles") == [:]
+    getCompressed("unittests:permissions-lz4:testuser:accounts") == null
+    getCompressed("unittests:permissions-lz4:testuser:applications") == null
+    getCompressed("unittests:permissions-lz4:testuser:service_accounts") == null
+    getCompressed("unittests:permissions-lz4:testuser:roles") == null
     jedis.smembers("unittests:roles:role1") == [] as Set
   }
 
   def "should get the permission out of redis"() {
     setup:
     jedis.sadd("unittests:users", "testuser")
-    jedis.hset("unittests:permissions:testuser:accounts",
-               "account",
-               '{"name":"account","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testuser:applications",
-               "app",
-               '{"name":"app","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testuser:service_accounts",
-               "serviceAccount",
-               '{"name":"serviceAccount"}')
+    setCompressed("unittests:permissions-lz4:testuser:accounts",
+               '{"account":{"name":"account","permissions":{"READ":["abc"]}}}')
+    setCompressed("unittests:permissions-lz4:testuser:applications",
+               '{"app":{"name":"app","permissions":{"READ":["abc"]}}}')
+    setCompressed("unittests:permissions-lz4:testuser:service_accounts",
+               '{"serviceAccount":{"name":"serviceAccount"}}')
 
     when:
     def result = repo.get("testuser").get()
@@ -303,9 +322,8 @@ class RedisPermissionsRepositorySpec extends Specification {
     result == expected
 
     when:
-    jedis.hset("unittests:permissions:__unrestricted_user__:accounts",
-               "account",
-               '{"name":"unrestrictedAccount","permissions":{}}')
+    setCompressed("unittests:permissions-lz4:__unrestricted_user__:accounts",
+               '{"account":{"name":"unrestrictedAccount","permissions":{}}}')
     jedis.set("unittests:last_modified:__unrestricted_user__", "1")
     result = repo.get("testuser").get()
 
@@ -322,30 +340,25 @@ class RedisPermissionsRepositorySpec extends Specification {
     Account account1 = new Account().setName("account1")
     Application app1 = new Application().setName("app1")
     ServiceAccount serviceAccount1 = new ServiceAccount().setName("serviceAccount1")
-    jedis.hset("unittests:permissions:testuser1:accounts",
-               "account1",
-               '{"name":"account1","permissions":{}}')
-    jedis.hset("unittests:permissions:testuser1:applications",
-               "app1",
-               '{"name":"app1","permissions":{}}')
-    jedis.hset("unittests:permissions:testuser1:service_accounts",
-               "serviceAccount1",
-               '{"name":"serviceAccount1"}')
+
+    setCompressed("unittests:permissions-lz4:testuser1:accounts",
+               '{"account1":{"name":"account1","permissions":{}}}')
+    setCompressed("unittests:permissions-lz4:testuser1:applications",
+               '{"app1":{"name":"app1","permissions":{}}}')
+    setCompressed("unittests:permissions-lz4:testuser1:service_accounts",
+               '{"serviceAccount1":{"name":"serviceAccount1"}}')
 
     and:
     def abcRead = new Permissions.Builder().add(Authorization.READ, "abc").build()
     Account account2 = new Account().setName("account2").setPermissions(abcRead)
     Application app2 = new Application().setName("app2").setPermissions(abcRead)
     ServiceAccount serviceAccount2 = new ServiceAccount().setName("serviceAccount2")
-    jedis.hset("unittests:permissions:testuser2:accounts",
-               "account2",
-               '{"name":"account2","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testuser2:applications",
-               "app2",
-               '{"name":"app2","permissions":{"READ":["abc"]}}')
-    jedis.hset("unittests:permissions:testuser2:service_accounts",
-               "serviceAccount2",
-               '{"name":"serviceAccount2"}')
+    setCompressed("unittests:permissions-lz4:testuser2:accounts",
+               '{"account2":{"name":"account2","permissions":{"READ":["abc"]}}}')
+    setCompressed("unittests:permissions-lz4:testuser2:applications",
+               '{"app2":{"name":"app2","permissions":{"READ":["abc"]}}}')
+    setCompressed("unittests:permissions-lz4:testuser2:service_accounts",
+               '{"serviceAccount2":{"name":"serviceAccount2"}}')
     and:
     jedis.sadd("unittests:permissions:admin", "testuser3")
 
@@ -410,15 +423,12 @@ class RedisPermissionsRepositorySpec extends Specification {
     def user5 = new UserPermission().setId("user5").setRoles([role5] as Set)
     def unrestricted = new UserPermission().setId(UNRESTRICTED).setAccounts([acct1] as Set)
 
-    jedis.hset("unittests:permissions:user1:roles", "role1", '{"name":"role1"}')
-    jedis.hset("unittests:permissions:user1:roles", "role2", '{"name":"role2"}')
-    jedis.hset("unittests:permissions:user2:roles", "role1", '{"name":"role1"}')
-    jedis.hset("unittests:permissions:user2:roles", "role3", '{"name":"role3"}')
-    jedis.hset("unittests:permissions:user4:roles", "role4", '{"name":"role4"}')
-    jedis.hset("unittests:permissions:user5:roles", "role5", '{"name":"role5"}')
-    jedis.hset("unittests:permissions:USER5:roles", "role5", '{"name":"role5"}')
+    setCompressed("unittests:permissions-lz4:user1:roles", '{"role1":{"name":"role1"},"role2":{"name":"role2"}}')
+    setCompressed("unittests:permissions-lz4:user2:roles", '{"role1":{"name":"role1"},"role3":{"name":"role3"}}')
+    setCompressed("unittests:permissions-lz4:user4:roles", '{"role4":{"name":"role4"}}')
+    setCompressed("unittests:permissions-lz4:user5:roles", '{"role5":{"name":"role5"}}')
 
-    jedis.hset("unittests:permissions:__unrestricted_user__:accounts", "acct1", '{"name":"acct1"}')
+    setCompressed("unittests:permissions-lz4:__unrestricted_user__:accounts", '{"acct1":{"name":"acct1"}}')
 
     jedis.sadd("unittests:roles:role1", "user1", "user2")
     jedis.sadd("unittests:roles:role2", "user1")


### PR DESCRIPTION
## WHAT
This PR makes a number of changes to improve the performance of RedisPermissionsRepository. As these are breaking changes from the perspective of the redis "schema" and other versions of Fiat, the changes are all together rather than in separate PRs. Splitting it up will require further renaming of redis keys to prevent conflicts, and this would further bloat redis memory usage. These changes are much better together than apart!

Summary:
 - Builds on top of the accepted / not merged [`Use byte[] instead of String` PR](https://github.com/spinnaker/fiat/pull/828)
 - Removes all uses of the O(n) operations [`HMSET`](https://redis.io/commands/hmset) / [`HGETALL`](https://redis.io/commands/hgetall) as the individual map keys are never used anyway. Replaces them with the O(1) [`GET`](https://redis.io/commands/get) / [`SET`](https://redis.io/commands/set) operations.
 - Serializes and deserializes objects in one go, no more strings containing JSON inside JSON which need to be parsed separately
 - Adds fast LZ4 deflate for compressing redis payloads, this has negligible CPU impact in exchange for significantly less IO. IO makes up a significant amount of time in `/roles/sync`
 - Adds a new permissions key `permissions-lz4` which is used instead of `permissions` for the above changes. That means updating fiat will not have any conflicts with old data that isn't a hashmap, isn't lz4 compressed etc. Downside: this means that after the upgrade, slightly more redis memory will be used for the new data + old data.

## WHY

The current RedisPermissionRepository is too slow for our use-case. This was an attempt (though it's not yet sufficient for us) to make fiat fast enough.

## RESULTS

https://github.com/Nessex/fiat/pull/1#issuecomment-785066525

## TODO

These are mostly administrative, the main change is pretty much ready to go.

 - [x] ~Take a second look at splitting up the PR~ This would require multiple data migrations.
 - [x] Get internal code review
 - [x] Squash changes to make them follow commit conventions
 - [ ] See if there's a way to clean up old redis `*:permissions:*` data after the upgrade
 - [ ] Add 1.24.1 + https://github.com/spinnaker/fiat/pull/828 + https://github.com/spinnaker/fiat/pull/830 branch to performance comparison
 - [ ] Wait for the [`Use byte[] instead of String` PR](https://github.com/spinnaker/fiat/pull/828) to be merged

---

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
