### PR TITLE
feat(exceptions): Add SpinnakerRetrofitErrorHandler and replace RetrofitError catch blocks

### DIFF
--- a/fiat-api/fiat-api.gradle
+++ b/fiat-api/fiat-api.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.spinnaker.kork:kork-telemetry"
   implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-retrofit"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -24,6 +24,7 @@ import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.ErrorConfiguration;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
@@ -81,6 +82,7 @@ public class FiatAuthenticationConfig {
         .setRequestInterceptor(interceptor)
         .setClient(new Ok3Client(okHttpClient))
         .setConverter(new JacksonConverter(objectMapper))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(FiatService.class))
         .build()

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.telemetry.caffeine.CaffeineStatsCounter;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.security.AccessControlled;
@@ -187,8 +188,11 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                       try {
                         fiatService.canCreate(username, resourceType, resource);
                         return true;
-                      } catch (NotFoundException e) {
-                        return false;
+                      } catch (SpinnakerHttpException e) {
+                        if(e.getResponseCode() == HttpStatus.NOT_FOUND.value()){
+                          return false;
+                        }
+                        throw e;
                       }
                     });
               })

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -26,8 +26,6 @@ import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.kork.telemetry.caffeine.CaffeineStatsCounter;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.security.AccessControlled;
@@ -191,16 +189,6 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                         return true;
                       } catch (NotFoundException e) {
                         return false;
-                      } catch (SpinnakerHttpException e) {
-                        boolean shouldRetry = true;
-                        if (e.getResponseCode() == HttpStatus.BAD_REQUEST.value()) {
-                          shouldRetry = false;
-                        }
-                        e.setRetryable(shouldRetry);
-                        throw e;
-                      } catch (SpinnakerServerException e) {
-                        e.setRetryable(true);
-                        throw e;
                       }
                     });
               })

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.fiat.model.UserPermission;
 import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
-import com.netflix.spinnaker.kork.exceptions.IntegrationException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.kork.telemetry.caffeine.CaffeineStatsCounter;
@@ -197,13 +196,11 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                         if (e.getResponseCode() == HttpStatus.BAD_REQUEST.value()) {
                           shouldRetry = false;
                         }
-                        IntegrationException ie = new IntegrationException(e);
-                        ie.setRetryable(shouldRetry);
-                        throw ie;
+                        e.setRetryable(shouldRetry);
+                        throw e;
                       } catch (SpinnakerServerException e) {
-                        IntegrationException ie = new IntegrationException(e);
-                        ie.setRetryable(true);
-                        throw ie;
+                        e.setRetryable(true);
+                        throw e;
                       }
                     });
               })

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.fiat.model.resources.Authorizable;
 import com.netflix.spinnaker.fiat.model.resources.ResourceType;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.telemetry.caffeine.CaffeineStatsCounter;
-import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.security.AccessControlled;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.Serializable;
@@ -189,7 +188,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
                         fiatService.canCreate(username, resourceType, resource);
                         return true;
                       } catch (SpinnakerHttpException e) {
-                        if(e.getResponseCode() == HttpStatus.NOT_FOUND.value()){
+                        if (e.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
                           return false;
                         }
                         throw e;

--- a/fiat-github/fiat-github.gradle
+++ b/fiat-github/fiat-github.gradle
@@ -9,5 +9,6 @@ dependencies {
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-retrofit"
   implementation "javax.validation:validation-api"
 }

--- a/fiat-github/src/main/java/com/netflix/spinnaker/fiat/config/GitHubConfig.java
+++ b/fiat-github/src/main/java/com/netflix/spinnaker/fiat/config/GitHubConfig.java
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.fiat.roles.github.GitHubProperties;
 import com.netflix.spinnaker.fiat.roles.github.client.GitHubClient;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public class GitHubConfig {
                 clientProvider.getClient(
                     new DefaultServiceEndpoint("github", gitHubProperties.getBaseUrl()))))
         .setConverter(new JacksonConverter())
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(GitHubClient.class))
         .build()

--- a/fiat-github/src/main/java/com/netflix/spinnaker/fiat/roles/github/GithubTeamsUserRolesProvider.java
+++ b/fiat-github/src/main/java/com/netflix/spinnaker/fiat/roles/github/GithubTeamsUserRolesProvider.java
@@ -27,12 +27,11 @@ import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import com.netflix.spinnaker.fiat.roles.github.client.GitHubClient;
 import com.netflix.spinnaker.fiat.roles.github.model.Member;
 import com.netflix.spinnaker.fiat.roles.github.model.Team;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
-
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerNetworkException;
 import lombok.Data;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -271,7 +270,7 @@ public class GithubTeamsUserRolesProvider implements UserRolesProvider, Initiali
     try {
       log.debug("Requesting page " + page + " of teams.");
       teams = gitHubClient.getOrgTeams(organization, page, gitHubProperties.paginationValue);
-    } catch (SpinnakerNetworkException e){
+    } catch (SpinnakerNetworkException e) {
       log.error(String.format("Could not find the server %s", gitHubProperties.getBaseUrl()), e);
     } catch (SpinnakerHttpException e) {
       if (e.getResponseCode() != HttpStatus.NOT_FOUND.value()) {
@@ -290,7 +289,7 @@ public class GithubTeamsUserRolesProvider implements UserRolesProvider, Initiali
     try {
       log.debug("Requesting page " + page + " of members.");
       members = gitHubClient.getOrgMembers(organization, page, gitHubProperties.paginationValue);
-    } catch (SpinnakerNetworkException e){
+    } catch (SpinnakerNetworkException e) {
       log.error(String.format("Could not find the server %s", gitHubProperties.getBaseUrl()), e);
     } catch (SpinnakerHttpException e) {
       if (e.getResponseCode() != HttpStatus.NOT_FOUND.value()) {
@@ -311,7 +310,7 @@ public class GithubTeamsUserRolesProvider implements UserRolesProvider, Initiali
       members =
           gitHubClient.getMembersOfTeam(
               organization, teamSlug, page, gitHubProperties.paginationValue);
-    } catch (SpinnakerNetworkException e){
+    } catch (SpinnakerNetworkException e) {
       log.error(String.format("Could not find the server %s", gitHubProperties.getBaseUrl()), e);
     } catch (SpinnakerHttpException e) {
       if (e.getResponseCode() != HttpStatus.NOT_FOUND.value()) {

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-config"
   implementation "io.spinnaker.kork:kork-plugins"
   implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.swagger:swagger-annotations"
   implementation "net.logstash.logback:logstash-logback-encoder"
 

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/ResourcesConfig.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
 import com.netflix.spinnaker.fiat.providers.internal.*;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +69,7 @@ public class ResourcesConfig {
             new Ok3Client(
                 clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint))))
         .setConverter(new JacksonConverter(objectMapper))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(Front50Api.class))
         .build()
@@ -102,6 +104,7 @@ public class ResourcesConfig {
                 clientProvider.getClient(
                     new DefaultServiceEndpoint("clouddriver", clouddriverEndpoint))))
         .setConverter(new JacksonConverter(objectMapper))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(ClouddriverApi.class))
         .build()
@@ -157,6 +160,7 @@ public class ResourcesConfig {
             new Ok3Client(
                 clientProvider.getClient(new DefaultServiceEndpoint("igor", igorEndpoint))))
         .setConverter(new JacksonConverter(objectMapper))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(IgorApi.class))
         .build()


### PR DESCRIPTION
This pull request registers `SpinnakerRetrofitErrorHandler` with each `Retrofit.RestAdapter` and replaces each `RetrofitError` catch block with a catch-block using `SpinnakerServerException` or the appropriate subclass. This is part of an effort to consume `SpinnakerRetrofitErrorHandler` in each Spinnaker microservice, as detailed in [issue #5473](https://github.com/spinnaker/spinnaker/issues/5473)
