### PR TITLE
fix(ldap): fixed sporadic occurrence of InvalidCacheLoadException

### DIFF
--- a/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
+++ b/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java
@@ -238,8 +238,7 @@ public class LdapUserRolesProvider extends BaseUserRolesProvider {
                               }
                             })));
     // add entries with empty roles for the missing users
-    users.parallelStream()
-        .forEach(user -> rolesForUsers.putIfAbsent(user.getId(), new ArrayList<>()));
+    users.forEach(user -> rolesForUsers.putIfAbsent(user.getId(), new ArrayList<>()));
     return rolesForUsers;
   }
 


### PR DESCRIPTION
Because of the use of parallelStream to add elements to HashMap, the result is not always reliable due to non-thread-safe nature and occasional  InvalidCacheLoadException is observed. Hence removed parallelStream. 
