### PR TITLE
chore(dependencies): remove org.springframework.boot:spring-boot-properties-migrator

### DIFF
--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -16,7 +16,6 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.google.guava:guava"
 
-  implementation "org.springframework.boot:spring-boot-properties-migrator"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "io.spinnaker.kork:kork-config"


### PR DESCRIPTION
since it's meant for migration only

See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#configuration-properties for background.
