### PR TITLE
fix(fiat-roles): Fiat fails to start if write mode is disabled

### DIFF
--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatRoleConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/FiatRoleConfig.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.roles.UserRolesSyncStrategy;
 import com.netflix.spinnaker.fiat.roles.UserRolesSyncStrategy.CachedSynchronizationStrategy;
 import com.netflix.spinnaker.fiat.roles.UserRolesSyncStrategy.DefaultSynchronizationStrategy;
 import lombok.Data;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -38,12 +39,14 @@ public class FiatRoleConfig {
       name = "fiat.role.sync-cache.enabled",
       havingValue = "false",
       matchIfMissing = true)
+  @ConditionalOnExpression("${fiat.write-mode.enabled:true}")
   UserRolesSyncStrategy defaultSyncStrategy(Synchronizer synchronizer) {
     return new DefaultSynchronizationStrategy(synchronizer);
   }
 
   @Bean
   @ConditionalOnProperty(name = "fiat.role.sync-cache.enabled", havingValue = "true")
+  @ConditionalOnExpression("${fiat.write-mode.enabled:true}")
   UserRolesSyncStrategy cachedSyncStrategy(Synchronizer synchronizer) {
     return new CachedSynchronizationStrategy(synchronizer);
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/Synchronizer.java
@@ -29,19 +29,26 @@ import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
 import com.netflix.spinnaker.fiat.providers.ProviderException;
 import com.netflix.spinnaker.fiat.providers.ResourceProvider;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 @Slf4j
 @Component
+@ConditionalOnExpression("${fiat.write-mode.enabled:true}")
 public class Synchronizer {
   private final ResourceProvidersHealthIndicator healthIndicator;
   private final PermissionsResolver permissionsResolver;


### PR DESCRIPTION
Spring refuses to start due to a missing bean when write mode is disabled. The roles sync should not be enabled at all when write mode is disabled, so this fix disables both sync strategies and the Synchronizer class if read mode is disabled. Fixes bug introduced in https://github.com/spinnaker/fiat/pull/962.

Error message:

```
***************************
APPLICATION FAILED TO START
***************************
Description:
Parameter 0 of constructor in com.netflix.spinnaker.fiat.roles.Synchronizer required a bean of type 'com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicato>
Action:
Consider defining a bean of type 'com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicator' in your configuration.
```