### PR TITLE
refactor(tests): convert junit4 based testcases to junit5 and clean up in fiat

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -39,5 +39,4 @@ dependencies {
 
   testImplementation "org.apache.commons:commons-collections4:4.1"
   testImplementation "org.testcontainers:testcontainers"
-  testImplementation "org.junit.platform:junit-platform-runner"
 }

--- a/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
+++ b/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
@@ -22,11 +22,8 @@ import static org.mockito.Mockito.verify;
 
 import com.netflix.spinnaker.fiat.config.ResourceProviderConfig;
 import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
-import org.junit.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnitPlatform.class)
 public class ClouddriverApplicationLoaderTest {
 
   @Test

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
@@ -6,12 +6,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 // This file must be .java because groovy barfs on the composite annotation style.
@@ -27,6 +27,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
       Main.class,
       TestDataLoaderConfig.class
     })
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public @interface FiatSystemTest {}

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/MainSpec.java
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/MainSpec.java
@@ -1,12 +1,12 @@
 package com.netflix.spinnaker.fiat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:fiat-test.yml"})
 public class MainSpec {


### PR DESCRIPTION
Before refactor, total test cases executed were 195. 
After refactor, total test cases executed are 195.