### PR TITLE
perf: Reduce Cost Of Sync Process

### DIFF
--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -79,7 +79,7 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
             applications: [
                 new Application(name: "abc-def",
                                 permissions: Permissions.factory([
-                                    (Authorization.READ): ["testRole"]
+                                    (Authorization.READ): ["testRole"] as Set
                                 ])),
             ],
             roles: [new Role("testRole")]

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Account.java
@@ -26,7 +26,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(
+    callSuper = false,
+    of = {"resourceType", "cloudProvider", "name"})
 public class Account extends BaseAccessControlled<Account> implements Viewable {
   final ResourceType resourceType = ResourceType.ACCOUNT;
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Application.java
@@ -29,7 +29,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(
+    callSuper = false,
+    of = {"resourceType", "name"})
 public class Application extends BaseAccessControlled<Application> implements Viewable {
   final ResourceType resourceType = ResourceType.APPLICATION;
 

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BaseAccessControlled.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BaseAccessControlled.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.netflix.spinnaker.fiat.model.Authorization;
-import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -31,7 +31,7 @@ public abstract class BaseAccessControlled<R extends BaseAccessControlled>
    * permissions.
    */
   @SuppressWarnings("unchecked")
-  public <T extends BaseAccessControlled> T setRequiredGroupMembership(List<String> membership) {
+  public <T extends BaseAccessControlled> T setRequiredGroupMembership(Set<String> membership) {
     if (membership == null || membership.isEmpty()) {
       return (T) this;
     }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BuildService.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/BuildService.java
@@ -26,7 +26,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Data
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(
+    callSuper = false,
+    of = {"resourceType", "name"})
 public class BuildService implements Resource.AccessControlled, Viewable {
 
   private final ResourceType resourceType = ResourceType.BUILD_SERVICE;

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/ResourceType.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 public class ResourceType {
 
   private final String name;
+  private final int hashCode;
 
   public static ResourceType ACCOUNT = new ResourceType("account");
   public static ResourceType APPLICATION = new ResourceType("application");
@@ -30,7 +31,8 @@ public class ResourceType {
   public static ResourceType BUILD_SERVICE = new ResourceType("build_service");
 
   public ResourceType(String name) {
-    this.name = name;
+    this.name = name.toLowerCase();
+    this.hashCode = Objects.hash(name);
   }
 
   // TODO(ttomsu): This is Redis-specific, so it probably shouldn't go here.
@@ -56,12 +58,12 @@ public class ResourceType {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ResourceType that = (ResourceType) o;
-    return Objects.equals(name.toLowerCase(), that.name.toLowerCase());
+    return Objects.equals(this.name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name.toLowerCase());
+    return hashCode;
   }
 
   @Override
@@ -70,6 +72,6 @@ public class ResourceType {
   }
 
   public String keySuffix() {
-    return name.toLowerCase() + "s";
+    return name + "s";
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Role.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.model.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.Data;
@@ -26,13 +27,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
-@Data
-@EqualsAndHashCode(of = "name")
-@NoArgsConstructor
 public class Role implements Resource, Viewable {
 
-  private final ResourceType resourceType = ResourceType.ROLE;
   private String name;
+  private int hashCode;
 
   public enum Source {
     EXTERNAL,
@@ -44,8 +42,18 @@ public class Role implements Resource, Viewable {
 
   private Source source;
 
+  public Role() {}
+
   public Role(String name) {
     this.setName(name);
+  }
+
+  public ResourceType getResourceType() {
+    return ResourceType.ROLE;
+  }
+
+  public String getName() {
+    return this.name;
   }
 
   public Role setName(@Nonnull String name) {
@@ -53,7 +61,41 @@ public class Role implements Resource, Viewable {
       throw new IllegalArgumentException("name cannot be empty");
     }
     this.name = name.toLowerCase();
+    this.hashCode = Objects.hash(ResourceType.ROLE, this.name);
     return this;
+  }
+
+  public Source getSource() {
+    return this.source;
+  }
+
+  public Role setSource(Source source) {
+    this.source = source;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Role that = (Role) o;
+    return Objects.equals(this.name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+  @Override
+  public String toString() {
+    return "Role(resourceType="
+        + this.getResourceType()
+        + ", name="
+        + this.getName()
+        + ", source="
+        + this.getSource()
+        + ")";
   }
 
   @JsonIgnore

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/resources/PermissionsSpec.groovy
@@ -68,24 +68,24 @@ class PermissionsSpec extends Specification {
     Permissions p = mapper.readValue(permissionJson, Permissions)
 
     then:
-    p.get(R) == ["foo"]
-    p.get(W) == ["bar"]
-    p.get(E) == []
+    p.get(R) == ["foo"] as Set
+    p.get(W) == ["bar"] as Set
+    p.get(E) == [] as Set
 
     when:
     Permissions.Builder b = mapper.readValue(permissionJson, Permissions.Builder)
     p = b.build()
 
     then:
-    p.get(R) == ["foo"]
-    p.get(W) == ["bar"]
-    p.get(E) == []
+    p.get(R) == ["foo"] as Set
+    p.get(W) == ["bar"] as Set
+    p.get(E) == [] as Set
   }
 
   def "should serialize"() {
     when:
     Permissions.Builder b = new Permissions.Builder()
-    b.set([(R): ["foo"], (W): ["bar"]])
+    b.set([(R): ["foo"] as Set, (W): ["bar"] as Set])
 
     then:
     permissionSerialized ==  mapper.writer(printer).writeValueAsString(b.build())
@@ -108,16 +108,16 @@ class PermissionsSpec extends Specification {
   def "should trim and lower"() {
     when:
     Permissions.Builder b = new Permissions.Builder()
-    b.set([(R): ["FOO"]])
+    b.set([(R): ["FOO"] as Set])
 
     then:
-    b.build().get(R) == ["foo"]
+    b.build().get(R) == ["foo"] as Set
 
     when:
     b.add(W, "bAr          ")
 
     then:
-    b.build().get(W) == ["bar"]
+    b.build().get(W) == ["bar"] as Set
   }
 
   def "test immutability"() {
@@ -146,13 +146,13 @@ class PermissionsSpec extends Specification {
     b.build().allGroups() == ["foo"] as Set
 
     when:
-    Permissions p = Permissions.factory([(R): ["bar"], (W): ["bar"]])
+    Permissions p = Permissions.factory([(R): ["bar"] as Set, (W): ["bar"] as Set])
 
     then:
     p.allGroups() == ["bar"] as Set
 
     when:
-    p = Permissions.factory([(R): ["foo"], (W): ["bar"]])
+    p = Permissions.factory([(R): ["foo"] as Set, (W): ["bar"] as Set])
 
     then:
     p.allGroups() == ["foo", "bar"] as Set
@@ -173,13 +173,13 @@ class PermissionsSpec extends Specification {
     p.getAuthorizations([]) == [R, W, E, C] as Set
 
     when:
-    p = Permissions.factory([(R): ["bar"], (W): ["bar"]])
+    p = Permissions.factory([(R): ["bar"] as Set, (W): ["bar"] as Set])
 
     then:
     p.getAuthorizations(["bar"]) == [R, W] as Set
 
     when:
-    p = Permissions.factory([(R): ["bar"]])
+    p = Permissions.factory([(R): ["bar"] as Set])
 
     then:
     p.getAuthorizations(["bar", "foo"]) == [R] as Set
@@ -194,8 +194,8 @@ class PermissionsSpec extends Specification {
     Permissions p = testConfigProps.permissions.build()
 
     then:
-    p.get(R) == ["foo"]
-    p.get(W) == ["bar"]
+    p.get(R) == ["foo"] as Set
+    p.get(W) == ["bar"] as Set
   }
 
   @Configuration

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolver.java
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 public class DefaultFallbackPermissionsResolver implements FallbackPermissionsResolver {
@@ -23,7 +23,7 @@ public class DefaultFallbackPermissionsResolver implements FallbackPermissionsRe
 
   @Override
   public Permissions resolve(@Nonnull Permissions permissions) {
-    Map<Authorization, List<String>> authorizations = permissions.unpack();
+    Map<Authorization, Set<String>> authorizations = permissions.unpack();
     authorizations.put(fallbackFrom, authorizations.get(fallbackTo));
     return Permissions.Builder.factory(authorizations).build();
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ApplicationResourcePermissionSource.java
@@ -23,8 +23,8 @@ import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 public final class ApplicationResourcePermissionSource
@@ -38,7 +38,7 @@ public final class ApplicationResourcePermissionSource
       return Permissions.EMPTY;
     }
 
-    Map<Authorization, List<String>> authorizations =
+    Map<Authorization, Set<String>> authorizations =
         Arrays.stream(Authorization.values()).collect(toMap(identity(), storedPermissions::get));
 
     // CREATE permissions are not allowed on the resource level.

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ChaosMonkeyApplicationResourcePermissionSource.java
@@ -20,17 +20,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 public class ChaosMonkeyApplicationResourcePermissionSource
     implements ResourcePermissionSource<Application> {
 
-  private final List<String> roles;
+  private final Set<String> roles;
   private final ObjectMapper objectMapper;
 
   public ChaosMonkeyApplicationResourcePermissionSource(
-      List<String> roles, ObjectMapper objectMapper) {
+      Set<String> roles, ObjectMapper objectMapper) {
     this.roles = roles;
     this.objectMapper = objectMapper;
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Resource;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Data;
@@ -56,7 +57,7 @@ public class ResourcePrefixPermissionSource<T extends Resource.AccessControlled>
       return this;
     }
 
-    public PrefixEntry setPermissions(Map<Authorization, List<String>> permissions) {
+    public PrefixEntry setPermissions(Map<Authorization, Set<String>> permissions) {
       this.permissions = Permissions.factory(permissions);
       return this;
     }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultFallbackPermissionsResolverSpec.groovy
@@ -11,6 +11,9 @@ class DefaultFallbackPermissionsResolverSpec extends Specification {
     private static final Authorization E = Authorization.EXECUTE
     private static final Authorization C = Authorization.CREATE
 
+    private static final Set<String> READ = ['r'] as Set
+    private static final Set<String> WRITE = ['w'] as Set
+    
     def makePerms(Map<Authorization, List<String>> auths) {
         return Permissions.Builder.factory(auths).build()
     }
@@ -27,10 +30,10 @@ class DefaultFallbackPermissionsResolverSpec extends Specification {
         makePerms(expectedPermissions) == result
 
         where:
-        fallbackFrom  ||  fallbackTo  || givenPermissions         || expectedPermissions
-        E             ||  R           || [:]                      || [:]
-        E             ||  R           || [(R): ['r']]             || [(R): ['r'], (E): ['r']]
-        E             ||  W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
-        C             ||  W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (C): ['w']]
+        fallbackFrom  ||  fallbackTo  || givenPermissions        || expectedPermissions
+        E             ||  R           || [:]                     || [:]
+        E             ||  R           || [(R): READ]             || [(R): READ, (E): READ]
+        E             ||  W           || [(R): READ, (W): WRITE] || [(R): READ, (W): WRITE, (E): WRITE]
+        C             ||  W           || [(R): READ, (W): WRITE] || [(R): READ, (W): WRITE, (C): WRITE]
     }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -51,14 +51,14 @@ class DefaultPermissionsResolverSpec extends Specification {
 
   @Shared
   Account reqGroup1Acct = new Account().setName("reqGroup1")
-                                       .setRequiredGroupMembership(["group1"])
+                                       .setRequiredGroupMembership(["group1"] as Set)
   @Shared
   Account reqGroup1and2Acct = new Account().setName("reqGroup1and2")
-                                           .setRequiredGroupMembership(["group1", "GrouP2"]) // test case insensitivity.
+                                           .setRequiredGroupMembership(["group1", "GrouP2"] as Set) // test case insensitivity.
 
   @Shared
   Account anonymousRead = new Account().setName("anonymousRead")
-                                       .setPermissions(Permissions.factory((Authorization.READ): [anonymous.name], (Authorization.WRITE): ["otherGroup"]))
+                                       .setPermissions(Permissions.factory((Authorization.READ): [anonymous.name] as Set, (Authorization.WRITE): ["otherGroup"] as Set))
 
   @Shared
   ClouddriverService clouddriverService = Mock(ClouddriverService) {

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -42,7 +42,11 @@ class DefaultApplicationProviderSpec extends Specification {
   @Subject DefaultApplicationResourceProvider provider
 
   def makePerms(Map<Authorization, List<String>> auths) {
-    return Permissions.Builder.factory(auths).build()
+    Map<Authorization, Set<String>> data = new HashMap<>()
+    if (auths != null) {
+      auths.entrySet().forEach { data.put(it.key, new HashSet(it.value)) }
+    }
+    return Permissions.Builder.factory(data).build()
   }
 
   @Unroll

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSourceSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSourceSpec.groovy
@@ -26,19 +26,19 @@ class ResourcePrefixPermissionSourceSpec extends Specification {
         given:
         def source = new ResourcePrefixPermissionSource<Application>().setPrefixes([
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('*').setPermissions([
-                        (Authorization.CREATE): ['admins']
+                        (Authorization.CREATE): ['admins'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('gotham*').setPermissions([
-                        (Authorization.CREATE): ['police']
+                        (Authorization.CREATE): ['police'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('gotham-joker').setPermissions([
-                        (Authorization.CREATE): ['batman']
+                        (Authorization.CREATE): ['batman'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('foo*').setPermissions([
-                        (Authorization.CREATE): ['police']
+                        (Authorization.CREATE): ['police'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('foo-joker').setPermissions([
-                        (Authorization.CREATE): ['batman']
+                        (Authorization.CREATE): ['batman'] as Set
                 ]),
         ]).setResolutionStrategy(ResourcePrefixPermissionSource.ResolutionStrategy.AGGREGATE)
 
@@ -61,19 +61,19 @@ class ResourcePrefixPermissionSourceSpec extends Specification {
         given:
         def source = new ResourcePrefixPermissionSource<Application>().setPrefixes([
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('*').setPermissions([
-                        (Authorization.CREATE): ['admins']
+                        (Authorization.CREATE): ['admins'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('gotham*').setPermissions([
-                        (Authorization.CREATE): ['police']
+                        (Authorization.CREATE): ['police'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('gotham-joker').setPermissions([
-                        (Authorization.CREATE): ['batman']
+                        (Authorization.CREATE): ['batman'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('foo*').setPermissions([
-                        (Authorization.CREATE): ['police']
+                        (Authorization.CREATE): ['police'] as Set
                 ]),
                 new ResourcePrefixPermissionSource.PrefixEntry<Application>().setPrefix('foo-joker').setPermissions([
-                        (Authorization.CREATE): ['batman']
+                        (Authorization.CREATE): ['batman'] as Set
                 ]),
         ]).setResolutionStrategy(ResourcePrefixPermissionSource.ResolutionStrategy.MOST_SPECIFIC)
 

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatServerConfigurationProperties.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.fiat.config;
 
 import com.netflix.spinnaker.fiat.model.Authorization;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -54,7 +54,7 @@ public class FiatServerConfigurationProperties {
 
   @Data
   static class ChaosMonkeyConfigurationProperties {
-    private List<String> roles = new ArrayList<>();
+    private Set<String> roles = new LinkedHashSet<>();
   }
 
   @Data

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/controllers/AuthorizeControllerSpec.groovy
@@ -389,7 +389,7 @@ class AuthorizeControllerSpec extends Specification {
     given:
     def applicationResourcePermissionProvider = Mock(ResourcePermissionProvider) {
       getPermissions(_) >> Permissions.factory([
-              (Authorization.CREATE): ['rolea']
+              (Authorization.CREATE): ['rolea'] as Set
       ])
     }
     permissionsRepository.put(roleAUser)


### PR DESCRIPTION
This change reduces the cost of generating the in-memory model for `UserPermission` and can cut sync time substantially for installations with a high number of resources, roles, and users. There should be no compatibility changes.

The primary changes are:

* Pre-compute the hash code for `ResourceType`, `Role`, and `Permission`. These objects are immutable are are treated as such within the code. At scale, the hash computation becomes expensive given the extensive usage of `Map` and `Set`.
* Change the internal representation of the roles associated with an `Authorization` type within `Permission` to be a `Set`. This makes the calculation of effective permissions vastly cheaper as the call to `Collections.disjoint()` can use an optimised path for `Set` rather than iterating over two lists of roles.
* Change how the hash code is computed for the Fiat domain model and only use fields that are relevant, typically excluding the `permissions` object. This reduces the cost of computing the hash which is a benefit to the sync process as it typically calls `UserPermission.getAllResources()` a lot.
* Improve the hash code calculation for Fiat domain to include the resource type value. This reduces the chance of collisions within the `Set` when calling `UserPermission.getAllResources()`

These changes combined and deployed in conjunction with #849 our role sync times go from an average of 4.5 minutes to 1.5 minutes to sync around 21,000,000 permissions. This should also benefit anyone using the Redis back end as the changes are storage layer independent.