### PR TITLE
perf(serviceAccounts): allows syncing service accounts without resolving user roles

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -82,6 +82,18 @@ public interface FiatService {
   long sync(@Body List<String> roles);
 
   /**
+   * Use to update a service account. As opposed to `sync`, this will not trigger a full sync for
+   * user role membership.
+   *
+   * @param serviceAccountId Name of the service account.
+   * @param roles The roles allowed for this service account.
+   * @return The number of non-anonymous users synced.
+   */
+  @POST("/roles/sync/serviceAccount/{serviceAccountId}")
+  long syncServiceAccount(
+      @Path("serviceAccountId") String serviceAccountId, @Body List<String> roles);
+
+  /**
    * @param userId The user being logged in
    * @param ignored ignored.
    * @return ignored.

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -203,7 +203,8 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
     return userToRoles;
   }
 
-  private Map<String, UserPermission> resolveResources(
+  @Override
+  public Map<String, UserPermission> resolveResources(
       @NonNull Map<String, Collection<Role>> userToRoles) {
     return userToRoles.entrySet().stream()
         .map(

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import java.util.Collection;
 import java.util.Map;
 
@@ -36,6 +37,11 @@ public interface PermissionsResolver {
   /** Resolves multiple user's permissions. Returned map is keyed by userId. */
   Map<String, UserPermission> resolve(Collection<ExternalUser> users)
       throws PermissionResolutionException;
+
+  /**
+   * Resolves multiple users resources without syncing group roles. Returned map is keyed by userId.
+   */
+  Map<String, UserPermission> resolveResources(Map<String, Collection<Role>> userToRoles);
 
   /** Clears resource cache: apps, service accounts,... */
   void clearCache();

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
@@ -145,11 +145,11 @@ public class Synchronizer {
 
     // Store this service account as a user with associated resources via `resolveAndMerge`.
     List<Role> convertedRoles =
-            roles.stream()
-                    .map(extRole -> new Role().setSource(Role.Source.EXTERNAL).setName(extRole))
-                    .collect(Collectors.toList());
+        roles.stream()
+            .map(extRole -> new Role().setSource(Role.Source.EXTERNAL).setName(extRole))
+            .collect(Collectors.toList());
     ExternalUser serviceAccount =
-            new ExternalUser().setId(serviceAccountId.toLowerCase()).setExternalRoles(convertedRoles);
+        new ExternalUser().setId(serviceAccountId.toLowerCase()).setExternalRoles(convertedRoles);
     UserPermission serviceAccountPermissions = permissionsResolver.resolveAndMerge(serviceAccount);
     permissionsRepository.put(serviceAccountPermissions);
 
@@ -160,16 +160,16 @@ public class Synchronizer {
     // The chance of collisions are quite low, but if it does occur often we should create
     // a specific update operation on the permissionsRepository.
     Map<String, Collection<Role>> allUsersForRoles =
-            permissionsRepository.getAllByRoles(roles).entrySet().stream()
-                    .filter(
-                            it ->
-                                    it.getValue().stream()
-                                            .map(Role::getName)
-                                            .collect(Collectors.toSet())
-                                            .containsAll(roles))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        permissionsRepository.getAllByRoles(roles).entrySet().stream()
+            .filter(
+                it ->
+                    it.getValue().stream()
+                        .map(Role::getName)
+                        .collect(Collectors.toSet())
+                        .containsAll(roles))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     Map<String, UserPermission> resolvedUsers =
-            permissionsResolver.resolveResources(allUsersForRoles);
+        permissionsResolver.resolveResources(allUsersForRoles);
     permissionsRepository.putAllById(resolvedUsers);
     return allUsersForRoles.size();
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
@@ -139,6 +139,41 @@ public class Synchronizer {
     }
   }
 
+  public long syncServiceAccount(String serviceAccountId, List<String> roles) {
+    // So that fiat will pull fresh permissions
+    permissionsResolver.clearCache();
+
+    // Store this service account as a user with associated resources via `resolveAndMerge`.
+    List<Role> convertedRoles =
+            roles.stream()
+                    .map(extRole -> new Role().setSource(Role.Source.EXTERNAL).setName(extRole))
+                    .collect(Collectors.toList());
+    ExternalUser serviceAccount =
+            new ExternalUser().setId(serviceAccountId.toLowerCase()).setExternalRoles(convertedRoles);
+    UserPermission serviceAccountPermissions = permissionsResolver.resolveAndMerge(serviceAccount);
+    permissionsRepository.put(serviceAccountPermissions);
+
+    // Resync resource for all users with the same roles (incl the requested service account),
+    // so that they may have permissions to act on this service account
+    // Note that this is not an atomic read/write operation, but they will be synced again
+    // during the next periodic sync.
+    // The chance of collisions are quite low, but if it does occur often we should create
+    // a specific update operation on the permissionsRepository.
+    Map<String, Collection<Role>> allUsersForRoles =
+            permissionsRepository.getAllByRoles(roles).entrySet().stream()
+                    .filter(
+                            it ->
+                                    it.getValue().stream()
+                                            .map(Role::getName)
+                                            .collect(Collectors.toSet())
+                                            .containsAll(roles))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    Map<String, UserPermission> resolvedUsers =
+            permissionsResolver.resolveResources(allUsersForRoles);
+    permissionsRepository.putAllById(resolvedUsers);
+    return allUsersForRoles.size();
+  }
+
   private boolean isServerHealthy() {
     return healthIndicator.health().getStatus() == Status.UP;
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncStrategy.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncStrategy.java
@@ -21,9 +21,10 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@FunctionalInterface
 public interface UserRolesSyncStrategy {
   long syncAndReturn(List<String> roles);
+
+  long syncServiceAccount(String serviceAccountId, List<String> roles);
 
   @RequiredArgsConstructor
   class DefaultSynchronizationStrategy implements UserRolesSyncStrategy {
@@ -33,6 +34,11 @@ public interface UserRolesSyncStrategy {
     @Override
     public long syncAndReturn(List<String> roles) {
       return this.synchronizer.syncAndReturn(roles);
+    }
+
+    @Override
+    public long syncServiceAccount(String serviceAccountId, List<String> roles) {
+      return this.synchronizer.syncServiceAccount(serviceAccountId, roles);
     }
   }
 
@@ -65,6 +71,11 @@ public interface UserRolesSyncStrategy {
       } finally {
         this.callableCache.clear(roles);
       }
+    }
+
+    @Override
+    public long syncServiceAccount(String serviceAccountId, List<String> roles) {
+      return this.synchronizer.syncServiceAccount(serviceAccountId, roles);
     }
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -107,6 +107,10 @@ public class UserRolesSyncer {
     return syncStrategy.syncAndReturn(roles);
   }
 
+  public long syncServiceAccount(String serviceAccountId, List<String> roles) {
+    return syncStrategy.syncServiceAccount(serviceAccountId, roles);
+  }
+
   private static String metricName(String name) {
     return "fiat.userRoles." + name;
   }

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -112,4 +112,14 @@ public class RolesController {
     }
     return count;
   }
+
+  @RequestMapping(value = "/sync/serviceAccount/{serviceAccountId:.+}", method = RequestMethod.POST)
+  public long syncServiceAccount(
+      @PathVariable String serviceAccountId, @RequestBody List<String> specificRoles) {
+    log.info(
+        "Service Account {} sync invoked by web request with roles: {}",
+        serviceAccountId,
+        specificRoles);
+    return syncer.syncServiceAccount(serviceAccountId, specificRoles);
+  }
 }


### PR DESCRIPTION
Hi team,

As prefaced on [Slack](https://spinnakerteam.slack.com/archives/C091CCWRJ/p1656558976174469), we have been running our own Spinnaker cluster for a while, and recently we've noticed that saving service accounts have been timing out from front50 to fiat. We discovered that this was because Fiat runs a sync across all users with the associated roles for the requested service account upon every save, which means for a relatively large user base, this operation results in well over 20s of runtime. 

We ran rudimentary investigation and found that this user role sync does not seem to be necessary for saving these service accounts, since scheduled syncs will straighten out any missing users recently added to this role on the next run. 

Following this train of thought, I'm raising this first PR on Fiat's side, which introduces a new endpoint that saves the service account, and adds it as a resource for all currently sync-ed users with these roles.

This change has been tested on my local dev environment, which seems to work well. It reduces the runtime of saving a service account to a sub-second operation. This should be quite a safe change to role out, since any impact will rely on consumes explicitly calling this new endpoint (which nobody is doing at the moment).

If everyone is happy with this change, the next PR we'll raise will be on Front50, which will call out to this new endpoint when saving service accounts. I'll be sure to introduce a config parameter so that this feature is opt-in only, and won't negatively impact users if something goes wrong.

Thanks!