### PR TITLE
feat(fiat) - Cache fetched LDAP roles to speed up role syncs.

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/config/LdapConfig.java
@@ -21,6 +21,7 @@ import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
@@ -112,5 +113,11 @@ public class LdapConfig {
      * batched ldap queries
      */
     boolean enableDnBasedMultiLoad = false;
+
+    /**
+     * Configures if caching of LDAP responses is enabled, and if so, the cache specific settings.
+     */
+    @NestedConfigurationProperty
+    private UserRolesProviderCacheConfig cache = new UserRolesProviderCacheConfig();
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UserRolesProviderCacheConfig.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UserRolesProviderCacheConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+
+@Data
+public class UserRolesProviderCacheConfig {
+
+  /**
+   * If true, then caching is enabled. If false, then all calls are passed directly through to the
+   * subclass, skipping the cache.
+   */
+  private boolean enabled = false;
+
+  /** Default cache entry expire time. */
+  private long expireAfterWriteSeconds = 600;
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -209,15 +209,16 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
     return userToRoles.entrySet().stream()
         .map(
             entry -> {
-              String userId = entry.getKey();
-              Set<Role> userRoles = new HashSet<>(entry.getValue());
+              final String userId = entry.getKey();
+              final Set<Role> userRoles = new HashSet<>(entry.getValue());
+              final boolean isAdmin = hasAdminRole(userRoles);
 
               return new UserPermission()
                   .setId(userId)
                   .setRoles(userRoles)
-                  .setAdmin(hasAdminRole(userRoles))
+                  .setAdmin(isAdmin)
                   .setAccountManager(hasAccountManagerRole(userRoles))
-                  .addResources(getResources(userId, userRoles, hasAdminRole(userRoles)));
+                  .addResources(getResources(userId, userRoles, isAdmin));
             })
         .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
   }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/BaseUserRolesProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/BaseUserRolesProvider.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.roles;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.netflix.spinnaker.fiat.config.UserRolesProviderCacheConfig;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.permissions.ExternalUser;
+import com.netflix.spinnaker.fiat.providers.ProviderException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** UserRolesProvider base implementation class providing caching for user roles. */
+public abstract class BaseUserRolesProvider implements UserRolesProvider {
+
+  /** Cache loader implementation consistent with UserRolesProvider. */
+  class BaseUserRolesProviderCacheLoader extends CacheLoader<String, Collection<Role>> {
+    @Override
+    public Collection<Role> load(final @NotNull String userId) {
+      return loadRolesForUser(new ExternalUser().setId(userId));
+    }
+
+    @Override
+    public Map<String, Collection<Role>> loadAll(@NotNull Iterable<? extends String> userIds) {
+      final List<ExternalUser> externalUsers =
+          ImmutableList.copyOf(userIds).stream()
+              .map(userId -> new ExternalUser().setId(userId))
+              .collect(Collectors.toList());
+      return loadRolesForUsers(externalUsers);
+    }
+  }
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  protected boolean cacheEnabled;
+  protected LoadingCache<String, Collection<Role>> loadingCache;
+
+  public final void setProviderCacheConfig(final UserRolesProviderCacheConfig cacheConfig) {
+    final boolean enableCache = cacheConfig != null && cacheConfig.isEnabled();
+    final long expireAfterWriteSeconds =
+        enableCache ? cacheConfig.getExpireAfterWriteSeconds() : 0L;
+
+    // Build the cache.
+    this.loadingCache = enableCache ? buildCache(expireAfterWriteSeconds) : null;
+    // Expose the cache for usage.
+    this.cacheEnabled = enableCache;
+
+    log.info(
+        "Caching status: enabled = {}, expireAfterWriteSeconds = {}",
+        enableCache,
+        expireAfterWriteSeconds);
+  }
+
+  private LoadingCache<String, Collection<Role>> buildCache(final long expireAfterWriteSeconds) {
+    return CacheBuilder.newBuilder()
+        .expireAfterWrite(expireAfterWriteSeconds, TimeUnit.SECONDS)
+        .build(new BaseUserRolesProviderCacheLoader());
+  }
+
+  @Override
+  public List<Role> loadRoles(final ExternalUser user) {
+    try {
+      if (cacheEnabled) {
+        // Responses by default stored as a collection in the cache to support the UserRolesProvider
+        // interface.
+        // If already a list, avoid duplicate list creation, else, return a new list.
+        final Collection<Role> roles = loadingCache.get(user.getId());
+        return roles instanceof List<?> ? (List<Role>) roles : new ArrayList<>(roles);
+      } else {
+        return loadRolesForUser(user);
+      }
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      if (e.getCause() instanceof ProviderException) {
+        throw (ProviderException) e.getCause();
+      }
+      throw new ProviderException(this.getClass(), e.getCause());
+    }
+  }
+
+  /**
+   * Helper method to encapsulate shared logic for converting list of users to ids for interacting
+   * with the cache.
+   *
+   * @param users Users to convert to ids.
+   * @return List of ids, one per user.
+   */
+  private List<String> convertExternalUsersToUserIds(final Iterable<ExternalUser> users) {
+    return StreamSupport.stream(users.spliterator(), false)
+        .map(ExternalUser::getId)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Map<String, Collection<Role>> multiLoadRoles(final Collection<ExternalUser> users) {
+    try {
+      if (cacheEnabled) {
+        // Convert the cached response to a mutable map object.
+        // By default, Guava cache getAll() responses are returned as an immutable map.
+        return new HashMap<>(loadingCache.getAll(convertExternalUsersToUserIds(users)));
+      } else {
+        return loadRolesForUsers(users);
+      }
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      if (e.getCause() instanceof ProviderException) {
+        throw (ProviderException) e.getCause();
+      }
+      throw new ProviderException(this.getClass(), e.getCause());
+    }
+  }
+
+  /**
+   * Loads roles for a single user to the cache. This method must be implemented in order to support
+   * cache loading functionality.
+   *
+   * @param user User for which to load roles.
+   * @return List of roles for the user.
+   * @throws ProviderException if there is an exception loading roles.
+   */
+  protected abstract List<Role> loadRolesForUser(final ExternalUser user) throws ProviderException;
+
+  /**
+   * Loads roles for multiple users to the cache. This method provides a default bulk cache load
+   * implementation which simply loads the cache one user entry at a time using {@link
+   * #loadRolesForUser}. This method should be overridden when bulk retrieval is significantly more
+   * efficient than many individual lookups.
+   *
+   * @param users Users for which to load roles.
+   * @return Mapping of user id to roles.
+   * @throws ProviderException if there is an exception loading roles.
+   */
+  protected Map<String, Collection<Role>> loadRolesForUsers(final Collection<ExternalUser> users)
+      throws ProviderException {
+    return users.stream().collect(Collectors.toMap(ExternalUser::getId, this::loadRolesForUser));
+  }
+
+  /** Invalidates a single user entry in the cache. */
+  public void invalidate(final ExternalUser user) {
+    if (cacheEnabled) {
+      loadingCache.invalidate(user.getId());
+    }
+  }
+
+  /** Invalidates multiple user entries in the cache. */
+  public void invalidate(final Iterable<ExternalUser> users) {
+    if (cacheEnabled) {
+      loadingCache.invalidateAll(convertExternalUsersToUserIds(users));
+    }
+  }
+
+  /** Invalidates all user entries in the cache. */
+  public void invalidateAll() {
+    if (cacheEnabled) {
+      loadingCache.invalidateAll();
+    }
+  }
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/BaseUserRolesProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/BaseUserRolesProviderSpec.groovy
@@ -1,0 +1,408 @@
+package com.netflix.spinnaker.fiat.roles
+
+import com.netflix.spinnaker.fiat.config.UserRolesProviderCacheConfig
+import com.netflix.spinnaker.fiat.model.resources.Role
+import com.netflix.spinnaker.fiat.permissions.ExternalUser
+import com.netflix.spinnaker.fiat.providers.ProviderException
+import spock.lang.Specification
+
+class BaseUserRolesProviderSpec extends Specification {
+
+    /** Simple implementation of {@link BaseUserRolesProvider} for testing of loading cache semantics. */
+    class TestBaseUserRolesProvider extends BaseUserRolesProvider {
+
+        /** Returns {@code true} if caching is enabled. */
+        protected boolean checkCacheEnabled() {
+            return cacheEnabled;
+        }
+
+        /**
+         * Returns the number of active entries in the cache. This method is intended for testing purposes
+         * only as a cache clean up is manually invoked prior to the size calculation. If caching is not
+         * enabled then returns -1.
+         *
+         * @return Size of the cache or -1 if caching is not enabled.
+         */
+        protected long size() {
+            if (cacheEnabled) {
+                loadingCache.cleanUp();
+                return loadingCache.size();
+            } else {
+                return -1L;
+            }
+        }
+
+        @Override
+        protected List<Role> loadRolesForUser(ExternalUser user) throws ProviderException {
+            return loadRolesForUserDelegate(user);
+        }
+
+        /**
+         * Support mocking of returned responses by the test layer.
+         * This method added to avoid cases where explicit mock of {@link #loadRolesForUser} was not registering with Spock.
+         */
+        public List<Role> loadRolesForUserDelegate(ExternalUser user) throws ProviderException {
+            return Collections.emptyList();
+        }
+    }
+
+    private UserRolesProviderCacheConfig baseCacheConfig() {
+        return baseCacheConfig(true, 100)
+    }
+
+    private UserRolesProviderCacheConfig baseCacheConfig(boolean cacheEnabled, int expireAfterWriteSeconds) {
+        def cacheConfig = new UserRolesProviderCacheConfig()
+        cacheConfig.setEnabled(cacheEnabled)
+        cacheConfig.setExpireAfterWriteSeconds(expireAfterWriteSeconds)
+
+        return cacheConfig
+    }
+
+    private ExternalUser externalUser(String id) {
+        return new ExternalUser().setId(id)
+    }
+
+    void "basic cache load - load()"() {
+        given:
+        def eu1 = externalUser("user1")
+        def role1 = new Role("group1")
+
+        def cacheConfig = baseCacheConfig()
+        def provider = Spy(TestBaseUserRolesProvider) {
+            loadRolesForUserDelegate(eu1) >> [role1]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        when:
+        def roles = provider.loadRoles(eu1)
+
+        then:
+        roles == [role1]
+        1 * provider.loadRolesForUser(eu1)
+        provider.size() == 1
+    }
+
+    void "basic cache load - loadAll()"() {
+        given:
+        def eu1 = externalUser("user1")
+        def eu2 = externalUser("user2")
+        def users = [eu1, eu2]
+
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+
+        def cacheConfig = baseCacheConfig()
+        def provider = Spy(TestBaseUserRolesProvider) {
+            loadRolesForUserDelegate(eu1) >> [role1]
+            loadRolesForUserDelegate(eu2) >> [role2]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        when:
+        def roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+
+        // loadAll() called with all users.
+        1 * provider.loadRolesForUsers(_)
+
+        // load() called once per user by loadAll().
+        1 * provider.loadRolesForUser(eu1)
+        1 * provider.loadRolesForUser(eu2)
+
+        // Cache is not empty.
+        provider.size() == users.size()
+    }
+
+    void "cache returns previously calculated entries by only calling loadAll() once"() {
+        given:
+        def users = [externalUser("user1"), externalUser("user2")]
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+
+        def cacheConfig = baseCacheConfig()
+        def provider = Spy(TestBaseUserRolesProvider){
+            loadRolesForUserDelegate(_ as ExternalUser) >>> [[role1], [role2]]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        // Load the cache.
+        when:
+        def roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+        1 * provider.loadRolesForUsers(users)
+        provider.size() == users.size()
+
+        // Return cached entries, i.e. no cache loading involved.
+        when:
+        roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+        0 * provider.loadRolesForUsers(_)
+        provider.size() == users.size()
+    }
+
+    void "cache expires entries based on write time"() {
+        given:
+        def users = [externalUser("user1"), externalUser("user2")]
+
+        int expireAfterWriteSeconds = 1
+        def cacheConfig = baseCacheConfig(true, expireAfterWriteSeconds)
+        def provider = Spy(TestBaseUserRolesProvider)
+        provider.setProviderCacheConfig(cacheConfig)
+
+        // Cache is loaded.
+        def roles = provider.multiLoadRoles(users)
+
+        // Cached entries still valid prior to expiry.
+        when:
+        sleep((long) 0.9 * 1000 * expireAfterWriteSeconds)
+
+        then:
+        provider.size() == users.size()
+
+        // Cached entries invalid after expiry.
+        when:
+        sleep((long) 1.0 * 1000 * expireAfterWriteSeconds)
+
+        then:
+        provider.size() == 0
+
+        // Cache is reloaded for expired entries.
+        when:
+        roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [], user2: []]
+        1 * provider.loadRolesForUsers(users)
+        provider.size() == users.size()
+    }
+
+    void "multiLoadRoles() only calls loadAll() for users not already in the cache"() {
+        given:
+        def eu1 = externalUser("user1")
+        def eu2 = externalUser("user2")
+        def users1 = [eu1, eu2]
+
+        def eu3 = externalUser("user3")
+        def eu4 = externalUser("user4")
+        def users2 = [eu3, eu4]
+
+        def usersAll = [eu1, eu2, eu3, eu4]
+
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+        def role3 = new Role("group3")
+        def role4 = new Role("group4")
+
+        def cacheConfig = baseCacheConfig()
+        def provider = Spy(TestBaseUserRolesProvider){
+            loadRolesForUserDelegate(_ as ExternalUser) >>> [[role1], [role2], [role3], [role4]]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        // Cache is loaded with the first group of users only.
+        when:
+        def roles = provider.multiLoadRoles(users1)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+        1 * provider.loadRolesForUsers(users1)
+        provider.size() == 2
+
+        // Cache is loaded with only the second group of users when multiLoadRoles() for all users performed.
+        when:
+        roles = provider.multiLoadRoles(usersAll)
+
+        then:
+        roles == [user1: [role1], user2: [role2], user3: [role3], user4: [role4]]
+        // Existing users in the cache are not reloaded.
+        0 * provider.loadRolesForUsers(users1)
+        // loadAll() is only called for users not yet in the cache.
+        1 * provider.loadRolesForUsers(users2)
+        provider.size() == 4
+    }
+
+    void "loadRoles() returns already cached entries when available"() {
+        given:
+        def eu1 = externalUser("user1")
+        def eu2 = externalUser("user2")
+        def users1 = [eu1, eu2]
+
+        def eu3 = externalUser("user3")
+
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+        def role3 = new Role("group3")
+
+        def cacheConfig = baseCacheConfig(true, 1000)
+        def provider = Spy(TestBaseUserRolesProvider) {
+            loadRolesForUserDelegate(eu1) >> [role1]
+            loadRolesForUserDelegate(eu2) >> [role2]
+            loadRolesForUserDelegate(eu3) >> [role3]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        // Cache is loaded with the first group of users only.
+        when:
+        def roles = provider.multiLoadRoles(users1)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+        1 * provider.loadRolesForUsers(users1)
+        1 * provider.loadRolesForUser(eu1)
+        1 * provider.loadRolesForUser(eu2)
+        provider.size() == 2
+
+        // loadRoles() for single, non-cached user loads that user explicitly.
+        when:
+        def singleUserRoles = provider.loadRoles(eu3)
+
+        then:
+        singleUserRoles == [role3]
+        0 * provider.loadRolesForUsers(_)
+        1 * provider.loadRolesForUser(eu3)
+        provider.size() == 3
+
+        // loadRoles() for already cached users returns cached values.
+        when:
+        def singleUserRoles1 = provider.loadRoles(eu1)
+        def singleUserRoles2 = provider.loadRoles(eu2)
+        def singleUserRoles3 = provider.loadRoles(eu3)
+
+        then:
+        singleUserRoles1 == [role1]
+        singleUserRoles2 == [role2]
+        singleUserRoles3 == [role3]
+        0 * provider.loadRolesForUsers(_)
+        0 * provider.loadRolesForUser(eu1)
+        0 * provider.loadRolesForUser(eu2)
+        0 * provider.loadRolesForUser(eu3)
+        provider.size() == 3
+    }
+
+    void "cache invalidation"() {
+        given:
+        def eu1 = externalUser("user1")
+        def eu2 = externalUser("user2")
+        def eu3 = externalUser("user3")
+        def eu4 = externalUser("user4")
+
+        def usersAll = [eu1, eu2, eu3, eu4]
+
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+        def role3 = new Role("group3")
+        def role4 = new Role("group4")
+
+        def cacheConfig = baseCacheConfig()
+        def provider = Spy(TestBaseUserRolesProvider){
+            loadRolesForUserDelegate(eu1) >> [role1]
+            loadRolesForUserDelegate(eu2) >> [role2]
+            loadRolesForUserDelegate(eu3) >> [role3]
+            loadRolesForUserDelegate(eu4) >> [role4]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        // Cache is loaded with all users.
+        when:
+        def roles = provider.multiLoadRoles(usersAll)
+
+        then:
+        roles == [user1: [role1], user2: [role2], user3: [role3], user4: [role4]]
+        1 * provider.loadRolesForUsers(usersAll)
+        provider.size() == 4
+
+        // Invalidate a single user.
+        when:
+        provider.invalidate(eu1)
+        roles = provider.multiLoadRoles([eu2, eu3, eu4])
+
+        then:
+        roles == [user2: [role2], user3: [role3], user4: [role4]]
+        0 * provider.loadRolesForUsers(_)
+        0 * provider.loadRolesForUser(_)
+        provider.size() == 3
+
+        // Invalidate multiple users.
+        when:
+        provider.invalidate([eu2, eu3])
+        roles = provider.multiLoadRoles([eu4])
+
+        then:
+        roles == [user4: [role4]]
+        0 * provider.loadRolesForUsers(_)
+        0 * provider.loadRolesForUser(_)
+        provider.size() == 1
+
+        // Invalidate all users.
+        when:
+        provider.invalidateAll()
+
+        then:
+        provider.size() == 0
+
+        // Cache is properly reloaded with all users.
+        when:
+        roles = provider.multiLoadRoles(usersAll)
+
+        then:
+        roles == [user1: [role1], user2: [role2], user3: [role3], user4: [role4]]
+        1 * provider.loadRolesForUsers(usersAll)
+        provider.size() == 4
+    }
+
+    void "cache not enabled"() {
+        given:
+        def eu1 = externalUser("user1")
+        def eu2 = externalUser("user2")
+        def users = [eu1, eu2]
+
+        def role1 = new Role("group1")
+        def role2 = new Role("group2")
+
+        def cacheConfig = baseCacheConfig(false, 100)
+        def provider = Spy(TestBaseUserRolesProvider) {
+            loadRolesForUserDelegate(eu1) >> [role1]
+            loadRolesForUserDelegate(eu2) >> [role2]
+        }
+        provider.setProviderCacheConfig(cacheConfig)
+
+        when:
+        def roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+
+        // loadRolesForUsers() called with all users.
+        1 * provider.loadRolesForUsers(_)
+
+        // loadRolesForUser() called once per user by loadRolesForUsers().
+        1 * provider.loadRolesForUser(eu1)
+        1 * provider.loadRolesForUser(eu2)
+
+        // Cache is not enabled.
+        provider.checkCacheEnabled() == false
+        provider.size() == -1L
+
+        when:
+        roles = provider.multiLoadRoles(users)
+
+        then:
+        roles == [user1: [role1], user2: [role2]]
+
+        // loadRolesForUsers() called with all users; nothing in the previous response was cached.
+        1 * provider.loadRolesForUsers(_)
+
+        // load() called once per user by loadAll(); nothing in the previous response was cached.
+        1 * provider.loadRolesForUser(eu1)
+        1 * provider.loadRolesForUser(eu2)
+
+        // Cache is not enabled.
+        provider.size() == -1L
+    }
+}


### PR DESCRIPTION
* BaseUserRolesProvider: New class to enable caching layer for concrete UserRolesProvider implementations.
* LdapUserRolesProvider: Update class to consume caching layer.
* When call for roles is initiated, now the local cache responds with cached roles else LDAP is contacted and the result gets cached.
* This feature can be enabled by adding the below configuration:
```yaml
auth:
  groupMembership:
    ldap:
      cache:
        enabled: true
        expireAfterWriteSeconds: 600        
```
* Cached entries expire after `expireAfterWriteSeconds` seconds. This is an optional configuration whose default value is 600(i..e, 1hour).

* Addressed the spinnaker issue: https://github.com/spinnaker/spinnaker/issues/6845