### PR TITLE
fix(dependency): Issue with jackson-bom and kotlin-bom version conflict resolution while upgrading the spring-boot 2.3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
     }
 
     dependencies {
-      implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       compileOnly "org.projectlombok:lombok"
       annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"


### PR DESCRIPTION
The root cause of this issue is uncontrolled conflict resolution of jackson-bom and kotlin-bom dependency version imported from external maven BOM provided by kork-bom, as per the gradle documentation here (https://docs.gradle.org/6.9.1/userguide/platforms.html#sub:bom_import), we can use gradle enforcedPlatform closure as part of the implementation to strictly adhere the versions of direct and transitive dependencies imported BOM. This approach could be considered as optimally feasible fix for this issue. And for upcoming upgrades and developments, it will also ensure the predictable dependency imports from kork-bom.

Similar issue has been encountered while upgrading spring-boot to 2.3.x for gate service, for detailed discussion please refer to:
https://github.com/spinnaker/gate/pull/1505

This fix is seamless for the existing code.