### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/fiat-sql-mysql/fiat-sql-mysql.gradle
+++ b/fiat-sql-mysql/fiat-sql-mysql.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    runtimeOnly("mysql:mysql-connector-java")
+    runtimeOnly("com.mysql:mysql-connector-j")
 }

--- a/fiat-sql/fiat-sql.gradle
+++ b/fiat-sql/fiat-sql.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation "dev.minutest:minutest"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
 
-    testImplementation "mysql:mysql-connector-java"
+    testImplementation "com.mysql:mysql-connector-j"
     testImplementation "org.testcontainers:mysql"
 
     testImplementation "org.testcontainers:postgresql"


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom
