### PR TITLE
fix(ldap/roles): fix the issue of multiple entries in Ldap for single user

### DIFF
--- a/fiat-ldap/src/test/groovy/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProviderTest.groovy
+++ b/fiat-ldap/src/test/groovy/com/netflix/spinnaker/fiat/roles/ldap/LdapUserRolesProviderTest.groovy
@@ -23,31 +23,35 @@ import org.apache.commons.lang3.tuple.Pair
 import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.ldap.control.PagedResultsDirContextProcessor
 import org.springframework.security.ldap.SpringSecurityLdapTemplate
-import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Subject
 import spock.lang.Unroll
 
 import javax.naming.directory.SearchControls
 
 class LdapUserRolesProviderTest extends Specification {
 
-  @Shared
-  @Subject
-  def provider = new LdapUserRolesProvider()
-
   @Unroll
   void "loadRoles should return no roles for serviceAccounts when userSearchFilter present"() {
     given:
-    def user = new ExternalUser(id: 'foo', externalRoles: [new Role(name: 'bar')])
+    def id = 'foo'
+    def user = new ExternalUser(id: id, externalRoles: [new Role(name: 'bar')])
 
     def configProps = baseConfigProps()
     configProps.groupSearchBase = groupSearchBase
     configProps.userSearchFilter = "notEmpty"
 
+    def provider = Spy(LdapUserRolesProvider){
+      1 * setConfigProps(configProps)
+      1 * setLdapTemplate(_ as SpringSecurityLdapTemplate)
+      1 * loadRoles(user)
+      1 * loadRolesForUser(user)
+      (0..1) * getUserFullDn(id)
+      0 * _
+    }
     provider.configProps = configProps
     provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
-      _ * searchForSingleEntry(*_) >> { throw new IncorrectResultSizeDataAccessException(1) }
+      (0..1) * searchForSingleEntry(*_) >> { throw new IncorrectResultSizeDataAccessException(1) }
+      0 * _
     }
 
     when:
@@ -66,15 +70,26 @@ class LdapUserRolesProviderTest extends Specification {
   @Unroll
   void "loadRoles should return no roles for serviceAccouts when userSearchFilter absent"() {
     given:
-    def user = new ExternalUser(id: 'foo', externalRoles: [new Role(name: 'bar')])
+    def id = 'id'
+    def user = new ExternalUser(id: id, externalRoles: [new Role(name: 'bar')])
 
     def configProps = baseConfigProps()
     configProps.groupSearchBase = groupSearchBase
+
+    def provider = Spy(LdapUserRolesProvider){
+      1 * setConfigProps(configProps)
+      1 * setLdapTemplate(_ as SpringSecurityLdapTemplate)
+      1 * loadRoles(user)
+      1 * loadRolesForUser(user)
+      (0..1) * getUserFullDn(id)
+      0 * _
+    }
 
     provider.configProps = configProps
     provider.ldapTemplate = Mock(SpringSecurityLdapTemplate) {
       (0..1) * searchForSingleEntry(*_) >> { throw new IncorrectResultSizeDataAccessException(1) }
       (0..1) * searchForSingleAttributeValues(*_) >> new HashSet<>()
+      0 * _
     }
 
     when:
@@ -97,7 +112,9 @@ class LdapUserRolesProviderTest extends Specification {
 
     def configProps = baseConfigProps()
     def provider = Spy(LdapUserRolesProvider){
-      loadRoles(_ as ExternalUser) >>> [[role1], [role2]]
+     2 * loadRoles(_ as ExternalUser) >>> [[role1], [role2]]
+     1 * setConfigProps(configProps)
+     0 * _
     }
     provider.setConfigProps(configProps)
 
@@ -107,6 +124,8 @@ class LdapUserRolesProviderTest extends Specification {
 
     then:
     roles == [user1: [], user2: []]
+    1 * provider.multiLoadRoles(users)
+    1 * provider.loadRolesForUsers(users)
 
     when:
     configProps.groupSearchBase = "notEmpty"
@@ -114,6 +133,8 @@ class LdapUserRolesProviderTest extends Specification {
 
     then:
     roles == [user1: [role1], user2: [role2]]
+    1 * provider.multiLoadRoles(users)
+    1 * provider.loadRolesForUsers(users)
   }
 
   void "multiLoadRoles should use groupUserAttributes when groupUserAttributes is not empty"() {
@@ -127,7 +148,9 @@ class LdapUserRolesProviderTest extends Specification {
             .setGroupSearchBase("ou=groups")
             .setGroupUserAttributes("member")
     def provider = Spy(LdapUserRolesProvider){
-      2 * loadRoles(_) >>> [[role1], [role2]]
+      2 * loadRoles(_ as ExternalUser) >>> [[role1], [role2]]
+      1 * setConfigProps(configProps)
+      0 * _
     }
     provider.setConfigProps(configProps)
 
@@ -136,6 +159,8 @@ class LdapUserRolesProviderTest extends Specification {
     def roles = provider.multiLoadRoles(users)
 
     then: "should use loadRoles"
+    1 * provider.multiLoadRoles(users)
+    1 * provider.loadRolesForUsers(users)
     roles == [user1: [role1], user2: [role2]]
 
     when: "users count is greater than thresholdToUseGroupMembership and enableDnBasedMultiLoad is false"
@@ -146,14 +171,16 @@ class LdapUserRolesProviderTest extends Specification {
               [Pair.of("user2", role2)],
               [Pair.of("unknown", role2)]
       ]
+      0 * _
     }
     roles = provider.multiLoadRoles(users)
 
     then: "should compile user DNs locally and query memberships for all groups to load roles"
     roles == [user1: [role1], user2: [role2]]
     users.each {0 * provider.getUserFullDn(it.id) }
-    0 * provider.doMultiLoadRoles(_)
-    0 * provider.doMultiLoadRolesPaginated(_)
+    1 * provider.setLdapTemplate(_ as SpringSecurityLdapTemplate)
+    1 * provider.multiLoadRoles(users)
+    1 * provider.loadRolesForUsers(users)
 
     when: "thresholdToUseGroupMembership is breached, userSearchFilter is empty and enableDnBasedMultiLoad is true"
     // Test to make sure that when the thresholdToUseGroupMembership is breached:
@@ -168,14 +195,18 @@ class LdapUserRolesProviderTest extends Specification {
               [Pair.of("uid=user2,ou=users,dc=springframework,dc=org", role2)],
               [Pair.of("unknown", role2)]
       ]
+      0 * _
     }
     roles = provider.multiLoadRoles(users)
 
     then: "should compile user DNs locally and query memberships for all groups to load roles"
     roles == [user1: [role1], user2: [role2]]
     users.each {1 * provider.getUserFullDn(it.id) }
+    1 * provider.multiLoadRoles(users)
+    1 * provider.setLdapTemplate(_ as SpringSecurityLdapTemplate)
     1 * provider.doMultiLoadRoles(_)
-    0 * provider.doMultiLoadRolesPaginated(_)
+    1 * provider.getUserDNs(_ as Collection<String>)
+    1 * provider.loadRolesForUsers(users)
 
     when: "thresholdToUseGroupMembership is breached and userSearchFilter is set"
     // Test to make sure that when the thresholdToUseGroupMembership is breached:
@@ -199,9 +230,11 @@ class LdapUserRolesProviderTest extends Specification {
 
     then: "should fetch user DNs from LDAP and query memberships for all groups to load roles"
     roles == ["user1@foo.com": [role1], "user2@foo.com": [role2]]
-    0 * provider.getUserFullDn(_)
+    1 * provider.multiLoadRoles(_ as Collection<ExternalUser>)
+    1 * provider.setLdapTemplate(_ as SpringSecurityLdapTemplate)
     1 * provider.doMultiLoadRoles(_)
-    0 * provider.doMultiLoadRolesPaginated(_)
+    1 * provider.getUserDNs(_ as Collection<String>)
+    1 * provider.loadRolesForUsers(_ as Collection<ExternalUser>)
   }
 
   void "multiLoadRoles should use pagination when enabled"() {
@@ -211,7 +244,11 @@ class LdapUserRolesProviderTest extends Specification {
     def role2 = new Role("group2")
 
     def configProps = baseConfigProps()
-    provider = Spy(provider)
+    def provider = Spy(LdapUserRolesProvider){
+      1 * setLdapTemplate(_ as SpringSecurityLdapTemplate)
+      1 * setConfigProps(_ as LdapConfig.ConfigProps)
+      0 * _
+    }
     provider.setConfigProps(configProps)
 
     when: "pagination is enabled"
@@ -244,6 +281,7 @@ class LdapUserRolesProviderTest extends Specification {
                 [Pair.of("${it.id}@foo.com" as String, role1),
                  Pair.of("${it.id}@foo.com" as String, role2)]
               }]
+      0 * _
     }
     def spiedProcessor = Spy(new PagedResultsDirContextProcessor(5, null))
     1 * provider.getPagedResultsDirContextProcessor(_) >> spiedProcessor
@@ -253,23 +291,29 @@ class LdapUserRolesProviderTest extends Specification {
 
     then: "should fetch ldap roles using pagination"
     roles == users.collectEntries { ["${it.id}" as String, [role1, role2]] }
-    0 * provider.doMultiLoadRoles(_)
-    1 * provider.doMultiLoadRolesPaginated(_)
+    1 * provider.multiLoadRoles(users)
+    1 * provider.doMultiLoadRolesPaginated(_ as Collection<String>)
+    1 * provider.loadRolesForUsers(_ as Collection<ExternalUser>)
+    1 * provider.getUserDNs(_ as Collection<String>)
   }
 
   void "multiLoadRoles should merge roles when multiple DNs exist for a user id"(){
     given:
-    def users = [externalUser("user1")]
+    def id = 'user1'
+    def ids = [id] as Set
+    def users = [externalUser(id)]
     def role1 = new Role("group1")
     def role2 = new Role("group2")
     def role3 = new Role("group3")
 
     def configProps = baseConfigProps()
     def provider = Spy(LdapUserRolesProvider){
-      getUserDNs(_ as Collection<String>) >> ['uid=dn1,ou=users,dc=springframework,dc=org': 'user1',
-                                              'uid=dn2,ou=users,dc=springframework,dc=org': 'user1']
-      doMultiLoadRoles(_ as Collection<String>) >> ['uid=dn1,ou=users,dc=springframework,dc=org' : [role1,role2],
-                                                    'uid=dn2,ou=users,dc=springframework,dc=org': [role3] ]
+      1 * getUserDNs(ids) >> ['uid=dn1,ou=users,dc=springframework,dc=org': id,
+                              'uid=dn2,ou=users,dc=springframework,dc=org': id]
+      1 * doMultiLoadRoles(_) >> ['uid=dn1,ou=users,dc=springframework,dc=org' : [role1,role2],
+                                  'uid=dn2,ou=users,dc=springframework,dc=org': [role3] ]
+      1 * setConfigProps(configProps)
+      0 * _
     }
     provider.setConfigProps(configProps)
 
@@ -282,6 +326,8 @@ class LdapUserRolesProviderTest extends Specification {
 
     then:
     roles == [user1: [role1, role2, role3]]
+    1 * provider.multiLoadRoles(users)
+    1 * provider.loadRolesForUsers(users)
   }
 
 


### PR DESCRIPTION
It has been observed that when a user has multiple entries in LDAP the resulting roles set for that user is empty. 
This  PR addresses the issue by merging the unique roles associated with all the entries for that user.

Before adding the changes, I have updated the existing tests to strengthen the assertions and included a test demonstrating the issue. 


