### PR TITLE
fix(google): skip groups for service accounts

### DIFF
--- a/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
+++ b/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
@@ -123,6 +123,12 @@ public class GoogleDirectoryUserRolesProvider implements UserRolesProvider, Init
     userEmails.forEach(
         email -> {
           try {
+            //Check if this is a managed service account, we should never check google groups for these
+            if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX) || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
+              //Skip over this in the batch
+              return;
+            }
+            
             GroupBatchCallback callback =
                 new GroupBatchCallback().setEmailGroupsMap(emailGroupsMap).setEmail(email);
             HttpRequest request =

--- a/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
+++ b/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
@@ -69,9 +69,10 @@ import org.springframework.util.Assert;
 public class GoogleDirectoryUserRolesProvider implements UserRolesProvider, InitializingBean {
   // Used to denote a pipeline permission, or manually created service account
   public static final String SERVICE_ACCOUNT_SUFFIX = "@managed-service-account";
-  // Used to denote a shared service account, used by service account shared between pipelines by unique role
+  // Used to denote a shared service account, used by service account shared between pipelines by
+  // unique role
   public static final String SHARED_SERVICE_ACCOUNT_SUFFIX = "@shared-managed-service-account";
-  
+
   @Autowired @Setter private Config config;
 
   private static final Collection<String> SERVICE_ACCOUNT_SCOPES =
@@ -123,12 +124,14 @@ public class GoogleDirectoryUserRolesProvider implements UserRolesProvider, Init
     userEmails.forEach(
         email -> {
           try {
-            //Check if this is a managed service account, we should never check google groups for these
-            if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX) || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
-              //Skip over this in the batch
+            // Check if this is a managed service account, we should never check google groups for
+            // these
+            if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX)
+                || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
+              // Skip over this in the batch
               return;
             }
-            
+
             GroupBatchCallback callback =
                 new GroupBatchCallback().setEmailGroupsMap(emailGroupsMap).setEmail(email);
             HttpRequest request =
@@ -170,11 +173,12 @@ public class GoogleDirectoryUserRolesProvider implements UserRolesProvider, Init
     }
 
     String userEmail = user.getId();
-    //Check if this is a managed service account, we should never check google groups for these
-    if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX) || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
+    // Check if this is a managed service account, we should never check google groups for these
+    if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX)
+        || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
       return new ArrayList<>();
     }
-    
+
     try {
       Groups groups = getGroupsFromEmail(userEmail);
       if (groups == null || groups.getGroups() == null || groups.getGroups().isEmpty()) {

--- a/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
+++ b/fiat-google-groups/src/main/java/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProvider.java
@@ -126,8 +126,8 @@ public class GoogleDirectoryUserRolesProvider implements UserRolesProvider, Init
           try {
             // Check if this is a managed service account, we should never check google groups for
             // these
-            if (userEmail.endsWith(SERVICE_ACCOUNT_SUFFIX)
-                || userEmail.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
+            if (email.endsWith(SERVICE_ACCOUNT_SUFFIX)
+                || email.endsWith(SHARED_SERVICE_ACCOUNT_SUFFIX)) {
               // Skip over this in the batch
               return;
             }

--- a/fiat-google-groups/src/test/groovy/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProviderSpec.groovy
+++ b/fiat-google-groups/src/test/groovy/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProviderSpec.groovy
@@ -61,6 +61,22 @@ class GoogleDirectoryUserRolesProviderSpec extends Specification {
         then:
         result4.name.containsAll(["test@test.com"])
         result4.name.size() == 1
+       
+        when:
+        //test that a service account does not get groups returned
+        def result1 = provider.loadRoles(externalUser("testuser@managed-service-account"))
+
+        then:
+        result1.name.containsAll([])
+        result1.name.size() == 0
+        
+        when:
+        //test that a shared service account does not get groups returned
+        def result1 = provider.loadRoles(externalUser("testuser@shared-managed-service-account"))
+
+        then:
+        result1.name.containsAll([])
+        result1.name.size() == 0
 
 
 

--- a/fiat-google-groups/src/test/groovy/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProviderSpec.groovy
+++ b/fiat-google-groups/src/test/groovy/com/netflix/spinnaker/fiat/roles/google/GoogleDirectoryUserRolesProviderSpec.groovy
@@ -64,19 +64,17 @@ class GoogleDirectoryUserRolesProviderSpec extends Specification {
        
         when:
         //test that a service account does not get groups returned
-        def result1 = provider.loadRoles(externalUser("testuser@managed-service-account"))
+        def result5 = provider.loadRoles(externalUser("testuser@managed-service-account"))
 
         then:
-        result1.name.containsAll([])
-        result1.name.size() == 0
+        result5.name.size() == 0
         
         when:
         //test that a shared service account does not get groups returned
-        def result1 = provider.loadRoles(externalUser("testuser@shared-managed-service-account"))
+        def result6 = provider.loadRoles(externalUser("testuser@shared-managed-service-account"))
 
         then:
-        result1.name.containsAll([])
-        result1.name.size() == 0
+        result6.name.size() == 0
 
 
 


### PR DESCRIPTION
Currently the google roles provider checks Google Groups for all service accounts, this is impossible to succeed because these are not real domains usable in Google Groups. This causes a couple of issues around rate limiting due to bad requests, and artificially increases the load on the Admin Directory API quota. By skipping over this without hitting Google we reduce the time needed to check permissions for this, and improve stability of this API
