### PR TITLE
feat(roles): add capability to control querying clouddriver for applications during roles sync

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+test {
+  useJUnitPlatform {
+    includeEngines "junit-vintage", "junit-jupiter"
+  }
+}
+
 dependencies {
   implementation project(":fiat-core")
 
@@ -39,4 +45,5 @@ dependencies {
 
   testImplementation "org.apache.commons:commons-collections4:4.1"
   testImplementation "org.testcontainers:testcontainers"
+  testImplementation "org.junit.platform:junit-platform-runner"
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Configuration;
+
+/** Defines the configs for the various resource providers */
+@Data
+@Configuration
+@ConfigurationProperties("resource.provider")
+public class ResourceProviderConfig {
+
+  /**
+   * Configs for the {@link com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider}
+   */
+  @NestedConfigurationProperty
+  private ApplicationProviderConfig application = new ApplicationProviderConfig();
+
+  @Data
+  public static class ApplicationProviderConfig {
+    /**
+     * If true, then {@link com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider}
+     * will call Clouddriver in addition to Front50 for loading applications. If false, then only
+     * Front50 will be used.
+     */
+    private boolean loadApplicationsFromClouddriver = true;
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/ResourceProviderConfig.java
@@ -35,11 +35,22 @@ public class ResourceProviderConfig {
 
   @Data
   public static class ApplicationProviderConfig {
+    @NestedConfigurationProperty private ClouddriverConfig clouddriver = new ClouddriverConfig();
+  }
+
+  @Data
+  public static class ClouddriverConfig {
     /**
      * If true, then {@link com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider}
      * will call Clouddriver in addition to Front50 for loading applications. If false, then only
      * Front50 will be used.
      */
-    private boolean loadApplicationsFromClouddriver = true;
+    private boolean loadApplications = true;
+
+    /**
+     * Defines how frequently the clouddriver application cache is refreshed. Note that the
+     * clouddriver application cache is refreshed only when loadApplications: true
+     */
+    private long cacheRefreshIntervalMs = 30000;
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -80,7 +80,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
       // This preserves stream concatenation logic below,
       // ensuring that there is a non-null placeholder for Clouddriver applications.
       final List<Application> clouddriverApplications =
-          applicationProviderConfig.isLoadApplicationsFromClouddriver()
+          applicationProviderConfig.getClouddriver().isLoadApplications()
               ? clouddriverService.getApplications()
               : Collections.emptyList();
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
+import com.netflix.spinnaker.fiat.config.ResourceProviderConfig.ApplicationProviderConfig;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Role;
@@ -42,6 +43,7 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   private final ResourcePermissionProvider<Application> permissionProvider;
   private final FallbackPermissionsResolver executeFallbackPermissionsResolver;
 
+  private final ApplicationProviderConfig applicationProviderConfig;
   private final boolean allowAccessToUnknownApplications;
 
   public DefaultApplicationResourceProvider(
@@ -49,12 +51,14 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
       ClouddriverService clouddriverService,
       ResourcePermissionProvider<Application> permissionProvider,
       FallbackPermissionsResolver executeFallbackPermissionsResolver,
-      boolean allowAccessToUnknownApplications) {
+      boolean allowAccessToUnknownApplications,
+      ApplicationProviderConfig applicationProviderConfig) {
     this.front50Service = front50Service;
     this.clouddriverService = clouddriverService;
     this.permissionProvider = permissionProvider;
     this.executeFallbackPermissionsResolver = executeFallbackPermissionsResolver;
     this.allowAccessToUnknownApplications = allowAccessToUnknownApplications;
+    this.applicationProviderConfig = applicationProviderConfig;
   }
 
   @Override
@@ -71,13 +75,19 @@ public class DefaultApplicationResourceProvider extends BaseResourceProvider<App
   @Override
   protected Set<Application> loadAll() throws ProviderException {
     try {
-      List<Application> front50Applications = front50Service.getAllApplications();
-      List<Application> clouddriverApplications = clouddriverService.getApplications();
+      final List<Application> front50Applications = front50Service.getAllApplications();
+      // If enabled, load applications from Clouddriver, else use an empty list.
+      // This preserves stream concatenation logic below,
+      // ensuring that there is a non-null placeholder for Clouddriver applications.
+      final List<Application> clouddriverApplications =
+          applicationProviderConfig.isLoadApplicationsFromClouddriver()
+              ? clouddriverService.getApplications()
+              : Collections.emptyList();
 
       // Stream front50 first so that if there's a name collision, we'll keep that one instead of
       // the clouddriver application (since front50 might have permissions stored on it, but the
       // clouddriver version definitely won't)
-      List<Application> applications =
+      final List<Application> applications =
           Streams.concat(front50Applications.stream(), clouddriverApplications.stream())
               .filter(distinctByKey(a -> a.getName().toUpperCase()))
               // Collect to a list instead of set since we're about to modify the applications

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoader.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoader.java
@@ -16,12 +16,29 @@
 
 package com.netflix.spinnaker.fiat.providers.internal;
 
+import com.netflix.spinnaker.fiat.config.ResourceProviderConfig.ApplicationProviderConfig;
 import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 
+@Slf4j
 public class ClouddriverApplicationLoader extends ClouddriverDataLoader<Application> {
+  ApplicationProviderConfig applicationProviderConfig;
+
   public ClouddriverApplicationLoader(
-      ProviderHealthTracker healthTracker, ClouddriverApi clouddriverApi) {
+      ProviderHealthTracker healthTracker,
+      ClouddriverApi clouddriverApi,
+      ApplicationProviderConfig applicationProviderConfig) {
     super(healthTracker, clouddriverApi::getApplications);
+    this.applicationProviderConfig = applicationProviderConfig;
+  }
+
+  @Override
+  @Scheduled(
+      fixedDelayString =
+          "${resource.provider.application.clouddriver.cacheRefreshIntervalMs:30000}")
+  protected void refreshCache() {
+    super.refreshCache();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverService.java
@@ -18,16 +18,25 @@ package com.netflix.spinnaker.fiat.providers.internal;
 
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Application;
+import java.util.Collections;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 
+@Slf4j
 public class ClouddriverService {
-  private final ClouddriverApplicationLoader clouddriverApplicationLoader;
+  @Nullable private final ClouddriverApplicationLoader clouddriverApplicationLoader;
   private final ClouddriverAccountLoader clouddriverAccountLoader;
 
   public ClouddriverService(
-      ClouddriverApplicationLoader clouddriverApplicationLoader,
+      @Nullable ClouddriverApplicationLoader clouddriverApplicationLoader,
       ClouddriverAccountLoader clouddriverAccountLoader) {
     this.clouddriverApplicationLoader = clouddriverApplicationLoader;
+    this.clouddriverAccountLoader = clouddriverAccountLoader;
+  }
+
+  public ClouddriverService(ClouddriverAccountLoader clouddriverAccountLoader) {
+    this.clouddriverApplicationLoader = null;
     this.clouddriverAccountLoader = clouddriverAccountLoader;
   }
 
@@ -36,6 +45,11 @@ public class ClouddriverService {
   }
 
   public List<Application> getApplications() {
+    if (clouddriverApplicationLoader == null) {
+      log.info("clouddriverApplicationLoader is not configured");
+      return Collections.emptyList();
+    }
+
     return clouddriverApplicationLoader.getData();
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -68,7 +68,13 @@ class DefaultApplicationProviderSpec extends Specification {
       ]
     }
 
-    provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, defaultProvider, fallbackPermissionsResolver, allowAccessToUnknownApplications)
+    provider = new DefaultApplicationResourceProvider(
+            front50Service,
+            clouddriverService,
+            defaultProvider,
+            fallbackPermissionsResolver,
+            allowAccessToUnknownApplications,
+            applicationProviderConfig)
 
     when:
     def restrictedResult = provider.getAllRestricted("userId", [new Role(role)] as Set<Role>, false)
@@ -177,15 +183,6 @@ class DefaultApplicationProviderSpec extends Specification {
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build())
     ]
 
-    Set<Application> expectedApps = [
-            new Application().setName("front50App1")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
-                    .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
-            new Application().setName("front50App2")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
-                    .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
-    ] as Set
-
     Front50Service front50Service = Mock(Front50Service) {
       getAllApplications() >> front50Apps
     }
@@ -194,7 +191,7 @@ class DefaultApplicationProviderSpec extends Specification {
       getApplications() >> clouddriverApps
     }
 
-    applicationProviderConfig.setLoadApplicationsFromClouddriver(loadApplicationsFromClouddriver)
+    applicationProviderConfig.clouddriver.setLoadApplications(loadApplicationsFromClouddriver)
 
     provider = new DefaultApplicationResourceProvider(
             front50Service,

--- a/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
+++ b/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.netflix.spinnaker.fiat.config.ResourceProviderConfig;
+import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
+import org.junit.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class ClouddriverApplicationLoaderTest {
+
+  @Test
+  public void testClouddriverGetApplicationsApiCallInvocation() {
+
+    ProviderHealthTracker providerHealthTracker = mock(ProviderHealthTracker.class);
+    ClouddriverApi clouddriverApi = mock(ClouddriverApi.class);
+    ResourceProviderConfig.ApplicationProviderConfig applicationProviderConfig =
+        new ResourceProviderConfig.ApplicationProviderConfig();
+    ClouddriverApplicationLoader applicationLoader =
+        new ClouddriverApplicationLoader(
+            providerHealthTracker, clouddriverApi, applicationProviderConfig);
+
+    applicationLoader.refreshCache();
+
+    verify(clouddriverApi, times(1)).getApplications();
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -86,13 +86,15 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
       ClouddriverService clouddriverService,
       ResourcePermissionProvider<Application> permissionProvider,
       FallbackPermissionsResolver executeFallbackPermissionsResolver,
-      FiatServerConfigurationProperties properties) {
+      FiatServerConfigurationProperties properties,
+      ResourceProviderConfig resourceProviderConfig) {
     return new DefaultApplicationResourceProvider(
         front50Service,
         clouddriverService,
         permissionProvider,
         executeFallbackPermissionsResolver,
-        properties.isAllowAccessToUnknownApplications());
+        properties.isAllowAccessToUnknownApplications(),
+        resourceProviderConfig.getApplication());
   }
 
   @Bean

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.Scope;
 import retrofit.Endpoints;
@@ -114,16 +115,37 @@ public class ResourcesConfig {
   }
 
   @Bean
+  @ConditionalOnProperty(
+      name = "resource.provider.application.clouddriver.load-applications",
+      havingValue = "true",
+      matchIfMissing = true)
   ClouddriverApplicationLoader clouddriverApplicationLoader(
-      ProviderHealthTracker providerHealthTracker, ClouddriverApi clouddriverApi) {
-    return new ClouddriverApplicationLoader(providerHealthTracker, clouddriverApi);
+      ProviderHealthTracker providerHealthTracker,
+      ClouddriverApi clouddriverApi,
+      ResourceProviderConfig resourceProviderConfig) {
+    return new ClouddriverApplicationLoader(
+        providerHealthTracker, clouddriverApi, resourceProviderConfig.getApplication());
   }
 
   @Bean
+  @ConditionalOnProperty(
+      name = "resource.provider.application.clouddriver.load-applications",
+      havingValue = "true",
+      matchIfMissing = true)
+  @Primary
   ClouddriverService clouddriverService(
       ClouddriverApplicationLoader clouddriverApplicationLoader,
       ClouddriverAccountLoader clouddriverAccountLoader) {
     return new ClouddriverService(clouddriverApplicationLoader, clouddriverAccountLoader);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      name = "resource.provider.application.clouddriver.load-applications",
+      havingValue = "false")
+  ClouddriverService clouddriverServiceWithoutApplicationLoader(
+      ClouddriverAccountLoader clouddriverAccountLoader) {
+    return new ClouddriverService(clouddriverAccountLoader);
   }
 
   @Bean


### PR DESCRIPTION
## Purpose

During heavy load, loading applications from Clouddriver causes Spinnaker logins to timeout. During the login flow, Fiat invokes a roles/sync request which causes it to fetch all applications from Clouddriver and Front50 to figure out which applications the user has permissions for. Sometimes, due to heavy load, Clouddriver takes a long time to provide this list of applications(6 - 8.5 mins as seen in our production instances) which causes the aforementioned login timeouts. Front50 is enough to figure out user permissions. So this PR provides a way to optionally turn off querying clouddriver for applications during the roles sync. By default, querying clouddriver for applications is enabled. Users can opt out of it by setting:
```
resource:
  provider:
    clouddriver:
       loadApplications: false
```

Users can also set 
```
resource:
  provider:
    clouddriver:
      cacheRefreshIntervalMs: <> # defaults to 30s
```
to control how frequently should the clouddriver applications cache be refreshed.      
      
Test Setup:
```
resource.provider.application.clouddriver.cacheRefreshIntervalMs: 60000
```
***
Test case 1:
```
loadApplications: true
```
Logs:
```
→ ksp logs spin-fiat-58464989d8-hrn5k -c fiat | grep "refreshing clouddriver application cache"
2021-07-08 19:11:30.860 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] refreshing clouddriver application cache
2021-07-08 19:12:30.872 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] refreshing clouddriver application cache
2021-07-08 19:13:30.888 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] refreshing clouddriver application cache
```
we see that the attempt to refresh clouddriver cache is made every minute.

***
Test Case 2:
```
loadApplications: false
```
Logs:
```
→ ksp logs spin-fiat-7ff5c758dd-rqmwb -c fiat -f | grep "clouddriver application cache refresh has been disabled"
2021-07-08 19:14:40.327 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] clouddriver application cache refresh has been disabled
2021-07-08 19:15:40.328 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] clouddriver application cache refresh has been disabled
2021-07-08 19:16:40.328 DEBUG 6 --- [   scheduling-1] c.n.s.f.p.i.ClouddriverApplicationLoader : [] clouddriver application cache refresh has been disabled
```
And we see that no clouddriver api call to get applications has been made from the scheduling thread:
```
 → ksp logs spin-fiat-7ff5c758dd-rqmwb -c fiat -f | grep "GET http://spin-clouddriver.spinnaker:7002/applications?restricted=false&expand=false"
2021-07-08 19:14:40.001  INFO 6 --- [           main] c.n.s.f.p.internal.ClouddriverApi        : [] ---> HTTP GET http://spin-clouddriver.spinnaker:7002/applications?restricted=false&expand=false
^C
```

the only call logged above is when the ContextRefreshedEvent occurs (from the main thread), which happens very infrequently



