### PR TITLE
fix(roles): Ensure account manager role is cached

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/AccountManagerConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/AccountManagerConfig.java
@@ -3,10 +3,12 @@ package com.netflix.spinnaker.fiat.config;
 import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 /** Configures Fiat aspects of the account management API. */
 @Configuration
+@EnableConfigurationProperties
 @ConfigurationProperties("fiat.account.manager")
 @Data
 public class AccountManagerConfig {

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -215,6 +215,7 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                   .setId(userId)
                   .setRoles(userRoles)
                   .setAdmin(hasAdminRole(userRoles))
+                  .setAccountManager(hasAccountManagerRole(userRoles))
                   .addResources(getResources(userId, userRoles, hasAdminRole(userRoles)));
             })
         .collect(Collectors.toMap(UserPermission::getId, Function.identity()));

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/config/AccountManagerConfigTest.java
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/config/AccountManagerConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Apple
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = "fiat.account.manager.roles = ops, sre, dev")
+@ContextConfiguration(classes = AccountManagerConfig.class)
+class AccountManagerConfigTest {
+
+  @Autowired private AccountManagerConfig accountManagerConfig;
+
+  @Test
+  void hasExpectedConfiguration() {
+    assertThat(accountManagerConfig.getRoles()).contains("ops", "sre", "dev");
+  }
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -260,7 +260,8 @@ class RedisPermissionsRepositorySpec extends Specification {
                  .setAccounts([account1] as Set)
                  .setApplications([app1] as Set)
                  .setServiceAccounts([serviceAccount1] as Set)
-                 .setRoles([role1] as Set))
+                 .setRoles([role1] as Set)
+                 .setAccountManager(true))
 
     then:
     jedis.smembers("unittests:users") == ["testuser"] as Set
@@ -274,7 +275,8 @@ class RedisPermissionsRepositorySpec extends Specification {
         '{"serviceAccount":{"name":"serviceAccount","memberOf":["role1"]}}'
     getCompressed("unittests:permissions-v2:testuser:roles") ==
         '{"role1":{"name":"role1"}}'
-    !jedis.sismember ("unittests:permissions:admin","testUser")
+    !jedis.sismember ("unittests:permissions:admin","testuser")
+    jedis.sismember("unittests:accountmanagers", "testuser")
   }
 
   def "should remove permission that has been revoked"() {

--- a/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/sql/tables/User.kt
+++ b/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/sql/tables/User.kt
@@ -54,6 +54,7 @@ class UserTable(
 
     val ID: TableField<UserTableRecord, String> = createField(DSL.name("id"), SQLDataType.VARCHAR(255).nullable(false), this, "")
     val ADMIN: TableField<UserTableRecord, Boolean> = createField(DSL.name("admin"), SQLDataType.BOOLEAN.nullable(false), this, "")
+    val ACCOUNT_MANAGER: TableField<UserTableRecord, Boolean> = createField(DSL.name("account_manager"), SQLDataType.BOOLEAN.nullable(false), this, "")
     val UPDATED_AT: TableField<UserTableRecord, Long> = createField(DSL.name("updated_at"), SQLDataType.BIGINT.nullable(false), this, "")
 
     private constructor(alias: Name, aliased: Table<UserTableRecord>?): this(alias, null, null, aliased, null)

--- a/fiat-sql/src/main/resources/db/changelog-master.yml
+++ b/fiat-sql/src/main/resources/db/changelog-master.yml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210324-resource-body-hash.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20220615-account-manager-flag.yml
+      relativeToChangelogFile: true

--- a/fiat-sql/src/main/resources/db/changelog/20220615-account-manager-flag.yml
+++ b/fiat-sql/src/main/resources/db/changelog/20220615-account-manager-flag.yml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: account-manager-flag
+      author: msicker
+      changes:
+        - addColumn:
+            tableName: fiat_user
+            columns:
+              - column:
+                  name: account_manager
+                  type: bool
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: fiat_user
+            columns:
+              - column:
+                  name: account_manager

--- a/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
+++ b/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryTests.kt
@@ -118,6 +118,7 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
                     .setBuildServices(setOf(buildService1))
                     .setServiceAccounts(setOf(serviceAccount1))
                     .setRoles(setOf(role1))
+                    .setAccountManager(true)
 
                 // verify the user is not found initially
                 var userPermission = sqlPermissionsRepository.get(userPermission1.id)
@@ -131,6 +132,7 @@ internal object SqlPermissionsRepositoryTests : JUnit5Minutests {
                 expectThat(actual.isPresent).isTrue()
                 expectThat(actual.get().id).isEqualTo(userPermission1.id)
                 expectThat(actual.get().isAdmin).isFalse()
+                expectThat(actual.get().isAccountManager).isTrue()
                 expectThat(actual.get().accounts).containsExactly(account1)
                 expectThat(actual.get().applications).containsExactly(app1)
                 expectThat(actual.get().buildServices).containsExactly(buildService1)


### PR DESCRIPTION
This updates the Redis and SQL permission caching to support the newly
introduced account manager meta-role.

* Ensures the `accountManager` flag is copied between live data and cache data as the cache data is what ends up determining Fiat policy evaluations in practice.