### PR TITLE
fix(build): release version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
     - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+    - "version-[0-9]+.[0-9]+.[0-9]+"
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g


### PR DESCRIPTION
The jenkins jobs that publish/release spinnaker use tags of this form. See e.g
spinnaker/buildtool@d5ce139/dev/buildtool/spinnaker_commands.py#L295
+
spinnaker/buildtool@d5ce139/dev/buildtool/spinnaker_commands.py#L305

Those jobs currently publish to bintray, but since that is going away, let's publish to nexus.