### PR TITLE
refactor(dependency): add explicit dependency of slf4j-api in fiat-ldap module during upgrade to spring boot 2.7.x

### DIFF
--- a/fiat-ldap/fiat-ldap.gradle
+++ b/fiat-ldap/fiat-ldap.gradle
@@ -22,4 +22,5 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.security:spring-security-ldap"
   implementation "com.google.guava:guava"
+  implementation "org.slf4j:slf4j-api"
 }


### PR DESCRIPTION
While upgrading spring boot 2.7.18, encounter below error during compilation of fiat-ldap module:
```
> Task :fiat-ldap:compileJava FAILED
/fiat/fiat-ldap/src/main/java/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProvider.java:54: error: package org.slf4j does not exist
@Slf4j
^
1 error
```
The root cause is the removal of `slf4j-api` transitive dependency from org.springframework.ldap:spring-ldap-core:2.4.1 (via. org.springframework.security:spring-security-ldap:5.7.11, which is part of spring boot 2.7.18). So, adding the dependency explicitly.

Before:
```
$ ./gradlew fiat-ldap:dI --dependency slf4j-api

> Task :fiat-ldap:dependencyInsight
org.slf4j:slf4j-api:1.7.36
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.slf4j:slf4j-api:1.7.36
\--- io.spinnaker.kork:kork-bom:7.227.0
     \--- compileClasspath

org.slf4j:slf4j-api:1.7.32 -> 1.7.36
\--- org.springframework.ldap:spring-ldap-core:2.3.8.RELEASE
     +--- io.spinnaker.kork:kork-bom:7.227.0
     |    \--- compileClasspath
     \--- org.springframework.security:spring-security-ldap:5.6.10
          +--- compileClasspath (requested org.springframework.security:spring-security-ldap)
          \--- io.spinnaker.kork:kork-bom:7.227.0 (*)
```

After:
```
$ ./gradlew fiat-ldap:dI --dependency slf4j-api

> Task :fiat-ldap:dependencyInsight
org.slf4j:slf4j-api:1.7.36
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.slf4j:slf4j-api:1.7.36
\--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
     \--- compileClasspath

org.slf4j:slf4j-api -> 1.7.36
\--- compileClasspath
```