### PR TITLE
fix(gha): fix syntax error in code that determines what repos to bump

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -15,7 +15,7 @@ jobs:
       id: bumpdep_targets
       run: |
         REPOS=clouddriver,echo,front50,gate,igor,keel,orca
-        if [ "${{ github.event.client_payload.branch }}" == "  origin/master"]; then
+        if [ "${{ github.event.client_payload.branch }}" == "  origin/master" ]; then
           echo "on master branch, include halyard in bumpdeps target list"
           REPOS+=",halyard"
         fi


### PR DESCRIPTION
To fix
```
Run REPOS=clouddriver,echo,front50,gate,igor,keel,orca
/home/runner/work/_temp/8d0ae0e7-a4c8-4d0d-9869-dafd99934f6c.sh: line 2: [: missing `]'
```
from e.g. https://github.com/spinnaker/fiat/actions/runs/3048063150/jobs/4912729065