### PR TITLE
fix(build): bump kork to 7.110.0, change groupId fro dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 subprojects {
-  group = "com.netflix.spinnaker.fiat"
+  group = "io.spinnaker.fiat"
   apply plugin: 'io.spinnaker.project'
 
   if ([korkVersion].find { it.endsWith("-SNAPSHOT") }) {
@@ -50,12 +50,12 @@ subprojects {
     }
 
     dependencies {
-      implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
       compileOnly "org.projectlombok:lombok"
-      annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-      testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
 
       testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-  api "com.netflix.spinnaker.kork:kork-api"
+  api "io.spinnaker.kork:kork-api"
 
   implementation project(":fiat-core")
 
@@ -24,10 +24,10 @@ dependencies {
   implementation "org.springframework.security:spring-security-core"
   implementation "org.springframework.security:spring-security-web"
   implementation "com.netflix.spectator:spectator-api"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-security"
-  implementation "com.netflix.spinnaker.kork:kork-telemetry"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-telemetry"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"

--- a/fiat-bom/fiat-bom.gradle
+++ b/fiat-bom/fiat-bom.gradle
@@ -21,7 +21,7 @@ javaPlatform {
 }
 
 dependencies {
-  api(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
+  api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
     rootProject

--- a/fiat-github/fiat-github.gradle
+++ b/fiat-github/fiat-github.gradle
@@ -8,5 +8,5 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-web"
 }

--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -30,12 +30,12 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-aop"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
-  implementation "com.netflix.spinnaker.kork:kork-security"
-  implementation "com.netflix.spinnaker.kork:kork-telemetry"
+  implementation "io.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-telemetry"
   implementation "redis.clients:jedis"
   implementation "com.google.api-client:google-api-client"
 
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+  testImplementation "io.spinnaker.kork:kork-jedis-test"
   testImplementation "org.apache.commons:commons-collections4:4.1"
 }

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -9,7 +9,7 @@ run {
   systemProperty('spring.config.additional-location', project.springConfigLocation)
   systemProperty('spring.profiles.active', project.springProfiles)
 }
-mainClassName = 'com.netflix.spinnaker.fiat.Main'
+mainClassName = 'io.spinnaker.fiat.Main'
 
 configurations.all {
   exclude group: 'javax.servlet', module: 'servlet-api'
@@ -28,12 +28,12 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-properties-migrator"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
-  implementation "com.netflix.spinnaker.kork:kork-plugins"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-plugins"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "io.swagger:swagger-annotations"
   implementation "net.logstash.logback:logstash-logback-encoder"
 
-  runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"
+  runtimeOnly "io.spinnaker.kork:kork-runtime"
 
   implementation project(':fiat-core')
   implementation project(':fiat-roles')
@@ -43,8 +43,8 @@ dependencies {
     implementation project(it)
   }
 
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis"
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+  testImplementation "io.spinnaker.kork:kork-jedis"
+  testImplementation "io.spinnaker.kork:kork-jedis-test"
 }
 
 applicationName = 'fiat'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 includeProviders=file,github,google-groups,ldap
-korkVersion=7.99.1
+korkVersion=7.110.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1
 targetJava11=true


### PR DESCRIPTION
There is an issue in the Plugins Framework that was solved in this PR: spinnaker/kork#866

but this fix was released in kork 7.110.0

I bumped the version of kork to include the fix in VersionManager in the plugins framework but this involved changing the groupId of kork because now it's been published under "io.spinnaker" and this release branch is pretty old.

I had to bump the version of Fiat as well because it has issues when trying to download the kork version in fiat due to the groupId change.