### PR TITLE
feat(ldap): Support for handling DN based multiloaded roles

### DIFF
--- a/fiat-ldap/fiat-ldap.gradle
+++ b/fiat-ldap/fiat-ldap.gradle
@@ -21,4 +21,5 @@ dependencies {
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.security:spring-security-ldap"
+  implementation "com.google.guava:guava"
 }

--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
@@ -51,14 +51,66 @@ public class LdapConfig {
     String managerDn;
     String managerPassword;
 
-    String groupSearchBase = "";
-    MessageFormat userDnPattern = new MessageFormat("uid={0},ou=users");
+    /** Search base to be used when querying users Example: "ou=users" */
     String userSearchBase = "";
+
+    /** Search base to be used when querying groups Example: "ou=groups" */
+    String groupSearchBase = "";
+
+    /** Pattern used for fetching user distinguished names */
+    MessageFormat userDnPattern = new MessageFormat("uid={0},ou=users");
+
+    /** Search filter used for querying users' distinguished names Example: "(employeeEmail={0})" */
     String userSearchFilter;
+
+    /** Search filter used for querying groups */
     String groupSearchFilter = "(uniqueMember={0})";
+
+    /** Group attribute for parsing out the role from the fetched groups */
     String groupRoleAttributes = "cn";
+
+    /**
+     * Group attribute for parsing out the group members from the fetched groups Example: "member"
+     */
     String groupUserAttributes = "";
 
+    /**
+     * Controls the user count threshold, used for determining if ldap groups for each user should
+     * be queried individually or not. If the threshold is breached, LDAP is queried to retrieve all
+     * groups and their members and then filtered based on the provided users
+     */
     int thresholdToUseGroupMembership = 100;
+
+    /**
+     * Controls whether paging should be used when fetching all LDAP groups. This is only applicable
+     * when enableDnBasedMultiLoad is true and thresholdToUseGroupMembership is breached.
+     */
+    boolean enablePagingForGroupMembershipQueries;
+
+    /**
+     * Number of results fetched per page for group membership queries. This is only applicable when
+     * thresholdToUseGroupMembership is breached and enablePagingForGroupMembershipQueries is set to
+     * true.
+     */
+    int pageSizeForGroupMembershipQueries = 100;
+
+    /**
+     * This value is used to determine the number of users to include in every ldap query when
+     * fetching user DNs from LDAP
+     */
+    int loadUserDNsBatchSize = 100;
+
+    /**
+     * The attribute used for parsing the id of the fetched ldap user. This is the id provided to
+     * Fiat when logging in the user, eg. employee email. This attribute is used for creating a map
+     * of the user dn to user id.
+     */
+    String userIdAttribute = "employeeEmail";
+
+    /**
+     * This attribute if true, enables multi loading of roles based on user DNs fetched using
+     * batched ldap queries
+     */
+    boolean enableDnBasedMultiLoad = false;
   }
 }

--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.fiat.roles.ldap;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import com.netflix.spinnaker.fiat.config.LdapConfig;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
@@ -29,6 +31,7 @@ import javax.naming.Name;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
+import javax.naming.directory.SearchControls;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -36,10 +39,14 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.ldap.control.PagedResultsDirContextProcessor;
 import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.ContextMapper;
+import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.DistinguishedName;
 import org.springframework.ldap.support.LdapEncoder;
+import org.springframework.ldap.support.LdapNameBuilder;
 import org.springframework.security.ldap.LdapUtils;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.stereotype.Component;
@@ -100,22 +107,56 @@ public class LdapUserRolesProvider implements UserRolesProvider {
         .collect(Collectors.toList());
   }
 
-  private class UserGroupMapper implements AttributesMapper<List<Pair<String, Role>>> {
+  class UserGroupMapper implements AttributesMapper<List<Pair<String, Role>>> {
+
+    @Override
     public List<Pair<String, Role>> mapFromAttributes(Attributes attrs) throws NamingException {
       String group = attrs.get(configProps.getGroupRoleAttributes()).get().toString();
       Role role = new Role(group).setSource(Role.Source.LDAP);
-      List<Pair<String, Role>> member = new ArrayList<>();
-      for (NamingEnumeration<?> members = attrs.get(configProps.getGroupUserAttributes()).getAll();
-          members.hasMore(); ) {
+      List<Pair<String, Role>> members = new ArrayList<>();
+      log.debug(
+          "Parsing out members of the LDAP group {} using attributes {}",
+          group,
+          configProps.getGroupUserAttributes());
+      for (NamingEnumeration<?> groupMembers =
+              attrs.get(configProps.getGroupUserAttributes()).getAll();
+          groupMembers.hasMore(); ) {
         try {
-          String user =
-              String.valueOf(configProps.getUserDnPattern().parse(members.next().toString())[0]);
-          member.add(Pair.of(user, role));
+          String user = getUser(groupMembers.next().toString());
+          members.add(Pair.of(user, role));
+          log.trace("Found user {} for the ldap group {}", user, group);
         } catch (ParseException e) {
           e.printStackTrace();
         }
       }
-      return member;
+      log.debug("Found following member role pairs for the group {}: {}", group, members);
+      return members;
+    }
+
+    private String getUser(String member) throws ParseException {
+      if (configProps.isEnableDnBasedMultiLoad()) {
+        return member.toLowerCase();
+      } else {
+        return String.valueOf(configProps.getUserDnPattern().parse(member)[0]);
+      }
+    }
+  }
+
+  /** Mapper for mapping user distinguished names to their ids */
+  class UserDNMapper implements ContextMapper<Pair<String, String>> {
+
+    @Override
+    public Pair<String, String> mapFromContext(Object ctx) {
+      DirContextAdapter context = (DirContextAdapter) ctx;
+      String userDN =
+          LdapNameBuilder.newInstance(LdapUtils.parseRootDnFromUrl(configProps.getUrl()))
+              .add(context.getDn())
+              .build()
+              .toString()
+              .toLowerCase();
+      String userId = context.getStringAttribute(configProps.getUserIdAttribute()).toLowerCase();
+      log.trace("Fetched user DN {} for user id {}", userDN, userId);
+      return Pair.of(userDN, userId);
     }
   }
 
@@ -127,7 +168,12 @@ public class LdapUserRolesProvider implements UserRolesProvider {
 
     if (users.size() > configProps.getThresholdToUseGroupMembership()
         && StringUtils.isNotEmpty(configProps.getGroupUserAttributes())) {
-      Set<String> userIds = users.stream().map(ExternalUser::getId).collect(Collectors.toSet());
+      log.info("Querying all groups to get a mapping of user to its roles.");
+      Set<String> userIds =
+          users.stream().map(user -> user.getId().toLowerCase()).collect(Collectors.toSet());
+      if (configProps.isEnableDnBasedMultiLoad()) {
+        return multiLoadDnBasedRoles(userIds);
+      }
       return ldapTemplate
           .search(
               configProps.getGroupSearchBase(),
@@ -145,13 +191,43 @@ public class LdapUserRolesProvider implements UserRolesProvider {
                   Collectors.mapping(Pair::getValue, Collectors.toCollection(ArrayList::new))));
     }
 
+    log.info("Querying individual groups memberships for {} users", users.size());
     // ExternalUser is used here as a simple data type to hold the username/roles combination.
     return users.stream()
         .map(u -> new ExternalUser().setId(u.getId()).setExternalRoles(loadRoles(u)))
         .collect(Collectors.toMap(ExternalUser::getId, ExternalUser::getExternalRoles));
   }
 
-  private String getUserFullDn(String userId) {
+  private Map<String, Collection<Role>> multiLoadDnBasedRoles(Set<String> userIds) {
+    Map<String, String> userDNToId = getUserDNs(userIds);
+    Map<String, Collection<Role>> userDNtoRoles =
+        configProps.isEnablePagingForGroupMembershipQueries()
+            ? doMultiLoadRolesPaginated(userDNToId.keySet())
+            : doMultiLoadRoles(userDNToId.keySet());
+
+    // Convert the fetched roles to a map of user id to roles
+    // and if one user has multiple DNs, merge roles
+    Map<String, Collection<Role>> rolesForUsers = new HashMap<>();
+    userDNtoRoles
+        .keySet()
+        .forEach(
+            userId ->
+                rolesForUsers.merge(
+                    userDNToId.get(userId),
+                    userDNtoRoles.get(userId),
+                    (addedRoles, newRoles) ->
+                        new ArrayList<>(
+                            new HashSet<>() {
+                              {
+                                addAll(addedRoles);
+                                addAll(newRoles);
+                              }
+                            })));
+    return rolesForUsers;
+  }
+
+  @VisibleForTesting
+  String getUserFullDn(String userId) {
     String rootDn = LdapUtils.parseRootDnFromUrl(configProps.getUrl());
     DistinguishedName root = new DistinguishedName(rootDn);
     log.debug("Root DN: " + root.toString());
@@ -184,5 +260,141 @@ public class LdapUserRolesProvider implements UserRolesProvider {
       log.error("Could not assemble full userDn", ine);
     }
     return null;
+  }
+
+  /**
+   * Gets the Distinguished Names for the provided user ids using batched ldap queries
+   *
+   * @param userIds list of user ids to fetch the DNs for
+   * @return mapping of user ids to their DNs
+   */
+  @VisibleForTesting
+  Map<String, String> getUserDNs(Collection<String> userIds) {
+    log.info("Loading distinguished names for {} users", userIds.size());
+    log.debug("Fetching distinguished names for the following users: {}", userIds);
+    Map<String, String> userDNToIdMap = new HashMap<>();
+    UserDNMapper userDNIdMapper = new UserDNMapper();
+
+    if (StringUtils.isNotEmpty(configProps.getUserSearchFilter())) {
+      log.debug(
+          "Fetching user DNs from LDAP since user search filter is set to {}",
+          configProps.getUserSearchFilter());
+      // Partion the list of userIds into batches of fixed sizes and process the batches one at a
+      // time
+      Iterables.partition(userIds, configProps.getLoadUserDNsBatchSize())
+          .forEach(
+              userIdsInBatch -> {
+                log.debug("Processing the following batch of users: {}", userIdsInBatch);
+                List<String> idFilters =
+                    userIdsInBatch.stream()
+                        .map(
+                            userId ->
+                                MessageFormat.format(configProps.getUserSearchFilter(), userId))
+                        .collect(Collectors.toList());
+
+                // This creates an "OR" filter of this form:
+                // (|(employeeEmail=foo@mycompany.com)(employeeEmail=bar@mycompany.com)(employeeEmail=bax@mycompany.com)...)
+                String userDNsFilter = String.format("(|%s)", String.join("", idFilters));
+                log.trace("LDAP query filter used for fetching the DNs: {}", userDNsFilter);
+                List<Pair<String, String>> userDNIdPairs =
+                    ldapTemplate.search(
+                        configProps.getUserSearchBase(), userDNsFilter, userDNIdMapper);
+
+                log.trace("Fetched the following user id DN pairs from LDAP: {}", userDNIdPairs);
+                userDNIdPairs.forEach(pair -> userDNToIdMap.put(pair.getKey(), pair.getValue()));
+              });
+    } else {
+      log.debug("Building user DN from LDAP since user search filter is empty");
+      userIds.forEach(userId -> userDNToIdMap.put(getUserFullDn(userId), userId));
+    }
+
+    log.debug("Loaded {} user DNs", userDNToIdMap.size());
+    return userDNToIdMap;
+  }
+
+  @VisibleForTesting
+  Map<String, Collection<Role>> doMultiLoadRoles(Collection<String> userIds) {
+    log.info("Multi-loading LDAP roles for {} users", userIds.size());
+    log.debug("Multi-loading LDAP roles for following users: {}", userIds);
+    Map<String, Collection<Role>> userRolesMap =
+        ldapTemplate
+            .search(
+                configProps.getGroupSearchBase(),
+                MessageFormat.format(
+                    configProps.getGroupSearchFilter(),
+                    "*",
+                    "*"), // Passing two wildcard params like loadRoles
+                new UserGroupMapper())
+            .stream()
+            .flatMap(List::stream)
+            .filter(p -> userIds.contains(p.getKey()))
+            .collect(
+                Collectors.groupingBy(
+                    Pair::getKey,
+                    Collectors.mapping(Pair::getValue, Collectors.toCollection(ArrayList::new))));
+    log.trace("Loaded the following {} user role mappings: {}", userRolesMap.size(), userRolesMap);
+    log.info("Multi-loaded roles for {} users", userRolesMap.size());
+    return userRolesMap;
+  }
+
+  @VisibleForTesting
+  Map<String, Collection<Role>> doMultiLoadRolesPaginated(Collection<String> userIds) {
+    log.info(
+        "Multi-loading LDAP roles for {} users having pagination enabled with a page size of {}",
+        userIds.size(),
+        configProps.getPageSizeForGroupMembershipQueries());
+    log.debug("Multi-loading LDAP roles for following users using pagination: {}", userIds);
+    PagedResultsDirContextProcessor processor =
+        getPagedResultsDirContextProcessor(configProps.getPageSizeForGroupMembershipQueries());
+    SearchControls searchControls = new SearchControls();
+    searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+    int page = 1;
+    Map<String, Collection<Role>> userRolesMap = new HashMap<>();
+    do {
+      log.debug("Processing page {} when querying ldap groups", page);
+
+      Map<String, Collection<Role>> currentPageUsers =
+          ldapTemplate
+              .search(
+                  configProps.getGroupSearchBase(),
+                  MessageFormat.format(
+                      configProps.getGroupSearchFilter(),
+                      "*",
+                      "*"), // Passing two wildcard params like loadRoles
+                  searchControls,
+                  new UserGroupMapper(),
+                  processor)
+              .stream()
+              .flatMap(List::stream)
+              .filter(p -> userIds.contains(p.getKey()))
+              .collect(
+                  Collectors.groupingBy(
+                      Pair::getKey,
+                      Collectors.mapping(Pair::getValue, Collectors.toCollection(ArrayList::new))));
+
+      log.trace(
+          "Loaded the following {} user role mappings in page {}: {}",
+          currentPageUsers.size(),
+          page,
+          currentPageUsers);
+
+      // Add the loaded roles in the final result map
+      currentPageUsers.forEach(
+          (id, roles) -> userRolesMap.computeIfAbsent(id, k -> new ArrayList<>()).addAll(roles));
+
+      page++;
+    } while (processor.hasMore());
+    log.trace("Loaded the following {} user role mappings: {}", userRolesMap.size(), userRolesMap);
+    log.info("Multi-loaded roles for {} users using pagination", userRolesMap.size());
+    return userRolesMap;
+  }
+
+  /**
+   * Provides a new instance of the {@link PagedResultsDirContextProcessor} class initialized with
+   * the provided page size
+   */
+  @VisibleForTesting
+  PagedResultsDirContextProcessor getPagedResultsDirContextProcessor(int pageSize) {
+    return new PagedResultsDirContextProcessor(pageSize, null);
   }
 }

--- a/fiat-ldap/src/test/groovy/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProviderTest.groovy
+++ b/fiat-ldap/src/test/groovy/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProviderTest.groovy
@@ -20,12 +20,15 @@ import com.netflix.spinnaker.fiat.config.LdapConfig
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.permissions.ExternalUser
 import org.springframework.dao.IncorrectResultSizeDataAccessException
+import org.springframework.ldap.control.PagedResultsDirContextProcessor
 import org.springframework.security.ldap.SpringSecurityLdapTemplate
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 import org.apache.commons.lang3.tuple.Pair
+
+import javax.naming.directory.SearchControls
 
 class LdapUserRolesProviderTest extends Specification {
 
@@ -118,7 +121,10 @@ class LdapUserRolesProviderTest extends Specification {
     def role1 = new Role("group1")
     def role2 = new Role("group2")
 
-    def configProps = baseConfigProps().setGroupSearchBase("notEmpty").setGroupUserAttributes("member")
+    def configProps = baseConfigProps()
+            .setUserSearchBase("ou=users")
+            .setGroupSearchBase("ou=groups")
+            .setGroupUserAttributes("member")
     def provider = Spy(LdapUserRolesProvider){
       2 * loadRoles(_) >>> [[role1], [role2]]
     }.setConfigProps(configProps)
@@ -130,16 +136,152 @@ class LdapUserRolesProviderTest extends Specification {
     then: "should use loadRoles"
     roles == [user1: [role1], user2: [role2]]
 
-    when: "users count is greater than thresholdToUseGroupMembership"
+    when: "users count is greater than thresholdToUseGroupMembership and enableDnBasedMultiLoad is false"
     configProps.thresholdToUseGroupMembership = 1
     provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
-      1 * search(*_) >> [[Pair.of("user1",role1)], [Pair.of("user2", role2)], [Pair.of("unknown", role2)]]
+      1 * search(*_) >> [
+              [Pair.of("user1", role1)],
+              [Pair.of("user2", role2)],
+              [Pair.of("unknown", role2)]
+      ]
     }
     roles = provider.multiLoadRoles(users)
 
-    then: "should use ldapTemplate.search method"
+    then: "should compile user DNs locally and query memberships for all groups to load roles"
     roles == [user1: [role1], user2: [role2]]
+    users.each {0 * provider.getUserFullDn(it.id) }
+    0 * provider.doMultiLoadRoles(_)
+    0 * provider.doMultiLoadRolesPaginated(_)
+
+    when: "thresholdToUseGroupMembership is breached, userSearchFilter is empty and enableDnBasedMultiLoad is true"
+    // Test to make sure that when the thresholdToUseGroupMembership is breached:
+    // 1. User DNs are compiled using the provided User DN Pattern in the configs, instead of querying LDAP,
+    //    when userSearchFilter is empty.
+    // 2. Roles are loaded by querying the memberships for all groups and then filtering based on the provided user ids
+    configProps.thresholdToUseGroupMembership = 1
+    configProps.enableDnBasedMultiLoad = true
+    provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
+      1 * search("ou=groups", "(uniqueMember=*)", _ as LdapUserRolesProvider.UserGroupMapper) >> [
+              [Pair.of("uid=user1,ou=users,dc=springframework,dc=org", role1)],
+              [Pair.of("uid=user2,ou=users,dc=springframework,dc=org", role2)],
+              [Pair.of("unknown", role2)]
+      ]
+    }
+    roles = provider.multiLoadRoles(users)
+
+    then: "should compile user DNs locally and query memberships for all groups to load roles"
+    roles == [user1: [role1], user2: [role2]]
+    users.each {1 * provider.getUserFullDn(it.id) }
+    1 * provider.doMultiLoadRoles(_)
+    0 * provider.doMultiLoadRolesPaginated(_)
+
+    when: "thresholdToUseGroupMembership is breached and userSearchFilter is set"
+    // Test to make sure that when the thresholdToUseGroupMembership is breached:
+    // 1. User DNs are fetched from LDAP when userSearchFilter is set
+    // 2. Roles are loaded by querying the memberships for all groups and then filtering based on the provided user ids
+    users = [externalUser("user1@foo.com"), externalUser("user2@foo.com")]
+    configProps.setUserSearchFilter("(employeeEmail={0})")
+    provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
+      1 * search("ou=users",
+              "(|(employeeEmail=user1@foo.com)(employeeEmail=user2@foo.com))",
+              _ as LdapUserRolesProvider.UserDNMapper) >>
+              [Pair.of("uid=user1,ou=users,dc=springframework,dc=org", "user1@foo.com"),
+               Pair.of("uid=user2,ou=users,dc=springframework,dc=org", "user2@foo.com")]
+      1 * search("ou=groups", "(uniqueMember=*)", _ as LdapUserRolesProvider.UserGroupMapper) >> [
+              [Pair.of("uid=user1,ou=users,dc=springframework,dc=org", role1)],
+              [Pair.of("uid=user2,ou=users,dc=springframework,dc=org", role2)],
+              [Pair.of("unknown", role2)]
+      ]
+    }
+    roles = provider.multiLoadRoles(users)
+
+    then: "should fetch user DNs from LDAP and query memberships for all groups to load roles"
+    roles == ["user1@foo.com": [role1], "user2@foo.com": [role2]]
+    0 * provider.getUserFullDn(_)
+    1 * provider.doMultiLoadRoles(_)
+    0 * provider.doMultiLoadRolesPaginated(_)
   }
+
+  void "multiLoadRoles should use pagination when enabled"() {
+    given:
+    def users = (1..10).collect {externalUser("user${it}@foo.com") }
+    def role1 = new Role("group1")
+    def role2 = new Role("group2")
+
+    def configProps = baseConfigProps()
+    provider = Spy(provider)
+    provider.setConfigProps(configProps)
+
+    when: "pagination is enabled"
+    configProps.setUserSearchBase("ou=users")
+            .setGroupSearchBase("ou=groups")
+            .setUserSearchFilter("(employeeEmail={0})")
+            .setGroupUserAttributes("member")
+            .setThresholdToUseGroupMembership(5)
+            .setEnablePagingForGroupMembershipQueries(true)
+            .setEnableDnBasedMultiLoad(true)
+            .setLoadUserDNsBatchSize(5)
+            .setPageSizeForGroupMembershipQueries(5)
+
+    provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
+      1 * search("ou=users", _ as String, _ as LdapUserRolesProvider.UserDNMapper) >>
+              users[0..4].collect {Pair.of("${it.id}@foo.com" as String, "${it.id}" as String) }
+      1 * search("ou=users", _ as String, _ as LdapUserRolesProvider.UserDNMapper) >>
+              users[5..9].collect {Pair.of("${it.id}@foo.com" as String, "${it.id}" as String) }
+
+      2 * search("ou=groups",
+              "(uniqueMember=*)",
+              _ as SearchControls,
+              _ as LdapUserRolesProvider.UserGroupMapper,
+              _ as PagedResultsDirContextProcessor) >>> [
+              users[0..4].collect {
+                [Pair.of("${it.id}@foo.com" as String, role1),
+                 Pair.of("${it.id}@foo.com" as String, role2)]
+              },
+              users[5..9].collect {
+                [Pair.of("${it.id}@foo.com" as String, role1),
+                 Pair.of("${it.id}@foo.com" as String, role2)]
+              }]
+    }
+    def spiedProcessor = Spy(new PagedResultsDirContextProcessor(5, null))
+    1 * provider.getPagedResultsDirContextProcessor(_) >> spiedProcessor
+    2 * spiedProcessor.hasMore() >>> [true, false]
+
+    def roles = provider.multiLoadRoles(users)
+
+    then: "should fetch ldap roles using pagination"
+    roles == users.collectEntries { ["${it.id}" as String, [role1, role2]] }
+    0 * provider.doMultiLoadRoles(_)
+    1 * provider.doMultiLoadRolesPaginated(_)
+  }
+
+  void "multiLoadRoles should merge roles when multiple DNs exist for a user id"(){
+    given:
+    def users = [externalUser("user1")]
+    def role1 = new Role("group1")
+    def role2 = new Role("group2")
+    def role3 = new Role("group3")
+
+    def configProps = baseConfigProps()
+    def provider = Spy(LdapUserRolesProvider){
+      getUserDNs(_ as Collection<String>) >> ['uid=dn1,ou=users,dc=springframework,dc=org': 'user1',
+                                              'uid=dn2,ou=users,dc=springframework,dc=org': 'user1']
+      doMultiLoadRoles(_ as Collection<String>) >> ['uid=dn1,ou=users,dc=springframework,dc=org' : [role1,role2],
+                                                    'uid=dn2,ou=users,dc=springframework,dc=org': [role3] ]
+    }
+    provider.setConfigProps(configProps)
+
+    when:
+    configProps.groupSearchBase = "notEmpty"
+    configProps.thresholdToUseGroupMembership = 0
+    configProps.groupUserAttributes = "notEmpty"
+    configProps.enableDnBasedMultiLoad = true
+    def roles = provider.multiLoadRoles(users)
+
+    then:
+    roles == [user1: [role1, role2, role3]]
+  }
+
 
   private static ExternalUser externalUser(String id) {
     return new ExternalUser().setId(id)


### PR DESCRIPTION
Addresses https://github.com/spinnaker/spinnaker/issues/6841
- The PR allows for getting Ldap memberships for large number of users
- Pagination support while fetching group memberships
- Support for user IDs to user DNs mapping provided using batched LDAP queries
- This is an opt-in feature using the below configuration:
```
auth:
  groupMembership:
    ldap:
      enableDnBasedMultiLoad: true
```

And to enable pagination, below configuration is also needed:
```
auth:
  groupMembership:
    ldap:
      enablePagingForGroupMembershipQueries: true
``` 