### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -1,14 +1,5 @@
 apply plugin: 'io.spinnaker.package'
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-  springProfiles = System.getProperty('spring.profiles.active', "test,local")
-}
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-  systemProperty('spring.profiles.active', project.springProfiles)
-}
 mainClassName = 'com.netflix.spinnaker.fiat.Main'
 
 configurations.all {


### PR DESCRIPTION
The properties spring.config.additional-location and spring.profiles.active are redundant in fiat-web.gradle file. These properties are set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.fiat.Main. So removing it from gradle file.