### PR TITLE
refactor(test): prefix redis:5-alpine images with library/

### DIFF
--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -87,7 +87,7 @@ class RedisPermissionsRepositorySpec extends Specification {
   Clock clock = new TestClock()
 
   def setupSpec() {
-    embeddedRedis = new GenericContainer(DockerImageName.parse("redis:5-alpine")).withExposedPorts(6379)
+    embeddedRedis = new GenericContainer(DockerImageName.parse("library/redis:5-alpine")).withExposedPorts(6379)
     embeddedRedis.start()
     def jedisPool = new JedisPool(embeddedRedis.host, embeddedRedis.getMappedPort(6379))
     jedis = jedisPool.getResource()

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -74,7 +74,7 @@ class UserRolesSyncerSpec extends Specification {
   RedisPermissionsRepository repo
 
   def setupSpec() {
-    embeddedRedis = new GenericContainer(DockerImageName.parse("redis:5-alpine")).withExposedPorts(6379)
+    embeddedRedis = new GenericContainer(DockerImageName.parse("library/redis:5-alpine")).withExposedPorts(6379)
     embeddedRedis.start()
     jedisPool = new JedisPool(embeddedRedis.host, embeddedRedis.getMappedPort(6379))
     jedis = jedisPool.getResource()

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/RedisContainerConfig.groovy
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/RedisContainerConfig.groovy
@@ -32,7 +32,7 @@ class RedisContainerConfig {
 
   @Bean(destroyMethod = "stop")
   GenericContainer redisContainer() {
-    def redisContainer = new GenericContainer(DockerImageName.parse("redis:5-alpine"))
+    def redisContainer = new GenericContainer(DockerImageName.parse("library/redis:5-alpine"))
       .withExposedPorts(6379);
 
     redisContainer.start()


### PR DESCRIPTION
so that uses in a private registry (e.g. via TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX) work.  Uses via docker.io continue to work.

For example:
```
$ docker pull redis:5-alpine
5-alpine: Pulling from library/redis
Digest: sha256:1a3c609295332f1ce603948142a132656c92a08149d7096e203058533c415b8c Status: Image is up to date for redis:5-alpine
docker.io/library/redis:5-alpine
```
```
$ docker pull docker.io/redis:5-alpine
5-alpine: Pulling from library/redis
Digest: sha256:1a3c609295332f1ce603948142a132656c92a08149d7096e203058533c415b8c Status: Image is up to date for redis:5-alpine
docker.io/library/redis:5-alpine
```
```
$ docker pull docker.io/library/redis:5-alpine
5-alpine: Pulling from library/redis
Digest: sha256:1a3c609295332f1ce603948142a132656c92a08149d7096e203058533c415b8c Status: Image is up to date for redis:5-alpine
docker.io/library/redis:5-alpine
```
See https://www.testcontainers.org/features/image_name_substitution#automatically-modifying-docker-hub-image-names for background.
