### PR TITLE
fix(retrofit): remove all com.squareup.okhttp dependencies

### DIFF
--- a/fiat-roles/fiat-roles.gradle
+++ b/fiat-roles/fiat-roles.gradle
@@ -20,9 +20,6 @@ dependencies {
   implementation "com.github.ben-manes.caffeine:caffeine"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
-  implementation "com.squareup.okhttp:okhttp"
-  implementation "com.squareup.okhttp:okhttp-urlconnection"
-  implementation "com.squareup.okhttp:okhttp-apache"
 
   implementation "io.github.resilience4j:resilience4j-spring-boot2"
   implementation "org.springframework:spring-core"

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -10,9 +10,6 @@ configurations.all {
 dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
-  implementation "com.squareup.okhttp:okhttp"
-  implementation "com.squareup.okhttp:okhttp-urlconnection"
-  implementation "com.squareup.okhttp:okhttp-apache"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.google.guava:guava"
 


### PR DESCRIPTION
All references to com.squareup.okhttp will be removed with this PR.

Refer https://github.com/spinnaker/kork/pull/1210 for kork PR which completes the removal of okhttp2 dependencies.