### PR TITLE
fix: improve performance of role sync with SQL

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
@@ -60,12 +60,13 @@ public interface PermissionsRepository {
   Map<String, Set<Role>> getAllById();
 
   /**
-   * Gets all Roles in the repository that has at least 1 of the specified roles, keyed by user ID.
-   * Because this method is usually used in conjunction with updating/syncing the users in question,
-   * the returned map will also contain the unrestricted user. If anyRoles is null, returns the same
-   * result as getAllById() (which includes the unrestricted user). If anyRoles is empty, this is an
-   * indication to sync only the anonymous/unrestricted user. When this is the case, this method
-   * returns a map with a single entry for the unrestricted user.
+   * Gets a map of all users and their Roles from the repository where the user has at least one of
+   * the specified named roles. Because this method is usually used in conjunction with
+   * updating/syncing the users in question, the returned map will also contain the unrestricted
+   * user. If anyRoles is null, returns the same result as getAllById() (which includes the
+   * unrestricted user). If anyRoles is empty, this is an indication to sync only the
+   * anonymous/unrestricted user. When this is the case, this method returns a map with a single
+   * entry for the unrestricted user.
    *
    * @param anyRoles
    * @return

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsRepository.java
@@ -17,9 +17,11 @@
 package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A PermissionsRepository is responsible for persisting UserPermission objects under a user ID key.
@@ -54,21 +56,21 @@ public interface PermissionsRepository {
    */
   Optional<UserPermission> get(String id);
 
-  /** Gets all UserPermissions in the repository keyed by user ID. */
-  Map<String, UserPermission> getAllById();
+  /** Gets all Roles in the repository keyed by user ID. */
+  Map<String, Set<Role>> getAllById();
 
   /**
-   * Gets all UserPermissions in the repository that has at least 1 of the specified roles, keyed by
-   * user ID. Because this method is usually used in conjuction with updating/syncing the users in
-   * question, the returned map will also contain the unrestricted user. If anyRoles is null,
-   * returns the same result as getAllById() (which includes the unrestricted user). If anyRoles is
-   * empty, this is an indication to sync only the anonymous/unrestricted user. When this is the
-   * case, this method returns a map with a single entry for the unrestricted user.
+   * Gets all Roles in the repository that has at least 1 of the specified roles, keyed by user ID.
+   * Because this method is usually used in conjunction with updating/syncing the users in question,
+   * the returned map will also contain the unrestricted user. If anyRoles is null, returns the same
+   * result as getAllById() (which includes the unrestricted user). If anyRoles is empty, this is an
+   * indication to sync only the anonymous/unrestricted user. When this is the case, this method
+   * returns a map with a single entry for the unrestricted user.
    *
    * @param anyRoles
    * @return
    */
-  Map<String, UserPermission> getAllByRoles(List<String> anyRoles);
+  Map<String, Set<Role>> getAllByRoles(List<String> anyRoles);
 
   /**
    * Delete the specified user permission.

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import net.jpountz.lz4.*;
 import redis.clients.jedis.*;
 import redis.clients.jedis.commands.BinaryJedisCommands;
@@ -392,15 +391,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     Set<String> allUsers =
         scanSet(allUsersKey).stream().map(String::toLowerCase).collect(Collectors.toSet());
 
-    if (allUsers.isEmpty()) {
-      return new HashMap<>(0);
-    }
-
-    return allUsers.stream()
-        .map(this::get)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.toMap(UserPermission::getId, p -> p.getRoles()));
+    return getRolesOf(allUsers);
   }
 
   @Override
@@ -408,13 +399,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     if (anyRoles == null) {
       return getAllById();
     } else if (anyRoles.isEmpty()) {
-      val unrestricted = getFromRedis(UNRESTRICTED);
-      if (unrestricted.isPresent()) {
-        val map = new HashMap<String, Set<Role>>();
-        map.put(UNRESTRICTED, unrestricted.get().getRoles());
-        return map;
-      }
-      return new HashMap<>();
+      return getRolesOf(Set.of(UNRESTRICTED));
     }
 
     final Set<String> uniqueUsernames = new HashSet<>();
@@ -424,11 +409,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     }
     uniqueUsernames.add(UNRESTRICTED);
 
-    return uniqueUsernames.stream()
-        .map(this::get)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.toMap(UserPermission::getId, p -> p.getRoles()));
+    return getRolesOf(uniqueUsernames);
   }
 
   @Override
@@ -449,6 +430,33 @@ public class RedisPermissionsRepository implements PermissionsRepository {
     } catch (Exception e) {
       log.error("Storage exception reading " + id + " entry.", e);
     }
+  }
+
+  private Map<String, Set<Role>> getRolesOf(Set<String> userIds) {
+    if (userIds.isEmpty()) {
+      return new HashMap<>(0);
+    }
+
+    Map<String, Set<Role>> usersToRoles = new HashMap<>(userIds.size());
+
+    for (String userId : userIds) {
+      try {
+        Set<Role> roles =
+            getUserResourceMapFromRedis(userId, ResourceType.ROLE).values().stream()
+                .map(it -> (Role) it)
+                .collect(Collectors.toSet());
+        usersToRoles.put(userId, roles);
+      } catch (Throwable t) {
+        String message = String.format("Storage exception reading %s entry.", userId);
+        log.error(message, t);
+        if (t instanceof SpinnakerException) {
+          throw (SpinnakerException) t;
+        }
+        throw new PermissionReadException(message, t);
+      }
+    }
+
+    return usersToRoles;
   }
 
   private Set<String> scanSet(byte[] key) {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -332,7 +332,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
   }
 
   @Override
-  public Map<String, UserPermission> getAllById() {
+  public Map<String, Set<Role>> getAllById() {
     Set<String> allUsers =
         scanSet(SafeEncoder.encode(allUsersKey)).stream()
             .map(String::toLowerCase)
@@ -346,18 +346,18 @@ public class RedisPermissionsRepository implements PermissionsRepository {
         .map(this::get)
         .filter(Optional::isPresent)
         .map(Optional::get)
-        .collect(Collectors.toMap(UserPermission::getId, p -> p));
+        .collect(Collectors.toMap(UserPermission::getId, p -> p.getRoles()));
   }
 
   @Override
-  public Map<String, UserPermission> getAllByRoles(List<String> anyRoles) {
+  public Map<String, Set<Role>> getAllByRoles(List<String> anyRoles) {
     if (anyRoles == null) {
       return getAllById();
     } else if (anyRoles.isEmpty()) {
       val unrestricted = getFromRedis(UNRESTRICTED);
       if (unrestricted.isPresent()) {
-        val map = new HashMap<String, UserPermission>();
-        map.put(UNRESTRICTED, unrestricted.get());
+        val map = new HashMap<String, Set<Role>>();
+        map.put(UNRESTRICTED, unrestricted.get().getRoles());
         return map;
       }
       return new HashMap<>();
@@ -374,7 +374,7 @@ public class RedisPermissionsRepository implements PermissionsRepository {
         .map(this::get)
         .filter(Optional::isPresent)
         .map(Optional::get)
-        .collect(Collectors.toMap(UserPermission::getId, p -> p));
+        .collect(Collectors.toMap(UserPermission::getId, p -> p.getRoles()));
   }
 
   @Override

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -396,7 +396,7 @@ class RedisPermissionsRepositorySpec extends Specification {
                                         .setServiceAccounts([serviceAccount2] as Set)
     def testUser3 = new UserPermission().setId("testUser3")
                                         .setAdmin(true)
-    result == ["testuser1": testUser1, "testuser2": testUser2, "testuser3": testUser3]
+    result == ["testuser1": testUser1.getRoles(), "testuser2": testUser2.getRoles(), "testuser3": testUser3.getRoles()]
   }
 
   def "should delete the specified user"() {
@@ -465,40 +465,40 @@ class RedisPermissionsRepositorySpec extends Specification {
     def result = repo.getAllByRoles(["role1"])
 
     then:
-    result == ["user1"       : user1.merge(unrestricted),
-               "user2"       : user2.merge(unrestricted),
-               (UNRESTRICTED): unrestricted]
+    result == ["user1"       : user1.getRoles() + unrestricted.getRoles(),
+               "user2"       : user2.getRoles() + unrestricted.getRoles(),
+               (UNRESTRICTED): unrestricted.getRoles()]
 
     when:
     result = repo.getAllByRoles(["role3", "role4"])
 
     then:
-    result == ["user2"       : user2.merge(unrestricted),
-               "user4"       : user4.merge(unrestricted),
-               (UNRESTRICTED): unrestricted]
+    result == ["user2"       : user2.getRoles() + unrestricted.getRoles(),
+               "user4"       : user4.getRoles() + unrestricted.getRoles(),
+               (UNRESTRICTED): unrestricted.getRoles()]
 
     when:
     result = repo.getAllByRoles(null)
 
     then:
-    result == ["user1"       : user1.merge(unrestricted),
-               "user2"       : user2.merge(unrestricted),
-               "user3"       : user3.merge(unrestricted),
-               "user4"       : user4.merge(unrestricted),
-               "user5"       : user5.merge(unrestricted),
-               (UNRESTRICTED): unrestricted]
+    result == ["user1"       : user1.getRoles() + unrestricted.getRoles(),
+               "user2"       : user2.getRoles() + unrestricted.getRoles(),
+               "user3"       : user3.getRoles() + unrestricted.getRoles(),
+               "user4"       : user4.getRoles() + unrestricted.getRoles(),
+               "user5"       : user5.getRoles() + unrestricted.getRoles(),
+               (UNRESTRICTED): unrestricted.getRoles()]
 
     when:
     result = repo.getAllByRoles([])
 
     then:
-    result == [(UNRESTRICTED): unrestricted]
+    result == [(UNRESTRICTED): unrestricted.getRoles()]
 
     when:
     result = repo.getAllByRoles(["role5"])
 
     then:
-    result == ["user5"       : user5.merge(unrestricted),
-               (UNRESTRICTED): unrestricted]
+    result == ["user5"       : user5.getRoles() + unrestricted.getRoles(),
+               (UNRESTRICTED): unrestricted.getRoles()]
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -164,10 +164,10 @@ class UserRolesSyncerSpec extends Specification {
 
     expect:
     repo.getAllById() == [
-        "user1"       : user1.merge(unrestrictedUser),
-        "user2"       : user2.merge(unrestrictedUser),
-        "user3"       : user3.merge(unrestrictedUser),
-        (UNRESTRICTED): unrestrictedUser
+        "user1"       : user1.getRoles() + unrestrictedUser.getRoles(),
+        "user2"       : user2.getRoles() + unrestrictedUser.getRoles(),
+        "user3"       : user3.getRoles() + unrestrictedUser.getRoles(),
+        (UNRESTRICTED): unrestrictedUser.getRoles()
     ]
 
     when:
@@ -192,20 +192,20 @@ class UserRolesSyncerSpec extends Specification {
     def expectedResult
     if (fullsync) {
       expectedResult = [
-              "user1"         : user1.merge(unrestrictedUser),
-              "user2"         : newUser2.merge(unrestrictedUser),
-              "user3"         : newUser3.merge(unrestrictedUser),
-              "abc"           : abcServiceAcct.merge(unrestrictedUser),
-              "xyz@domain.com": xyzServiceAcct.merge(unrestrictedUser),
-              (UNRESTRICTED)  : unrestrictedUser
+              "user1"         : user1.getRoles() + unrestrictedUser.getRoles(),
+              "user2"         : newUser2.getRoles() + unrestrictedUser.getRoles(),
+              "user3"         : newUser3.getRoles() + unrestrictedUser.getRoles(),
+              "abc"           : abcServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              "xyz@domain.com": xyzServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              (UNRESTRICTED)  : unrestrictedUser.getRoles()
       ]
     } else {
       expectedResult = [
-              "user1"         : user1.merge(unrestrictedUser),
-              "user2"         : user2.merge(unrestrictedUser),
-              "user3"         : newUser3.merge(unrestrictedUser),
-              "abc"           : abcServiceAcct.merge(unrestrictedUser),
-              (UNRESTRICTED)  : unrestrictedUser
+              "user1"         : user1.getRoles() + unrestrictedUser.getRoles(),
+              "user2"         : user2.getRoles() + unrestrictedUser.getRoles(),
+              "user3"         : newUser3.getRoles() + unrestrictedUser.getRoles(),
+              "abc"           : abcServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              (UNRESTRICTED)  : unrestrictedUser.getRoles()
       ]
     }
     repo.getAllById() == expectedResult

--- a/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
+++ b/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
@@ -418,9 +418,9 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        "testuser1" to testUser1,
-                        "testuser2" to testUser2,
-                        "testuser3" to testUser3
+                        "testuser1" to testUser1.roles,
+                        "testuser2" to testUser2.roles,
+                        "testuser3" to testUser3.roles
                     )
                 )
             }
@@ -488,9 +488,9 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        "user1" to user1.merge(unrestricted),
-                        "user2" to user2.merge(unrestricted),
-                        UNRESTRICTED_USERNAME to unrestricted
+                        "user1" to user1.roles.plus(unrestricted.roles),
+                        "user2" to user2.roles.plus(unrestricted.roles),
+                        UNRESTRICTED_USERNAME to unrestricted.roles
                     )
                 )
 
@@ -498,9 +498,9 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        "user2" to user2.merge(unrestricted),
-                        "user4" to user4.merge(unrestricted),
-                        UNRESTRICTED_USERNAME to unrestricted
+                        "user2" to user2.roles.plus(unrestricted.roles),
+                        "user4" to user4.roles.plus(unrestricted.roles),
+                        UNRESTRICTED_USERNAME to unrestricted.roles
                     )
                 )
 
@@ -508,12 +508,12 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        "user1" to user1.merge(unrestricted),
-                        "user2" to user2.merge(unrestricted),
-                        "user3" to user3.merge(unrestricted),
-                        "user4" to user4.merge(unrestricted),
-                        "user5" to user5.merge(unrestricted),
-                        UNRESTRICTED_USERNAME to unrestricted
+                        "user1" to user1.roles.plus(unrestricted.roles),
+                        "user2" to user2.roles.plus(unrestricted.roles),
+                        "user3" to user3.roles.plus(unrestricted.roles),
+                        "user4" to user4.roles.plus(unrestricted.roles),
+                        "user5" to user5.roles.plus(unrestricted.roles),
+                        UNRESTRICTED_USERNAME to unrestricted.roles
                     )
                 )
 
@@ -521,7 +521,7 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        UNRESTRICTED_USERNAME to unrestricted
+                        UNRESTRICTED_USERNAME to unrestricted.roles
                     )
                 )
 
@@ -529,8 +529,8 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
 
                 expectThat(result).isEqualTo(
                     mapOf(
-                        "user5" to user5.merge(unrestricted),
-                        UNRESTRICTED_USERNAME to unrestricted
+                        "user5" to user5.roles.plus(unrestricted.roles),
+                        UNRESTRICTED_USERNAME to unrestricted.roles
                     )
                 )
             }
@@ -681,7 +681,6 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
                     executor.shutdownNow()
                 }
             }
-
         }
 
         after {

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/AuthorizeController.java
@@ -89,7 +89,10 @@ public class AuthorizeController {
     }
 
     log.debug("UserPermissions requested for all users");
-    return permissionsRepository.getAllById().values().stream()
+    return permissionsRepository.getAllById().keySet().stream()
+        .map(permissionsRepository::get)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .map(UserPermission::getView)
         .map(
             u ->


### PR DESCRIPTION
The permission rebuild process during role synchronization only requires
the set of roles that each user has. This change modifies the SQL and
Redis `PermissionRepository` instances to only return the roles.

For our use case this drops about 2 minutes of the sync time (so from 3 minutes to 1 minute).