### PR TITLE
chore(ci): Upload halconfigs to GCS on Tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,22 @@ jobs:
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
           ./gradlew --info publish
+      - name: Login to Google Cloud
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/auth@v0'
+        # use service account flow defined at: https://github.com/google-github-actions/upload-cloud-storage#authenticating-via-service-account-key-json
+        with:
+          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+      - name: Upload halconfig profiles to GCS
+        # https://console.cloud.google.com/storage/browser/halconfig
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: 'google-github-actions/upload-cloud-storage@v0'
+        with:
+          path: 'halconfig/'
+          destination: 'halconfig/${{ steps.build_variables.outputs.REPO }}/${{ steps.release_info.outputs.RELEASE_VERSION }}'
+          parent: false
       - name: Login to GAR
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')


### PR DESCRIPTION
Previous release tools would publish basic halconfig profiles to GCS
bucket: [https://console.cloud.google.com/storage/browser/halconfig/`<service>`/`<version>`/*](https://console.cloud.google.com/storage/browser/halconfig/%60%3Cservice%3E%60/%60%3Cversion%3E%60/*)

Where `<service>` might be `rosco` and `<version>` is our git tag, eg: `v1.2.3`.

Halyard downloads these profiles during `hal deploy apply`.
As the profiles are deprecated it would be ideal to remove from Halyard
but it may break users workflows.

For now we can upload the files as part of our regular service 'release'
flow (git tag <version> && git push) using GHA.