### PR TITLE
chore(build): set timeout for apt publishing to 10 minutes and add --stacktrace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           ORG_GRADLE_PROJECT_artifactRegistryPublishEnabled: true
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          ./gradlew -PartifactRegistryAptImportTimeoutSeconds=300 --info publish
+          ./gradlew -PartifactRegistryAptImportTimeoutSeconds=600 --info --stacktrace publish
       - name: Login to Google Cloud
         # Only run this on repositories in the 'spinnaker' org, not on forks.
         if: startsWith(github.repository, 'spinnaker/')


### PR DESCRIPTION
5 minutes wasn't enough in https://github.com/spinnaker/fiat/actions/runs/3491447692/jobs/5844087369
