### PR TITLE
fix(config): Remove unsupported config keys

### DIFF
--- a/fiat-web/config/fiat.yml
+++ b/fiat-web/config/fiat.yml
@@ -8,10 +8,6 @@ okHttpClient:
   retries:
     maxElapsedBackoffMs: 5000
 
-endpoints:
-  health:
-    sensitive: false
-
 # For options, see com.netflix.spinnaker.fiat.config.FiatServerConfigurationProperties
 
 logging:


### PR DESCRIPTION
This change removes the configuration key `endpoints.health.sensitive`
from `fiat.yml` as it's no longer supported.

Currently when starting Fiat the following message is printed:
```
The use of configuration keys that are no longer supported was found in the environment:

Property source 'applicationConfig: [classpath:/fiat.yml]':
	Key: endpoints.health.sensitive
		Line: 13
		Reason: Endpoint sensitive flag is no longer customizable as Spring Boot no longer provides a customizable security auto-configuration .
```

With this change that message is no longer printed.
