### PR TITLE
feat(core): Add account manager roles config

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -37,6 +37,7 @@ public class UserPermission {
   private Set<BuildService> buildServices = new LinkedHashSet<>();
   private Set<Resource> extensionResources = new LinkedHashSet<>();
   private boolean admin = false;
+  private boolean accountManager;
 
   /**
    * Custom setter to normalize the input. lombok.accessors.chain is enabled, so setters must return
@@ -118,6 +119,7 @@ public class UserPermission {
     Set<BuildService.View> buildServices;
     HashMap<ResourceType, Set<Authorizable>> extensionResources;
     boolean admin;
+    boolean accountManager;
     boolean legacyFallback = false;
     boolean allowAccessToUnknownApplications = false;
 
@@ -149,6 +151,7 @@ public class UserPermission {
       }
 
       this.admin = permission.isAdmin();
+      this.accountManager = permission.isAccountManager();
     }
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/AccountManagerConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/AccountManagerConfig.java
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.fiat.config;
+
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Configures Fiat aspects of the account management API. */
+@Configuration
+@ConfigurationProperties("fiat.account.manager")
+@Data
+public class AccountManagerConfig {
+
+  /** List of roles allowed to programmatically manage accounts. */
+  private List<String> roles = List.of();
+}


### PR DESCRIPTION
This adds a Fiat configuration option for the Account Management API in Clouddriver for listing which roles are allowed to manage accounts in the API.

This option was requested during the initial phase of development for the API. We'll need a Fiat release cut in order to use the changes in Clouddriver, however.