### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 in fiat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
       }
       minHeapSize = "512m"
       maxHeapSize = "512m"
+      useJUnitPlatform()
     }
     tasks.withType(Javadoc) {
       failOnError = false
@@ -69,6 +70,7 @@ subprojects {
       testImplementation "org.springframework:spring-test"
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
       testRuntimeOnly "org.objenesis:objenesis"
     }
   }

--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -39,7 +39,3 @@ dependencies {
 
   testImplementation "org.slf4j:slf4j-api"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
-}
-
 dependencies {
   implementation project(":fiat-core")
 

--- a/fiat-sql/fiat-sql.gradle
+++ b/fiat-sql/fiat-sql.gradle
@@ -51,9 +51,3 @@ dependencies {
     // Only used for Initializing Datasource. For actual CRUD, test containers preferred.
     testImplementation "com.h2database:h2"
 }
-
-test {
-    useJUnitPlatform {
-        includeEngines "junit-vintage", "junit-jupiter"
-    }
-}


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from [spring-boot-starter-test](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test). It is required for executing junit4 based test cases in fiat. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 87 to 180 test case executions.
