### PR TITLE
fix(logs): Redacted secret data in logs.

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
@@ -41,16 +41,8 @@ class HeadersRedactor {
   }
 
   private static String getRedactedHeaderValue(String headerName, String headerValue) {
-    if (headerName.startsWith(SECRET_DATA_HEADER_FORMAT)) {
+    if (!headerName.startsWith(SECRET_DATA_HEADER_FORMAT)) {
       return SECRET_DATA_VALUE;
-    } else {
-      return removeCredsFromAuthorization(headerName, headerValue);
-    }
-  }
-
-  private static String removeCredsFromAuthorization(String headerName, String headerValue) {
-    if (headerName.contains(AUTHORIZATION_HEADER)) {
-      return headerValue.trim().split("\n")[0].split(" ")[0] + " " + SECRET_DATA_VALUE;
     } else {
       return headerValue;
     }

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+public class HeadersRedactor {
+
+  private static final String SECRET_DATA_HEADER_FORMAT = "X-";
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String SECRET_DATA_VALUE = "**REDACTED**";
+
+  public Map<String, String> getRedactedHeaders(HttpServletRequest request) {
+    Map<String, String> headers = new HashMap<>();
+
+    if (request.getHeaderNames() != null) {
+      for (Enumeration<String> h = request.getHeaderNames(); h.hasMoreElements(); ) {
+        String headerName = h.nextElement();
+        String headerValue = getRedactedHeaderValue(headerName, request.getHeader(headerName));
+        headers.put(headerName, headerValue);
+      }
+    }
+    return headers;
+  }
+
+  private String getRedactedHeaderValue(String headerName, String headerValue) {
+    if (headerName.startsWith(SECRET_DATA_HEADER_FORMAT)) {
+      return SECRET_DATA_VALUE;
+    } else {
+      return removeCredsFromAuthorization(headerName, headerValue);
+    }
+  }
+
+  private String removeCredsFromAuthorization(String headerName, String headerValue) {
+    if (headerName.contains(AUTHORIZATION_HEADER)) {
+      return headerValue.trim().split("\n")[0].split(" ")[0] + " " + SECRET_DATA_VALUE;
+    } else {
+      return headerValue;
+    }
+  }
+}

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Netflix, Inc.
+ * Copyright 2023 Armory, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
-public class HeadersRedactor {
+class HeadersRedactor {
 
   private static final String SECRET_DATA_HEADER_FORMAT = "X-";
   private static final String AUTHORIZATION_HEADER = "Authorization";
@@ -40,7 +40,7 @@ public class HeadersRedactor {
     return headers;
   }
 
-  private String getRedactedHeaderValue(String headerName, String headerValue) {
+  private static String getRedactedHeaderValue(String headerName, String headerValue) {
     if (headerName.startsWith(SECRET_DATA_HEADER_FORMAT)) {
       return SECRET_DATA_VALUE;
     } else {
@@ -48,7 +48,7 @@ public class HeadersRedactor {
     }
   }
 
-  private String removeCredsFromAuthorization(String headerName, String headerValue) {
+  private static String removeCredsFromAuthorization(String headerName, String headerValue) {
     if (headerName.contains(AUTHORIZATION_HEADER)) {
       return headerValue.trim().split("\n")[0].split(" ")[0] + " " + SECRET_DATA_VALUE;
     } else {

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
@@ -23,8 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 
 class HeadersRedactor {
 
-  private static final String SECRET_DATA_HEADER_FORMAT = "X-";
-  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String WHITELIST_HEADER_PREFIX = "X-";
   private static final String SECRET_DATA_VALUE = "**REDACTED**";
 
   public Map<String, String> getRedactedHeaders(HttpServletRequest request) {
@@ -40,8 +39,8 @@ class HeadersRedactor {
     return headers;
   }
 
-  private static String getRedactedHeaderValue(String headerName, String headerValue) {
-    if (!headerName.startsWith(SECRET_DATA_HEADER_FORMAT)) {
+  private String getRedactedHeaderValue(String headerName, String headerValue) {
+    if (!headerName.startsWith(WHITELIST_HEADER_PREFIX)) {
       return SECRET_DATA_VALUE;
     } else {
       return headerValue;

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator
 import org.jetbrains.annotations.Nullable
 import org.springframework.beans.BeansException
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 import spock.lang.Shared
 import spock.lang.Subject
@@ -76,7 +75,7 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
     @Subject
     def fiatAccessDeniedExceptionHandler = new FiatAccessDeniedExceptionHandler(exceptionMessageDecorator)
 
-    def request = new MockHttpServletRequest()
+    def request = Mock(HttpServletRequest)
     def response = Mock(HttpServletResponse)
 
     @Shared
@@ -98,10 +97,6 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
         upv.setApplications([new Application.View().setName(resource)
                                      .setAuthorizations([userAuthorizationType] as Set)] as Set)
         fiatService.getUserPermission("testUser") >> upv
-
-        request.addHeader("Content-Type", "text/html");
-        request.addHeader("Authorization", "bearer token");
-        request.addHeader("X-Frame-Options", "DENY");
 
         when:
         evaluator.hasPermission(authentication, resource, 'APPLICATION', authorizationTypeRequired)

--- a/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
+++ b/fiat-api/src/test/groovy/com/netflix/spinnaker/fiat/shared/FiatAccessDeniedExceptionHandlerSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator
 import org.jetbrains.annotations.Nullable
 import org.springframework.beans.BeansException
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 import spock.lang.Shared
 import spock.lang.Subject
@@ -75,7 +76,7 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
     @Subject
     def fiatAccessDeniedExceptionHandler = new FiatAccessDeniedExceptionHandler(exceptionMessageDecorator)
 
-    def request = Mock(HttpServletRequest)
+    def request = new MockHttpServletRequest()
     def response = Mock(HttpServletResponse)
 
     @Shared
@@ -97,6 +98,10 @@ class FiatAccessDeniedExceptionHandlerSpec extends FiatSharedSpecification {
         upv.setApplications([new Application.View().setName(resource)
                                      .setAuthorizations([userAuthorizationType] as Set)] as Set)
         fiatService.getUserPermission("testUser") >> upv
+
+        request.addHeader("Content-Type", "text/html");
+        request.addHeader("Authorization", "bearer token");
+        request.addHeader("X-Frame-Options", "DENY");
 
         when:
         evaluator.hasPermission(authentication, resource, 'APPLICATION', authorizationTypeRequired)

--- a/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
+++ b/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.shared;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class HeadersRedactorTest {
+
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  HeadersRedactor unit = new HeadersRedactor();
+
+  @Test
+  public void redactHeadersTest() {
+    request.addHeader("Content-Type", "text/html");
+    request.addHeader("Authorization", "bearer token");
+    request.addHeader("Proxy-Authorization", "bearer token");
+    request.addHeader("X-Frame-Options", "DENY");
+
+    Map<String, String> result = unit.getRedactedHeaders(request);
+
+    assertEquals("text/html", result.get("Content-Type"));
+    assertEquals("bearer **REDACTED**", result.get("Authorization"));
+    assertEquals("bearer **REDACTED**", result.get("Proxy-Authorization"));
+    assertEquals("**REDACTED**", result.get("X-Frame-Options"));
+  }
+}

--- a/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
+++ b/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Netflix, Inc.
+ * Copyright 2023 Armory, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
+++ b/fiat-api/src/test/java/com/netflix/spinnaker/fiat/shared/HeadersRedactorTest.java
@@ -28,7 +28,7 @@ class HeadersRedactorTest {
   HeadersRedactor unit = new HeadersRedactor();
 
   @Test
-  public void redactHeadersTest() {
+  public void verifyNoSecretDataIsShownTest() {
     request.addHeader("Content-Type", "text/html");
     request.addHeader("Authorization", "bearer token");
     request.addHeader("Proxy-Authorization", "bearer token");
@@ -36,9 +36,9 @@ class HeadersRedactorTest {
 
     Map<String, String> result = unit.getRedactedHeaders(request);
 
-    assertEquals("text/html", result.get("Content-Type"));
-    assertEquals("bearer **REDACTED**", result.get("Authorization"));
-    assertEquals("bearer **REDACTED**", result.get("Proxy-Authorization"));
-    assertEquals("**REDACTED**", result.get("X-Frame-Options"));
+    assertEquals("**REDACTED**", result.get("Content-Type"));
+    assertEquals("**REDACTED**", result.get("Authorization"));
+    assertEquals("**REDACTED**", result.get("Proxy-Authorization"));
+    assertEquals("DENY", result.get("X-Frame-Options"));
   }
 }


### PR DESCRIPTION
Redacted secret data from log in `FiatAccessDeniedExceptionHandler`. 

### Example:

```
17:59:18.180 [Test worker] ERROR com.netflix.spinnaker.fiat.shared.FiatAccessDeniedExceptionHandler - Encountered exception while processing request : with headers={Authorization=bearer **REDACTED**, X-Frame-Options=**REDACTED**, Content-Type=text/html}
org.springframework.security.access.AccessDeniedException: Forbidden
```