### PR TITLE
Fix testcontainers jdbc urls

### DIFF
--- a/fiat-sql/fiat-sql.gradle
+++ b/fiat-sql/fiat-sql.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j"
 
+    testImplementation "io.spinnaker.kork:kork-sql-test"
+
     testImplementation "io.mockk:mockk"
     testImplementation "dev.minutest:minutest"
     testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
+++ b/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.fiat.permissions.sql.tables.references.PERMISSION
 import com.netflix.spinnaker.fiat.permissions.sql.tables.references.RESOURCE
 import com.netflix.spinnaker.fiat.permissions.sql.tables.references.USER
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import dev.minutest.ContextBuilder
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -696,11 +697,11 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
     fun tests() = rootContext<JooqConfig> {
 
         fixture {
-            JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22:///databasename")
+           JooqConfig(SQLDialect.MYSQL, SqlTestUtil.tcJdbcUrl)
         }
 
         context("mysql CRUD operations") {
-            crudOperations(JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22:///databasename"))
+            crudOperations(JooqConfig(SQLDialect.MYSQL, SqlTestUtil.tcJdbcUrl))
         }
 
         context("postgresql CRUD operations") {

--- a/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
+++ b/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
@@ -696,18 +696,18 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
     fun tests() = rootContext<JooqConfig> {
 
         fixture {
-            JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22://somehostname:someport/databasename")
+            JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22:///databasename")
         }
 
         context("mysql CRUD operations") {
-            crudOperations(JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22://somehostname:someport/databasename"))
+            crudOperations(JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22:///databasename"))
         }
 
         context("postgresql CRUD operations") {
             crudOperations(
                 JooqConfig(
                     SQLDialect.POSTGRES,
-                    "jdbc:tc:postgresql:12-alpine://somehostname:someport/databasename"
+                    "jdbc:tc:postgresql:12-alpine:///databasename"
                 )
             )
         }

--- a/fiat-web/src/test/resources/fiat-test.yml
+++ b/fiat-web/src/test/resources/fiat-test.yml
@@ -20,10 +20,10 @@ sql:
   enabled: false
   connectionPools:
     default:
-      jdbcUrl: "jdbc:tc:mysql:5.7.22://somehostname:someport/somedb"
+      jdbcUrl: "jdbc:tc:mysql:5.7.22:///somedb"
       user:
   migration:
-    jdbcUrl: "jdbc:tc:mysql:5.7.22://somehostname:someport/somedb"
+    jdbcUrl: "jdbc:tc:mysql:5.7.22:///somedb"
     user:
 
 permissionsRepository:

--- a/fiat-web/src/test/resources/fiat-test.yml
+++ b/fiat-web/src/test/resources/fiat-test.yml
@@ -18,13 +18,6 @@ spring:
 
 sql:
   enabled: false
-  connectionPools:
-    default:
-      jdbcUrl: "jdbc:tc:mysql:5.7.22:///somedb"
-      user:
-  migration:
-    jdbcUrl: "jdbc:tc:mysql:5.7.22:///somedb"
-    user:
 
 permissionsRepository:
   redis:


### PR DESCRIPTION
This works with testcontainers 1.15.1, but also with 1.16.2, where 1.16.2 [broke before this](https://github.com/spinnaker/fiat/runs/4218090381?check_suite_focus=true).