### PR TITLE
feat(api): Add support for more Spring Security APIs

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -39,3 +39,7 @@ dependencies {
 
   testImplementation "org.slf4j:slf4j-api"
 }
+
+test {
+  useJUnitPlatform()
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/AuthenticatedRequestAuthenticationConverter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/AuthenticatedRequestAuthenticationConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+public class AuthenticatedRequestAuthenticationConverter implements AuthenticationConverter {
+  @Override
+  public Authentication convert(HttpServletRequest request) {
+    return AuthenticatedRequest.getSpinnakerUser()
+        .map(
+            user ->
+                (Authentication) new PreAuthenticatedAuthenticationToken(user, "N/A", List.of()))
+        .orElseGet(
+            () ->
+                new AnonymousAuthenticationToken(
+                    "anonymous",
+                    "anonymous",
+                    AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/AuthenticatedRequestAuthenticationConverter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/AuthenticatedRequestAuthenticationConverter.java
@@ -25,6 +25,12 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+/**
+ * Provides an Authentication for an HTTP request using the current {@link
+ * AuthenticatedRequest#getSpinnakerUser()}.
+ *
+ * @see AuthenticatedRequest
+ */
 public class AuthenticatedRequestAuthenticationConverter implements AuthenticationConverter {
   @Override
   public Authentication convert(HttpServletRequest request) {

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -86,8 +86,9 @@ public class FiatAuthenticationConfig {
   }
 
   @Bean
-  FiatWebSecurityConfigurerAdapter fiatSecurityConfig(FiatStatus fiatStatus) {
-    return new FiatWebSecurityConfigurerAdapter(fiatStatus);
+  FiatWebSecurityConfigurerAdapter fiatSecurityConfig(
+      FiatStatus fiatStatus, FiatPermissionEvaluator permissionEvaluator) {
+    return new FiatWebSecurityConfigurerAdapter(fiatStatus, permissionEvaluator);
   }
 
   @Bean
@@ -97,12 +98,15 @@ public class FiatAuthenticationConfig {
     return new FiatAccessDeniedExceptionHandler(exceptionMessageDecorator);
   }
 
-  private class FiatWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+  private static class FiatWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
     private final FiatStatus fiatStatus;
+    private final FiatPermissionEvaluator permissionEvaluator;
 
-    private FiatWebSecurityConfigurerAdapter(FiatStatus fiatStatus) {
+    private FiatWebSecurityConfigurerAdapter(
+        FiatStatus fiatStatus, FiatPermissionEvaluator permissionEvaluator) {
       super(true);
       this.fiatStatus = fiatStatus;
+      this.permissionEvaluator = permissionEvaluator;
     }
 
     @Override
@@ -114,7 +118,8 @@ public class FiatAuthenticationConfig {
           .anonymous()
           .and()
           .addFilterBefore(
-              new FiatAuthenticationFilter(fiatStatus), AnonymousAuthenticationFilter.class);
+              new FiatAuthenticationFilter(fiatStatus, permissionEvaluator),
+              AnonymousAuthenticationFilter.class);
     }
   }
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConverter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConverter.java
@@ -27,6 +27,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+/**
+ * Converts an {@code X-SPINNAKER-USER} HTTP header into an Authentication object containing a list
+ * of roles and other {@linkplain SpinnakerAuthorities granted authorities} in its granted
+ * authorities.
+ */
 @RequiredArgsConstructor
 public class FiatAuthenticationConverter implements AuthenticationConverter {
   private final FiatPermissionEvaluator permissionEvaluator;

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConverter.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.netflix.spinnaker.fiat.model.SpinnakerAuthorities;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.kork.common.Header;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+@RequiredArgsConstructor
+public class FiatAuthenticationConverter implements AuthenticationConverter {
+  private final FiatPermissionEvaluator permissionEvaluator;
+
+  @Override
+  public Authentication convert(HttpServletRequest request) {
+    String user = request.getHeader(Header.USER.getHeader());
+    if (user != null) {
+      UserPermission.View permission = permissionEvaluator.getPermission(user);
+      if (permission != null) {
+        return new PreAuthenticatedAuthenticationToken(
+            user, "N/A", permission.toGrantedAuthorities());
+      }
+    }
+    return new AnonymousAuthenticationToken(
+        "anonymous", "anonymous", List.of(SpinnakerAuthorities.ANONYMOUS_AUTHORITY));
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatClientConfigurationProperties.java
@@ -43,6 +43,9 @@ public class FiatClientConfigurationProperties {
 
   @NestedConfigurationProperty private RetryConfiguration retry = new RetryConfiguration();
 
+  @NestedConfigurationProperty
+  private GrantedAuthorities grantedAuthorities = new GrantedAuthorities();
+
   public RetryConfiguration getRetry() {
     retry.setDynamicConfigService(dynamicConfigService);
     return retry;
@@ -92,5 +95,10 @@ public class FiatClientConfigurationProperties {
       return dynamicConfigService.getConfig(
           Double.class, "fiat.retry.retryMultiplier", retryMultiplier);
     }
+  }
+
+  @Data
+  public static class GrantedAuthorities {
+    private boolean enabled;
   }
 }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -150,6 +150,9 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
   @Override
   public boolean hasPermission(
       Authentication authentication, Object resource, Object authorization) {
+    if (!fiatStatus.isGrantedAuthoritiesEnabled()) {
+      return false;
+    }
     if (!fiatStatus.isEnabled()) {
       return true;
     }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -21,12 +21,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.SpinnakerAuthorities;
 import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
 import com.netflix.spinnaker.kork.exceptions.IntegrationException;
 import com.netflix.spinnaker.kork.telemetry.caffeine.CaffeineStatsCounter;
+import com.netflix.spinnaker.security.AccessControlled;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -148,6 +150,22 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
   @Override
   public boolean hasPermission(
       Authentication authentication, Object resource, Object authorization) {
+    if (!fiatStatus.isEnabled()) {
+      return true;
+    }
+    if (authentication == null || resource == null) {
+      log.warn(
+          "Permission denied because at least one of the required arguments was null. authentication={}, resource={}",
+          authentication,
+          resource);
+      return false;
+    }
+    if (authentication.getAuthorities().contains(SpinnakerAuthorities.ADMIN_AUTHORITY)) {
+      return true;
+    }
+    if (resource instanceof AccessControlled) {
+      return ((AccessControlled) resource).isAuthorized(authentication, authorization);
+    }
     return false;
   }
 
@@ -223,7 +241,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
 
     // Service accounts don't have read/write authorizations.
     if (!r.equals(ResourceType.SERVICE_ACCOUNT)) {
-      a = Authorization.valueOf(authorization.toString());
+      a = Authorization.parse(authorization);
     }
 
     if (a == Authorization.CREATE) {

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatStatus.java
@@ -35,6 +35,7 @@ public class FiatStatus {
 
   private final AtomicBoolean enabled;
   private final AtomicBoolean legacyFallbackEnabled;
+  private final AtomicBoolean grantedAuthoritiesEnabled;
 
   @Autowired
   public FiatStatus(
@@ -47,6 +48,8 @@ public class FiatStatus {
     this.enabled = new AtomicBoolean(fiatClientConfigurationProperties.isEnabled());
     this.legacyFallbackEnabled =
         new AtomicBoolean(fiatClientConfigurationProperties.isLegacyFallback());
+    this.grantedAuthoritiesEnabled =
+        new AtomicBoolean(fiatClientConfigurationProperties.getGrantedAuthorities().isEnabled());
 
     PolledMeter.using(registry)
         .withName("fiat.enabled")
@@ -54,6 +57,9 @@ public class FiatStatus {
     PolledMeter.using(registry)
         .withName("fiat.legacyFallback.enabled")
         .monitorValue(legacyFallbackEnabled, value -> legacyFallbackEnabled.get() ? 1 : 0);
+    PolledMeter.using(registry)
+        .withName("fiat.granted-authorities.enabled")
+        .monitorValue(grantedAuthoritiesEnabled, value -> grantedAuthoritiesEnabled.get() ? 1 : 0);
   }
 
   public boolean isEnabled() {
@@ -62,6 +68,10 @@ public class FiatStatus {
 
   public boolean isLegacyFallbackEnabled() {
     return legacyFallbackEnabled.get();
+  }
+
+  public boolean isGrantedAuthoritiesEnabled() {
+    return grantedAuthoritiesEnabled.get();
   }
 
   @Scheduled(fixedDelay = 30000L)
@@ -76,6 +86,10 @@ public class FiatStatus {
       legacyFallbackEnabled.set(
           dynamicConfigService.isEnabled(
               "fiat.legacyFallback", fiatClientConfigurationProperties.isLegacyFallback()));
+      grantedAuthoritiesEnabled.set(
+          dynamicConfigService.isEnabled(
+              "fiat.granted-authorities",
+              fiatClientConfigurationProperties.getGrantedAuthorities().isEnabled()));
     } catch (Exception e) {
       log.warn("Unable to refresh fiat status, reason: {}", e.getMessage());
     }

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/AccessControlledResource.java
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/AccessControlledResource.java
@@ -19,13 +19,14 @@ package com.netflix.spinnaker.fiat.shared;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.security.AccessControlled;
+import java.util.Objects;
 import org.springframework.security.core.Authentication;
 
 public class AccessControlledResource implements AccessControlled {
   private final Permissions permissions;
 
   public AccessControlledResource(Permissions permissions) {
-    this.permissions = permissions;
+    this.permissions = Objects.requireNonNull(permissions);
   }
 
   @Override

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/AccessControlledResource.java
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/AccessControlledResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.security.AccessControlled;
+import org.springframework.security.core.Authentication;
+
+public class AccessControlledResource implements AccessControlled {
+  private final Permissions permissions;
+
+  public AccessControlledResource(Permissions permissions) {
+    this.permissions = permissions;
+  }
+
+  @Override
+  public boolean isAuthorized(Authentication authentication, Object authorization) {
+    Authorization a = Authorization.parse(authorization);
+    return permissions.getAuthorizations(authentication.getAuthorities()).contains(a);
+  }
+}

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.shared
 
 import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.SpinnakerAuthorities
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Application
 import com.netflix.spinnaker.fiat.model.resources.Authorizable
@@ -49,7 +50,8 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
   )
 
   @Shared
-  def authentication = new PreAuthenticatedAuthenticationToken("testUser", null, [])
+  def authentication = new PreAuthenticatedAuthenticationToken("testUser", null,
+          [SpinnakerAuthorities.forRoleName('test group')])
 
   def cleanup() {
     MDC.clear()
@@ -297,5 +299,27 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
   private static class MyExtensionResourceView implements Authorizable {
     String name
     Set<Authorization> authorizations
+  }
+
+  def "should evaluate permissions for AccessControlled objects"() {
+    given:
+    def resource = new AccessControlledResource(new Permissions.Builder().add(Authorization.READ, 'test group').build())
+
+    when:
+    def hasPermission = evaluator.hasPermission(authentication, resource, authorization)
+
+    then:
+    hasPermission == expectedHasPermission
+
+    where:
+    authorization      | expectedHasPermission
+    'read'             | true
+    "read"             | true
+    'READ'             | true
+    "READ"             | true
+    Authorization.READ | true
+    'write'            | false
+    'WRITE'            | false
+    'EXECUTE'          | false
   }
 }

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluatorSpec.groovy
@@ -292,6 +292,7 @@ class FiatPermissionEvaluatorSpec extends FiatSharedSpecification {
     configurationProperties.enabled = true
     configurationProperties.cache.maxEntries = 0
     configurationProperties.cache.expiresAfterWriteSeconds = 0
+    configurationProperties.grantedAuthorities.enabled = true
     return configurationProperties
   }
 

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatSharedSpecification.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatSharedSpecification.groovy
@@ -25,6 +25,7 @@ abstract class FiatSharedSpecification extends Specification {
     Registry registry = new NoopRegistry()
     FiatStatus fiatStatus = Mock(FiatStatus) {
         _ * isEnabled() >> { return true }
+        _ * isGrantedAuthoritiesEnabled() >> { return true }
     }
 
     private static FiatClientConfigurationProperties buildConfigurationProperties() {

--- a/fiat-core/fiat-core.gradle
+++ b/fiat-core/fiat-core.gradle
@@ -1,5 +1,7 @@
 dependencies {
 
+  api "org.springframework.security:spring-security-core"
+
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.google.code.findbugs:jsr305"
   implementation "org.slf4j:slf4j-api"

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/Authorization.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.fiat.model;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 public enum Authorization {
   READ,
@@ -28,4 +30,12 @@ public enum Authorization {
 
   public static final Set<Authorization> ALL =
       Collections.unmodifiableSet(EnumSet.allOf(Authorization.class));
+
+  @Nullable
+  public static Authorization parse(Object o) {
+    if (o instanceof Authorization) {
+      return (Authorization) o;
+    }
+    return o != null ? valueOf(o.toString().toUpperCase(Locale.ROOT)) : null;
+  }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/SpinnakerAuthorities.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/SpinnakerAuthorities.java
@@ -19,6 +19,11 @@ package com.netflix.spinnaker.fiat.model;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+/**
+ * Constants and utilities for working with Spring Security GrantedAuthority objects specific to
+ * Spinnaker and Fiat. Spinnaker-specific roles such as admin and account manager are represented
+ * here as granted authorities.
+ */
 public class SpinnakerAuthorities {
   public static final String ADMIN = "SPINNAKER_ADMIN";
   /** Granted authority for Spinnaker administrators. */

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/SpinnakerAuthorities.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/SpinnakerAuthorities.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.model;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class SpinnakerAuthorities {
+  public static final String ADMIN = "SPINNAKER_ADMIN";
+  /** Granted authority for Spinnaker administrators. */
+  public static final GrantedAuthority ADMIN_AUTHORITY = new SimpleGrantedAuthority(ADMIN);
+
+  public static final String ACCOUNT_MANAGER = "SPINNAKER_ACCOUNT_MANAGER";
+  /** Granted authority for Spinnaker account managers. */
+  public static final GrantedAuthority ACCOUNT_MANAGER_AUTHORITY =
+      new SimpleGrantedAuthority(ACCOUNT_MANAGER);
+
+  /** Granted authority for anonymous users. */
+  public static final GrantedAuthority ANONYMOUS_AUTHORITY = forRoleName("ANONYMOUS");
+
+  /** Creates a granted authority corresponding to the provided name of a role. */
+  public static GrantedAuthority forRoleName(String role) {
+    return new SimpleGrantedAuthority(String.format("ROLE_%s", role));
+  }
+}

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/UserPermission.java
@@ -25,6 +25,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import org.springframework.security.core.GrantedAuthority;
 
 @Data
 public class UserPermission {
@@ -152,6 +153,25 @@ public class UserPermission {
 
       this.admin = permission.isAdmin();
       this.accountManager = permission.isAccountManager();
+    }
+
+    /**
+     * Returns this user permission view as a set of granted authorities. This authority set
+     * contains the user's roles along with authorities indicating if they're Spinnaker admins or
+     * account managers.
+     */
+    public Set<GrantedAuthority> toGrantedAuthorities() {
+      Set<GrantedAuthority> authorities = new LinkedHashSet<>();
+      if (isAdmin()) {
+        authorities.add(SpinnakerAuthorities.ADMIN_AUTHORITY);
+      }
+      if (isAccountManager()) {
+        authorities.add(SpinnakerAuthorities.ACCOUNT_MANAGER_AUTHORITY);
+      }
+      for (Role.View role : getRoles()) {
+        authorities.add(SpinnakerAuthorities.forRoleName(role.getName()));
+      }
+      return authorities;
     }
   }
 }

--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.fiat.model.Authorization;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.val;
+import org.springframework.security.core.GrantedAuthority;
 
 /**
  * Representation of authorization configuration for a resource. This object is immutable, which
@@ -89,6 +90,17 @@ public class Permissions {
 
   public Set<Authorization> getAuthorizations(List<String> userRoles) {
     return getAuthorizationsFromRoles(new LinkedHashSet<>(userRoles));
+  }
+
+  public Set<Authorization> getAuthorizations(
+      Collection<? extends GrantedAuthority> userAuthorities) {
+    Set<String> userRoles =
+        userAuthorities.stream()
+            .map(GrantedAuthority::getAuthority)
+            .filter(authority -> authority.startsWith("ROLE_"))
+            .map(authority -> authority.substring("ROLE_".length()))
+            .collect(Collectors.toSet());
+    return getAuthorizationsFromRoles(userRoles);
   }
 
   private Set<Authorization> getAuthorizationsFromRoles(Set<String> userRoles) {

--- a/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/UserPermissionTest.java
+++ b/fiat-core/src/test/groovy/com/netflix/spinnaker/fiat/model/UserPermissionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+class UserPermissionTest {
+  @Test
+  void rolesConvertToGrantedAuthorities() {
+    Role first = new Role("first");
+    Role second = new Role("second");
+    Role third = new Role("third");
+    UserPermission userPermission =
+        new UserPermission().setId("jesse").setRoles(Set.of(first, second, third));
+    Set<GrantedAuthority> authorities = userPermission.getView().toGrantedAuthorities();
+    Set<String> result = AuthorityUtils.authorityListToSet(authorities);
+    assertThat(result).containsExactlyInAnyOrder("ROLE_first", "ROLE_second", "ROLE_third");
+  }
+
+  @Test
+  void adminRoleConvertsToGrantedAuthority() {
+    UserPermission userPermission = new UserPermission().setId("sherry").setAdmin(true);
+    Set<GrantedAuthority> authorities = userPermission.getView().toGrantedAuthorities();
+    assertThat(authorities).containsExactly(SpinnakerAuthorities.ADMIN_AUTHORITY);
+  }
+
+  @Test
+  void accountManagerConvertsToGrantedAuthority() {
+    UserPermission userPermission = new UserPermission().setId("ralph").setAccountManager(true);
+    Set<GrantedAuthority> authorities = userPermission.getView().toGrantedAuthorities();
+    assertThat(authorities).containsExactly(SpinnakerAuthorities.ACCOUNT_MANAGER_AUTHORITY);
+  }
+}


### PR DESCRIPTION
This implements a few relevant Spring Security features and updates Fiat to use them in addition to the newly added AccessControlled interface in Kork.

- Introduces Spinnaker-specific GrantedAuthority values for admins, account managers, and anonymous users.
- Adds conversion from a user's set of roles to a set of granted authorities based on Spring Security conventions (`ROLE_foo` style authorities).
- Adds an implementation for FiatPermissionEvaluator::hasPermission for checking permissions on AccessControlled objects.
- Updates to Permissions/UserPermission to support GrantedAuthority conversions and checks.
- Adds spring-security-core as an API dependency to fiat-core as we now reference GrantedAuthority, Authentication, and some other core security interfaces.
- Updates Authorization parsing to support case-insensitive versions as Spring Security defines some common ones in lowercase like read/write/etc.