### PR TITLE
chore(dependencies): don't create an autobump PR for halyard on a fia…

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -14,6 +14,6 @@ jobs:
         ref: ${{ github.event.client_payload.ref }}
         baseBranch: ${{ github.event.client_payload.branch }}
         key: fiatVersion
-        repositories: clouddriver,echo,front50,gate,halyard,igor,keel,orca
+        repositories: clouddriver,echo,front50,gate,igor,keel,orca
       env:
         GITHUB_OAUTH: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}


### PR DESCRIPTION
…t release branch

since release branches in halyard don't align with release branches in fiat.  For example,
a release-1.27.x branch exists in both fiat and halyard.  In fiat release-1.27.x aligns
with spinnaker version 1.27.x, but halyard version numbers are independent from spinnaker
versions.
