### PR TITLE
refactor(tests): replace HashSet.Of() and HashMap.Of() with Set.Of() and Map.Of() during upgrade to spring boot 2.7.x

### DIFF
--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverSpec.groovy
@@ -340,10 +340,10 @@ class DefaultPermissionsResolverSpec extends Specification {
     ]
 
     when:
-    applicationProvider.getAllRestricted("user1", HashSet.of(role1), false) >> [testApp1].toSet()
-    applicationProvider.getAllRestricted("user2", HashSet.of(role1, role2), false) >> [testApp2].toSet()
-    applicationProvider.getAllRestricted("user3", HashSet.of(role1, roleAdmin), true) >> [testAppAdmin].toSet()
-    applicationProvider.getAllRestricted("abc@managed-service-accounts", HashSet.of(role1), false) >> [testApp1].toSet()
+    applicationProvider.getAllRestricted("user1", Set.of(role1), false) >> [testApp1].toSet()
+    applicationProvider.getAllRestricted("user2", Set.of(role1, role2), false) >> [testApp2].toSet()
+    applicationProvider.getAllRestricted("user3", Set.of(role1, roleAdmin), true) >> [testAppAdmin].toSet()
+    applicationProvider.getAllRestricted("abc@managed-service-accounts", Set.of(role1), false) >> [testApp1].toSet()
     def result = resolver.resolveResources(userToRoles)
 
     then:

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -167,19 +167,19 @@ class DefaultApplicationProviderSpec extends Specification {
     setup:
     def front50Apps = [
             new Application().setName("front50App1")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
             new Application().setName("front50App2")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build())
     ]
 
     def clouddriverApps = [
             new Application().setName("clouddriverApp1")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
             new Application().setName("clouddriverApp2")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build())
     ]
 
@@ -224,22 +224,22 @@ class DefaultApplicationProviderSpec extends Specification {
     setup:
     def testApps = [
             new Application().setName("front50App1")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
             new Application().setName("front50App2")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build())
     ]
 
     Set<Application> expectedApps = [
             new Application().setName("front50App1")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder()
                             .add(Authorization.READ, "role")
                             .add(Authorization.EXECUTE, "role")
                             .build()),
             new Application().setName("front50App2")
-                    .setDetails(HashMap.of("foo", "bar", "xyz", "pqr"))
+                    .setDetails(Map.of("foo", "bar", "xyz", "pqr"))
                     .setPermissions(new Permissions.Builder()
                             .add(Authorization.READ, "role")
                             .add(Authorization.EXECUTE, "role")


### PR DESCRIPTION
While upgrading spring boot 2.7.18, encounter below errors during test compilation of fiat-roles module:
```
No signature of method: static java.util.HashSet.of() is applicable for argument types: (com.netflix.spinnaker.fiat.model.resources.Role) values: [Role(resourceType=role, name=role1, source=null)]
Possible solutions: is(java.lang.Object), max(), any(), sort(), sum(), min()
groovy.lang.MissingMethodException: No signature of method: static java.util.HashSet.of() is applicable for argument types: (com.netflix.spinnaker.fiat.model.resources.Role) values: [Role(resourceType=role, name=role1, source=null)]
Possible solutions: is(java.lang.Object), max(), any(), sort(), sum(), min()
        at com.netflix.spinnaker.fiat.permissions.DefaultPermissionsResolverSpec.should resolve resources for users and service accounts(DefaultPermissionsResolverSpec.groovy:343)
```
```
No signature of method: static java.util.HashMap.of() is applicable for argument types: (String, String, String, String) values: [foo, bar, xyz, pqr]
Possible solutions: any(), sort(), notify(), wait(), size(), clone()
groovy.lang.MissingMethodException: No signature of method: static java.util.HashMap.of() is applicable for argument types: (String, String, String, String) values: [foo, bar, xyz, pqr]
Possible solutions: any(), sort(), notify(), wait(), size(), clone()
        at com.netflix.spinnaker.fiat.providers.DefaultApplicationProviderSpec.enable calling Clouddriver during application load based on config(DefaultApplicationProviderSpec.groovy:170)

```
```
No signature of method: static java.util.HashMap.of() is applicable for argument types: (String, String, String, String) values: [foo, bar, xyz, pqr]
Possible solutions: any(), sort(), notify(), wait(), size(), clone()
groovy.lang.MissingMethodException: No signature of method: static java.util.HashMap.of() is applicable for argument types: (String, String, String, String) values: [foo, bar, xyz, pqr]
Possible solutions: any(), sort(), notify(), wait(), size(), clone()
        at com.netflix.spinnaker.fiat.providers.DefaultApplicationProviderSpec.should suppress details when loading all applications(DefaultApplicationProviderSpec.groovy:227)

```
Spring boot 2.7.18 brings groovy 3.0.19 as transitive dependency. The root cause of the issue is a breaking change introduced from groovy 3.0.18 onwards, that allows a Java class to inherit static methods from its interface. To fix these issues replacing the HashSet.Of() and HashMap.Of() with Set.Of() and Map.Of().

http://groovy-lang.org/changelogs/changelog-3.0.18.html 
https://issues.apache.org/jira/browse/GROOVY-8164

Before:
```
$ ./gradlew fiat-roles:dI --dependency org.codehaus.groovy --configuration testCompileClasspath

> Task :fiat-roles:dependencyInsight
org.codehaus.groovy:groovy:3.0.17
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:3.0.17
\--- io.spinnaker.kork:kork-bom:7.227.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy:3.0.8 -> 3.0.17
+--- org.spockframework:spock-core:2.0-groovy-3.0
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.227.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:2.0-groovy-3.0
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.227.0 (*)
\--- org.spockframework:spock-spring:2.0-groovy-3.0 (*)

```

After:
```
$ ./gradlew fiat-roles:dI --dependency org.codehaus.groovy --configuration testCompileClasspath

> Task :fiat-roles:dependencyInsight
org.codehaus.groovy:groovy:3.0.19
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy:3.0.19
\--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
     \--- testCompileClasspath

org.codehaus.groovy:groovy:3.0.8 -> 3.0.19
+--- org.spockframework:spock-core:2.0-groovy-3.0
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:2.0-groovy-3.0
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:sb2718-SNAPSHOT (*)
\--- org.spockframework:spock-spring:2.0-groovy-3.0 (*)

```