### PR TITLE
fix(ci): Only bumpdep Halyard for master branch

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -14,10 +14,10 @@ jobs:
     - name: decide bumpdep target repositories
       id: bumpdep_targets
       run: |
-        REPOS=clouddriver,echo,front50,gate,halyard,igor,keel,orca
-        if [ "${{ github.event.client_payload.branch }}" != "  origin/master"]; then
-          echo "on release-* branch, excluding halyard from dumpdeps target list"
-          REPOS=clouddriver,echo,front50,gate,igor,keel,orca
+        REPOS=clouddriver,echo,front50,gate,igor,keel,orca
+        if [ "${{ github.event.client_payload.branch }}" == "  origin/master"]; then
+          echo "on master branch, include halyard in bumpdeps target list"
+          REPOS+=",halyard"
         fi
         echo ::set-output name=REPOS::$(echo -e "${REPOS}")
     - uses: spinnaker/bumpdeps@master

--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -9,12 +9,23 @@ jobs:
     if: startsWith(github.repository, 'spinnaker/')
     runs-on: ubuntu-latest
     steps:
+    # Halyard releases are separate from Spinnaker releases so we need to
+    # exclude Halyard from bump deps when targeting services release-* branches.
+    - name: decide bumpdep target repositories
+      id: bumpdep_targets
+      run: |
+        REPOS=clouddriver,echo,front50,gate,halyard,igor,keel,orca
+        if [ "${{ github.event.client_payload.branch }}" != "  origin/master"]; then
+          echo "on release-* branch, excluding halyard from dumpdeps target list"
+          REPOS=clouddriver,echo,front50,gate,igor,keel,orca
+        fi
+        echo ::set-output name=REPOS::$(echo -e "${REPOS}")
     - uses: spinnaker/bumpdeps@master
       with:
         ref: ${{ github.event.client_payload.ref }}
         baseBranch: ${{ github.event.client_payload.branch }}
         key: fiatVersion
-        repositories: clouddriver,echo,front50,gate,halyard,igor,keel,orca
+        repositories: ${{ steps.bumpdep_targets.outputs.REPOS }}
         mavenRepositoryUrl: https://repo.maven.apache.org/maven2
         groupId: io.spinnaker.fiat
         artifactId: fiat-bom


### PR DESCRIPTION
Halyard releases are different and release-* branches have no connection
with Spinnaker service releases.

We only want to bumpdep Halyard if tag was pushed to `master` branch.

For services we always want to bumpdep same branch.
