### PR TITLE
fix(gha): Event branch doesn't match

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -15,7 +15,7 @@ jobs:
       id: bumpdep_targets
       run: |
         REPOS=clouddriver,echo,front50,gate,igor,keel,orca
-        if [ "${{ github.event.client_payload.branch }}" == "  origin/master" ]; then
+        if [ "${{ github.event.client_payload.branch }}" == " origin/master" ]; then
           echo "on master branch, include halyard in bumpdeps target list"
           REPOS+=",halyard"
         fi


### PR DESCRIPTION
Somehow ended up with an extra space in the string to match.

From: https://github.com/spinnaker/fiat/actions/runs/3048395605/jobs/4913412198
```
  if [ " origin/master" == "  origin/master" ]; then
```