### PR TITLE
fix(ssl): Removed unused deprecated okHttpClientConfig from retrofitConfig.

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/RetrofitConfig.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import java.io.IOException;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -30,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,8 +40,6 @@ import retrofit.RestAdapter;
 /** This package is placed in fiat-core in order to be shared by fiat-web and fiat-shared. */
 @Configuration
 public class RetrofitConfig {
-
-  @Autowired @Setter private OkHttpClientConfiguration okHttpClientConfig;
 
   @Value("${ok-http-client.connection-pool.max-idle-connections:5}")
   @Setter


### PR DESCRIPTION
This change removes unused deprecated class. Its instantiation caused fiat to fail when configuring SSL. Other then fixing an issue, the class was never used.

Tested on local environment on fiat 1.29.x, master and 1.30.x.

Before this change:
* fiat was throwing FileNotFound because OkHttpClientConfigurationProperties were not decrypted
  * the properties were not decrypted and the key-store could not be downloaded into a file
* this happened because  okHttpClientConfig instantiated OkHttpClientConfigurationProperties before the SecretBeanPostProcessor was instantiated

After the change:
* SecretBeanPostProcessor is instantiated first
* then it is used when OkHttpClientConfigurationProperties is instantiated  to decrypt each property