### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY fiat-web/build/install/fiat /opt/fiat
 RUN mkdir -p /opt/fiat/plugins && chown -R spinnaker:nogroup /opt/fiat/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 102.9 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#9 103.0 qemu: uncaught target signal 11 (Segmentation fault) - core dumped #9 103.4 Segmentation fault (core dumped)
#9 103.4 qemu: uncaught target signal 11 (Segmentation fault) - core dumped #9 103.8 Segmentation fault (core dumped)
#9 103.8 dpkg: error processing package libc-bin (--configure):
#9 103.8  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/fiat/actions/runs/13294115878/job/37121762284?pr=1202

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834